### PR TITLE
readd travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"


### PR DESCRIPTION
We can now use travis to test Fauxton as a standalone repo and the build only takes around 1min! 

Once it is merged, I would ask infra for enabling travis support.
