### PR TITLE
COUCHDB-2302: Allow creation of new sections in config view

### DIFF
--- a/app/addons/config/resources.js
+++ b/app/addons/config/resources.js
@@ -67,7 +67,13 @@ function (app, FauxtonAPI) {
 
     findEntryInSection: function (sectionName, entry) {
       var section = _.findWhere(this.toJSON(), {"section": sectionName}),
-          options = _.findWhere(section.options, {name: entry});
+          options;
+
+      if (!section) {
+        return false;
+      }
+
+      options = _.findWhere(section.options, {name: entry});
 
       return options;
     },

--- a/app/addons/config/templates/modal.html
+++ b/app/addons/config/templates/modal.html
@@ -21,7 +21,6 @@ the License.
   <form id="js-add-section-form" class="form well">
     <label>Section</label>
     <input type="text" name="section" placeholder="Section" >
-    <span class="help-block">Enter an existing section name to add to it.</span>
     <input type="text" name="name" placeholder="Name">
     <br/>
     <input type="text" name="value" placeholder="Value">

--- a/app/addons/config/tests/configSpec.js
+++ b/app/addons/config/tests/configSpec.js
@@ -63,12 +63,26 @@ define([
       modal.$('input[name="name"]').val("testname2");
       assert.notOk(modal.isUniqueEntryInSection(collection));
     });
+
+    it("does not send an error for a new section", function () {
+      modal.$('input[name="section"]').val("newsection");
+      modal.$('input[name="name"]').val("testname");
+      modal.$('input[name="value"]').val("testvalue");
+      var spy = sinon.spy(modal, "errorMessage");
+
+      modal.validate();
+      assert.notOk(spy.called);
+    });
   });
 
   describe("Config: Collection", function () {
     it("looks if entries are new", function () {
       assert.ok(collection.findEntryInSection("foo1", "testname"));
       assert.notOk(collection.findEntryInSection("foo1", "testname2"));
+    });
+
+    it("returns false if findEntryInSection does not have the section", function () {
+      assert.notOk(collection.findEntryInSection("foo-not-exists", "testname"));
     });
   });
 

--- a/app/addons/config/views.js
+++ b/app/addons/config/views.js
@@ -151,23 +151,28 @@ function(app, FauxtonAPI, Config, Components) {
 
   Views.Modal = FauxtonAPI.View.extend({
     className: "modal hide fade",
+
     template:  "addons/config/templates/modal",
+
     events: {
-      "submit #js-add-section-form": "validate"
+      "submit #js-add-section-form": "submitClick"
     },
+
     initialize: function () {
       this.sourceArray = _.map(this.collection.toJSON(), function (item, key) {
         return item.section;
       });
     },
-    afterRender: function(){
+
+    afterRender: function () {
       this.sectionTypeAhead = new Components.Typeahead({
         source: this.sourceArray,
         el: 'input[name="section"]'
       });
       this.sectionTypeAhead.render();
     },
-    submitForm: function (event) {
+
+    submitForm: function () {
       var option = new Config.OptionModel({
         section: this.$('input[name="section"]').val(),
         name: this.$('input[name="name"]').val(),
@@ -193,26 +198,31 @@ function(app, FauxtonAPI, Config, Components) {
       Views.Events.trigger("newSection");
 
     },
+
     isUniqueEntryInSection: function (collection) {
       var sectionName = this.$('input[name="section"]').val(),
           entry = this.$('input[name="name"]').val();
 
       return collection.findEntryInSection(sectionName, entry);
     },
-    isSection: function(){
+
+    isSection: function () {
       var section = this.$('input[name="section"]').val();
       return _.find(this.sourceArray, function(item){ return item === section; });
     },
-    validate: function (event){
+
+    submitClick: function (event) {
       event.preventDefault();
+      this.validate();
+    },
+
+    validate: function () {
       var section = this.$('input[name="section"]').val(),
           name = this.$('input[name="name"]').val(),
           value = this.$('input[name="value"]').val(),
           collection = this.collection;
 
-      if(!this.isSection()){
-         this.errorMessage("You need to use an existing section");
-      } else if (!name) {
+      if (!name) {
         this.errorMessage("Add a name");
       } else if (!value) {
         this.errorMessage("Add a value");


### PR DESCRIPTION
COUCHDB-2302: Allow creation of new sections in config view

I added a bunch of tests and moved one method from the view to the collection.

I also removed some unused properties, like `this.error` and separated the event-handler from the logic to make the code testable.

Split in multiple logical commits as I first added tests, then refactored and then fixed the actual bug.
