### PR TITLE
2160 fix csp for Fauxton dev mode

### DIFF
--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -335,6 +335,8 @@ table.databases {
 
 /* Fixed side navigation */
 #primary-navbar {
+  /* hack for the scrollbar that shines through from the sidebar */
+  -webkit-transform: translate3d(0, 0, 0);
   height: 100%;
   position: fixed;
   width: @navWidth;

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,10 @@ A recent of [node.js](http://nodejs.org/) and npm is required.
 
 ### Fauxton Setup ###
 
-    cd src/fauxton
+    # Clone the Fauxton repo: https://git-wip-us.apache.org/repos/asf/couchdb-fauxton.git
+    git clone https://git-wip-us.apache.org/repos/asf/couchdb-fauxton.git fauxton
+
+    cd fauxton
 
     # Install all dependencies
     npm install


### PR DESCRIPTION
The ace editor uses data: to load images - so we have to allow for that. The same would apply when serving fauxton out of CouchDB w/out node.js. This PR fixes the node.js-based dev mode (grunt dev)
