### PR TITLE
Fix API bar buttons color

### DIFF
--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -936,7 +936,7 @@ div.spinner {
     }
     .btn{
       background-color: @red;
-      color: #333;
+      color: #fff;
       margin-left: -1px;
       padding: 10px 10px 8px;
       border: none;


### PR DESCRIPTION
They are too dark and doesn't match common design guidelines about red buttons.

Before:
![Before](http://i.imgur.com/j10uS6i.png)

After:
![After](http://i.imgur.com/7vcTp61.png)
