### PR TITLE
Link local docs in Fauxton

### DIFF
--- a/app/addons/documents/templates/design_doc_selector.html
+++ b/app/addons/documents/templates/design_doc_selector.html
@@ -12,7 +12,7 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 <div class="span3">
-  <label for="ddoc">Save to Design Document <a class="help-link" href="<%-getDocUrl('design_doc')%>" target="_blank"><i class="icon-question-sign"></i></a></label>
+  <label for="ddoc">Save to Design Document <a class="help-link" data-bypass="true" href="<%-getDocUrl('design_doc')%>" target="_blank"><i class="icon-question-sign"></i></a></label>
   <select id="ddoc">
     <optgroup label="Select a document">
       <option value="new-doc">New document</option>

--- a/app/addons/documents/templates/view_editor.html
+++ b/app/addons/documents/templates/view_editor.html
@@ -35,13 +35,13 @@ the License.
           </div>
 
           <div class="control-group">
-            <label for="index-name">Index name <a class="help-link" href="<%-getDocUrl('view_functions')%>" target="_blank"><i class="icon-question-sign"></i></a></label>
+            <label for="index-name">Index name <a class="help-link" data-bypass="true" href="<%-getDocUrl('view_functions')%>" target="_blank"><i class="icon-question-sign"></i></a></label>
             <input type="text" id="index-name" value="<%- viewName %>" placeholder="Index name" />
           </div>
 
 
           <div class="control-group">
-            <label for="map-function">Map function <a class="help-link" href="<%-getDocUrl('map_functions')%>" target="_blank"><i class="icon-question-sign"></i></a></label>
+            <label for="map-function">Map function <a class="help-link" data-bypass="true" href="<%-getDocUrl('map_functions')%>" target="_blank"><i class="icon-question-sign"></i></a></label>
             <% if (newView) { %>
             <div class="js-editor" id="map-function"><%= langTemplates.map %></div>
             <% } else { %>
@@ -52,7 +52,7 @@ the License.
 
 
           <div class="control-group">
-            <label for="reduce-function-selector">Reduce (optional) <a class="help-link" href="<%-getDocUrl('reduce_functions')%>" target="_blank"><i class="icon-question-sign"></i></a></label>
+            <label for="reduce-function-selector">Reduce (optional) <a class="help-link" data-bypass="true" href="<%-getDocUrl('reduce_functions')%>" target="_blank"><i class="icon-question-sign"></i></a></label>
 
             <select id="reduce-function-selector">
               <option value="" <%- !reduceFunStr ? 'selected="selected"' : '' %>>None</option>

--- a/app/addons/fauxton/templates/api_bar.html
+++ b/app/addons/fauxton/templates/api_bar.html
@@ -21,7 +21,7 @@ the License.
     <div class="input-prepend input-append">
       <span class="add-on">
         API URL
-        <a class="help-link" href="<%-getDocUrl(documentation)%>" target="_blank">
+        <a class="help-link" data-bypass="true" href="<%-getDocUrl(documentation)%>" target="_blank">
           <i class="icon-question-sign"></i>
         </a>
       </span>

--- a/app/addons/fauxton/templates/nav_bar.html
+++ b/app/addons/fauxton/templates/nav_bar.html
@@ -34,7 +34,7 @@ the License.
   <div id="bottom-nav">
   	<ul id="bottom-nav-links" class="nav">
         <li data-nav-name= "Documentation">
-            <a href="<%-getDocUrl('docs')%>" target="_blank">
+            <a data-bypass="true" href="<%-getDocUrl('docs')%>" target="_blank">
               <i class="fonticon-bookmark fonticon"></i>
                 Documentation
             </a>

--- a/app/addons/permissions/templates/section.html
+++ b/app/addons/permissions/templates/section.html
@@ -13,7 +13,7 @@ the License.
 -->
 <header class="page-header">
 <h3> <%- section %> </h3>
-<p class="help"> <%- help %> <a class="help-link" href="<%-getDocUrl('database_permission')%>" target="_blank"><i class="icon-question-sign"> </i> </a></p>
+<p class="help"> <%- help %> <a class="help-link" data-bypass="true" href="<%-getDocUrl('database_permission')%>" target="_blank"><i class="icon-question-sign"> </i> </a></p>
 </header>
 
 <div class="row-fluid">

--- a/app/addons/replication/templates/form.html
+++ b/app/addons/replication/templates/form.html
@@ -63,7 +63,7 @@ the License.
 
 			<label for="createTarget">
 				<input type="checkbox" name="create_target" value="true" id="createTarget">
-				Create Target <a class="help-link" href="<%-getDocUrl('replication_doc')%>" target="_blank"><i class="icon-question-sign" rel="tooltip" title="Create the target database"></i></a>
+				Create Target <a class="help-link" data-bypass="true" href="<%-getDocUrl('replication_doc')%>" target="_blank"><i class="icon-question-sign" rel="tooltip" title="Create the target database"></i></a>
 			</label>
 		</div>
 

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -36,25 +36,24 @@ function(utils, d3) {
     return path;
   };
 
-
   // Get the URL for documentation, wiki, wherever we store it.
   // update the URLs in documentation_urls.js
   Helpers.docs =  {
-    "docs": "http://docs.couchdb.org/en/latest/intro/api.html#documents",
-    "all_dbs": "http://docs.couchdb.org/en/latest/api/server/common.html?highlight=all_dbs#get--_all_dbs",
-    "replication_doc": "http://docs.couchdb.org/en/latest/replication/replicator.html#basics",
-    "design_doc": "http://docs.couchdb.org/en/latest/couchapp/ddocs.html#design-docs",
-    "view_functions": "http://docs.couchdb.org/en/latest/couchapp/ddocs.html#view-functions",
-    "map_functions": "http://docs.couchdb.org/en/latest/couchapp/ddocs.html#map-functions",
-    "reduce_functions": "http://docs.couchdb.org/en/latest/couchapp/ddocs.html#reduce-and-rereduce-functions",
-    "api_reference": "http://docs.couchdb.org/en/latest/http-api.html",
-    "database_permission": "http://docs.couchdb.org/en/latest/api/database/security.html#db-security",
-    "stats": "http://docs.couchdb.org/en/latest/api/server/common.html?highlight=stats#get--_stats",
-    "_active_tasks": "http://docs.couchdb.org/en/latest/api/server/common.html?highlight=stats#active-tasks",
-    "log": "http://docs.couchdb.org/en/latest/api/server/common.html?highlight=stats#log",
-    "config": "http://docs.couchdb.org/en/latest/config/index.html",
-    "views": "http://docs.couchdb.org/en/latest/intro/overview.html#views",
-    "changes": "http://docs.couchdb.org/en/latest/api/database/changes.html?highlight=changes#post--db-_changes"
+    "docs": "/_utils/docs/intro/api.html#documents",
+    "all_dbs": "/_utils/docs/api/server/common.html?highlight=all_dbs#get--_all_dbs",
+    "replication_doc": "/_utils/docs/replication/replicator.html#basics",
+    "design_doc": "/_utils/docs/couchapp/ddocs.html#design-docs",
+    "view_functions": "/_utils/docs/couchapp/ddocs.html#view-functions",
+    "map_functions": "/_utils/docs/couchapp/ddocs.html#map-functions",
+    "reduce_functions": "/_utils/docs/couchapp/ddocs.html#reduce-and-rereduce-functions",
+    "api_reference": "/_utils/docs/http-api.html",
+    "database_permission": "/_utils/docs/api/database/security.html#db-security",
+    "stats": "/_utils/docs/api/server/common.html?highlight=stats#get--_stats",
+    "_active_tasks": "/_utils/docs/api/server/common.html?highlight=stats#active-tasks",
+    "log": "/_utils/docs/api/server/common.html?highlight=stats#log",
+    "config": "/_utils/docs/config/index.html",
+    "views": "/_utils/docs/intro/overview.html#views",
+    "changes": "/_utils/docs/api/database/changes.html?highlight=changes#post--db-_changes"
   };
 
   Helpers.getDocUrl = function(docKey){

--- a/tasks/couchserver.js
+++ b/tasks/couchserver.js
@@ -64,9 +64,6 @@ module.exports = function (grunt) {
       } else if (!!url.match(/\.css|img/)) {
         url = url.replace(/\?.*/, '');
         filePath = path.join(dist_dir,url);
-      /*} else if (!!url.match(/\/js\//)) {
-        // serve any javascript or files from dist debug dir
-        filePath = path.join(dist_dir,req.url);*/
       } else if (!!url.match(/\.js$|\.html$/)) {
         // server js from app directory
         filePath = path.join(app_dir, url.replace('/_utils/fauxton/',''));
@@ -79,6 +76,10 @@ module.exports = function (grunt) {
         // serve main index file from here
         filePath = path.join(dist_dir, 'index.html');
       };
+
+      if (/_utils\/docs/.test(filePath)) {
+        filePath = false;
+      }
 
       if (filePath) {
         return send(req, filePath)


### PR DESCRIPTION
This is a port from https://github.com/apache/couchdb/pull/232

Already got +1, but let's see what travis says :)

---

Instead of linking to the latest version online, we link to the
docs for the locally installed version. The docs are
generated automatically when running make / make install, if you
have Sphinx installed. For development, the dev-server will just
proxy the request.
