### PR TITLE
Implement a filter for databases

### DIFF
--- a/app/addons/activetasks/assets/less/activetasks.less
+++ b/app/addons/activetasks/assets/less/activetasks.less
@@ -14,3 +14,33 @@
 .active-tasks th {
   cursor: pointer;
 }
+
+.activetasks-header .task-search-database {
+  margin: 20px;
+}
+
+.active-tasks th {
+  &.type {
+    width: 10%;
+  }
+
+  &.database {
+    width: 23%;
+  }
+
+  &.started {
+    width: 17%;
+  }
+
+  &.updated {
+    width: 17%;
+  }
+
+  &.pid {
+    width: 10%;
+  }
+
+  &.status {
+    width: 23%;
+  }
+}

--- a/app/addons/activetasks/resources.js
+++ b/app/addons/activetasks/resources.js
@@ -63,6 +63,10 @@ function (app, Fauxton) {
     }
   });
 
+  Active.Search = Backbone.Model.extend({
+    filterDatabase: null,
+    filterType: "all"
+  });
 
   return Active;
 });

--- a/app/addons/activetasks/routes.js
+++ b/app/addons/activetasks/routes.js
@@ -20,11 +20,15 @@ define([
 function (app, FauxtonAPI, Activetasks, Views) {
 
   var ActiveTasksRouteObject = FauxtonAPI.RouteObject.extend({
-    layout: "with_sidebar",
+    layout: "with_tabs_sidebar",
 
     routes: {
       "activetasks/:id": "defaultView",
       "activetasks": "defaultView"
+    },
+
+    events: {
+      "route:changeFilter": "changeFilter",
     },
 
     selectedHeader: 'Active Tasks',
@@ -41,15 +45,25 @@ function (app, FauxtonAPI, Activetasks, Views) {
 
     initialize: function () {
       this.allTasks = new Activetasks.AllTasks();
+      this.search = new Activetasks.Search();
     },
 
     defaultView: function () {
-      this.setView("#dashboard-content", new Views.View({
+      this.setView("#dashboard-lower-content", new Views.View({
         collection: this.allTasks,
-        currentView: "all"
+        currentView: "all",
+        searchModel: this.search
       }));
 
       this.setView("#sidebar-content", new Views.TabMenu({}));
+
+      this.headerView = this.setView("#dashboard-upper-content", new Views.TabHeader({
+        searchModel: this.search
+      }));
+    },
+
+    changeFilter: function (filterType) {
+      this.search.set('filterType', filterType);
     }
   });
 

--- a/app/addons/activetasks/templates/tab_header.html
+++ b/app/addons/activetasks/templates/tab_header.html
@@ -1,0 +1,33 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<div class="dashboard-upper-menu">
+  <ul class="nav nav-tabs window-resizeable" id="db-views-tabs-nav">
+    <li>
+      <a class="js-toggle-filter" href="#filter" data-bypass="true" data-toggle="tab">
+        <i class="fonticon fonticon-plus"></i>Filter
+      </a>
+    </li>
+  </ul>
+</div>
+
+<div class="tab-content">
+  <div class="tab-pane" id="query">
+    <div class="activetasks-header">
+      <div class="pull-right">
+          <input class="task-search-database" type="text" name="search" placeholder="Search for databases...">
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/addons/activetasks/templates/table.html
+++ b/app/addons/activetasks/templates/table.html
@@ -12,19 +12,7 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 
-<!--
-Licensed under the Apache License, Version 2.0 (the "License"); you may not
-use this file except in compliance with the License. You may obtain a copy of
-the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations under
-the License.
--->
 
 <% if (collection.length === 0){%>
    <tr>
@@ -36,12 +24,12 @@ the License.
 
   <thead>
     <tr>
-      <th data-type="type">Type</th>
-      <th data-type="source,target,database">Object</th>
-      <th data-type="started_on">Started on</th>
-      <th data-type="updated_on">Last updated on</th>
-      <th data-type="pid">PID</th>
-      <th data-type="progress" width="200">Status</th>
+      <th class="type" data-type="type">Type</th>
+      <th class="database" data-type="source,target,database">Database</th>
+      <th class="started" data-type="started_on">Started on</th>
+      <th class="updated" data-type="updated_on">Last updated on</th>
+      <th class="pid" data-type="pid">PID</th>
+      <th class="status" data-type="progress">Status</th>
     </tr>
   </thead>
 

--- a/app/addons/activetasks/tests/viewsSpec.js
+++ b/app/addons/activetasks/tests/viewsSpec.js
@@ -13,8 +13,9 @@ define([
         'api',
         'addons/activetasks/views',
         'addons/activetasks/resources',
+        'addons/activetasks/routes',
         'testUtils'
-], function (FauxtonAPI, Views, Activetasks, testUtils) {
+], function (FauxtonAPI, Views, Activetasks, RouteObject, testUtils) {
   var assert = testUtils.assert,
       ViewSandbox = testUtils.ViewSandbox;
 
@@ -62,19 +63,30 @@ define([
         assert.ok(spy.calledOnce);
       });
 
+      it("should set the correct active tab", function () {
+        var $rep = tabMenu.$('li[data-type="replication"]');
+        $rep.click();
+        assert.ok($rep.hasClass('active'));
+      });
     });
 
     describe('on request by type', function () {
-      var viewSandbox, mainView;
-      beforeEach(function (done) {
+      var viewSandbox, mainView, tabHeader, searchModel;
 
+      beforeEach(function (done) {
+        searchModel = new Activetasks.Search();
+
+        tabHeader = new Views.TabHeader({
+          searchModel: searchModel
+        });
         mainView = new Views.View({
           collection: new Activetasks.AllTasks(),
-          currentView: "all"
+          currentView: "all",
+          searchModel: searchModel
         });
 
         viewSandbox = new ViewSandbox();
-        viewSandbox.renderView(tabMenu).promise().then(function () {
+        viewSandbox.renderView(tabHeader, function () {
           viewSandbox.renderView(mainView, done);
         });
       });
@@ -83,16 +95,9 @@ define([
         viewSandbox.remove();
       });
 
-      it("should set the filter the main-view", function () {
-        var $rep = tabMenu.$('li[data-type="replication"]');
-        $rep.click();
-        assert.equal("replication", mainView.filter);
-      });
-
-      it("should set correct active tab", function () {
-        var $rep = tabMenu.$('li[data-type="replication"]');
-        $rep.click();
-        assert.ok($rep.hasClass('active'));
+      it("should set the filter 'database' for the main-view", function () {
+        var $rep = tabHeader.$("input").val("registry").trigger("keyup");
+        assert.equal("registry", mainView.searchModel.get('filterDatabase'));
       });
     });
 
@@ -103,7 +108,8 @@ define([
     beforeEach(function (done) {
       mainView = new Views.View({
         collection: new Activetasks.AllTasks(),
-        currentView: "all"
+        currentView: "all",
+        searchModel: new Activetasks.Search()
       });
 
       viewSandbox = new ViewSandbox();


### PR DESCRIPTION
This is a port of https://github.com/apache/couchdb/pull/210 with the difference that I am using the upper tabs now and not the sidebar for the searchinput (like in the Changes-Filter, ca7843b81e9dc85921cb6e612e0e2cc51ce64a98) 

---

Uses a new model to manage the state of the different search
filters to filter the view.

Nice feature: the filter for the database (upper input) and
the filters for the type (buttons) work nicely together,
so you can filter out all replications for that
database (let's name it registry)  without the compaction,
if you choose replication as type and enter "registry" in the
top input.

Closes COUCHDB-2125
