### PR TITLE
fix CSP for Fauxton dev mode

### DIFF
--- a/tasks/couchserver.js
+++ b/tasks/couchserver.js
@@ -46,7 +46,7 @@ module.exports = function (grunt) {
           filePath;
 
       if (setContentSecurityPolicy) {
-        var headerValue = "default-src 'self'; img-src 'self'; font-src 'self'; " +
+        var headerValue = "default-src 'self'; img-src 'self' data:; font-src 'self'; " +
                           "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';";
         res.setHeader('Content-Security-Policy', headerValue);
       }


### PR DESCRIPTION
The ace editor uses data: to load images - so we have to allow for that. The same would apply when serving fauxton out of CouchDB w/out node.js. This PR fixes the node.js-based dev mode (grunt dev). Hope this is the one this time
