### PR TITLE
Fix double-click on design documents in all-docs-list

### DIFF
--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -114,7 +114,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions,
 
     edit: function(event) {
       event.preventDefault();
-      FauxtonAPI.navigate("#" + this.model.url('app'));
+      FauxtonAPI.navigate("#" + this.model.url('web-index'));
     },
 
     destroy: function(event) {


### PR DESCRIPTION
Closes COUCHDB-2247
