### PR TITLE
Show scrollbar for small browser heights

### DIFF
--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -335,6 +335,18 @@ table.databases {
   }
 }
 
+@media screen and ( max-height: 600px ){
+ #primary-navbar{
+     overflow-y: scroll;
+ }
+}
+
+@media screen and ( min-height: 600px ){
+ #primary-navbar{
+     overflow-y: hidden;
+ }
+}
+
 /* Fixed side navigation */
 #primary-navbar {
   height: 100%;
@@ -343,7 +355,6 @@ table.databases {
   top: 0;
   bottom: 0;
   background-color: @primaryNav;
-  overflow: hidden;
   .js-version {
     color: #fff;
     font-size: 10px;


### PR DESCRIPTION
This hides the scrollbar unless the browser height is very small. Then
the scrollbar is visible.
