### PR TITLE
Sidebar: Do not show version on a collapsed view

### DIFF
--- a/app/addons/fauxton/base.js
+++ b/app/addons/fauxton/base.js
@@ -237,7 +237,7 @@ function(app, FauxtonAPI, resizeColumns, Components, ZeroClipboard) {
     },
 
     beforeRender: function () {
-      this.insertView(".version", this.versionFooter);
+      this.insertView(".js-version", this.versionFooter);
       this.addLinkViews();
     },
 

--- a/app/addons/fauxton/templates/nav_bar.html
+++ b/app/addons/fauxton/templates/nav_bar.html
@@ -70,5 +70,5 @@ the License.
       <% }); %>
     </ul>
   </div>
-  <div class="version"></div>
+  <div class="js-version"></div>
 </div>

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -344,10 +344,15 @@ table.databases {
   bottom: 0;
   background-color: @primaryNav;
   overflow-y: scroll;
-  .version {
+  .js-version {
     color: #fff;
     font-size: 10px;
     padding-left: 10px;
+  }
+  .closeMenu & {
+    .js-version {
+      display: none;
+    }
   }
   #footer-links{
     position: absolute;


### PR DESCRIPTION
There is not enough space for showing the version on a collapsed
sidebar.

COUCHDB-2234
