### PR TITLE
COUCHDB-2291 - Fix selection of all docs & delete button

### DIFF
--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -396,6 +396,7 @@ function(app, FauxtonAPI, PagingCollection) {
       return "docs";
     },
     initialize: function(_models, options) {
+      this.viewMeta = options.viewMeta;
       this.database = options.database;
       this.params = _.clone(options.params);
 

--- a/app/addons/documents/tests/views-sidebarSpec.js
+++ b/app/addons/documents/tests/views-sidebarSpec.js
@@ -19,14 +19,14 @@ define([
 
   describe('Documents Sidebar', function () {
     var view;
-      beforeEach(function () {
-        viewSandbox = new ViewSandbox();
-        viewSandbox.renderView(view);
-      });
+    beforeEach(function () {
+      viewSandbox = new ViewSandbox();
+      viewSandbox.renderView(view);
+    });
 
-      afterEach(function () {
-        viewSandbox.remove();
-      });
+    afterEach(function () {
+      viewSandbox.remove();
+    });
   });
 });
 

--- a/app/addons/documents/tests/viewsSpec.js
+++ b/app/addons/documents/tests/viewsSpec.js
@@ -11,14 +11,47 @@
 // the License.
 define([
         'addons/documents/views',
+        'addons/documents/resources',
         'addons/databases/base',
         'testUtils'
-], function (Views, Databases, testUtils) {
-  var assert = testUtils.assert;
+], function (Views, Resources, Databases, testUtils) {
+  var assert = testUtils.assert,
+      ViewSandbox = testUtils.ViewSandbox,
+      viewSandbox;
 
-  describe('DocumentsViews', function () {
+  describe('AllDocsList', function () {
+    var database = new Databases.Model({id: 'registry'}),
+        bulkDeleteDocCollection = new Resources.BulkDeleteDocCollection([], {databaseId: 'registry'});
+
+    database.allDocs = new Resources.AllDocs({_id: "ente"}, {
+      database: database,
+      viewMeta: {update_seq: 1},
+      params: {}
+    });
+
+    var view = new Views.Views.AllDocsList({
+      viewList: false,
+      bulkDeleteDocsCollection: bulkDeleteDocCollection,
+      collection: database.allDocs
+    });
+
+    beforeEach(function () {
+      viewSandbox = new ViewSandbox();
+      viewSandbox.renderView(view);
+    });
+
+    afterEach(function () {
+      viewSandbox.remove();
+    });
+
     it('should load', function () {
       assert.equal(typeof Views.Views.AllDocsList, 'function');
+    });
+
+    it('pressing SelectAll should fill the delete-bulk-docs-collection', function () {
+      assert.equal(bulkDeleteDocCollection.length, 0);
+      view.$('button.all').trigger('click');
+      assert.equal(bulkDeleteDocCollection.length, 1);
     });
   });
 });

--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -430,8 +430,34 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions,
       });
     },
 
-    selectAll: function(evt){
-      $('.all-docs').find("input:checkbox").prop('checked', !$(evt.target).hasClass('active')).trigger('change');
+    selectAll: function (evt) {
+      var $allDocs = this.$('.all-docs'),
+          $rows = $allDocs.find('tr'),
+          $checkboxes = $allDocs.find('input:checkbox'),
+          modelsAffected,
+          docs;
+
+      $checkboxes.prop('checked', !$(evt.target).hasClass('active')).trigger('change');
+
+      if ($(evt.target).hasClass('active')) {
+        modelsAffected = _.reduce($rows, function (acc, el) {
+          var docId = $(el).attr('data-id');
+          acc.push(docId);
+          return acc;
+        }, []);
+        this.bulkDeleteDocsCollection.remove(modelsAffected);
+      } else {
+        modelsAffected = _.reduce($rows, function (acc, el) {
+          var docId = $(el).attr('data-id'),
+              rev = this.collection.get(docId).get('_rev');
+
+          acc.push({_id: docId, _rev: rev, _deleted: true});
+          return acc;
+        }, [], this);
+        this.bulkDeleteDocsCollection.add(modelsAffected);
+      }
+
+      this.toggleTrash();
     },
 
     serialize: function() {


### PR DESCRIPTION
Fix deletion of docs that where selected using select-all
- add docs on page to bulk-delete-collection on select-all-click,
  which also reenables the trash-button
- make AllDocs testable, enable injection for viewMeta

Closes COUCHDB-2291
