### PR TITLE
modify the documentation for the installation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,8 @@ A recent of [node.js](http://nodejs.org/) and npm is required.
 
 ### Fauxton Setup ###
 
-    # Clone the Fauxton repo: https://github.com/apache/couchdb-fauxton.git
-    git clone https://github.com/apache/couchdb-fauxton fauxton
+    # Clone the Fauxton repo: https://git-wip-us.apache.org/repos/asf/couchdb-fauxton.git
+    git clone https://git-wip-us.apache.org/repos/asf/couchdb-fauxton.git fauxton
 
     cd fauxton
 


### PR DESCRIPTION
When you download the fauxton repo, there is just couchdb-fauxton.
in this PR, I propose to save the repo in the fauxton directory.
