### PR TITLE
edit doc page now has ID in title; other

### DIFF
--- a/app/addons/documents/routes-doc-editor.js
+++ b/app/addons/documents/routes-doc-editor.js
@@ -52,8 +52,8 @@ function(app, FauxtonAPI, Documents, DocEditor, Databases) {
 
     crumbs: function() {
       return [
-        {"name": this.database.id, "link": Databases.databaseUrl(this.database)}
-        //{"name": this.docID, "link": "#"}
+        {"name": this.database.id, "link": Databases.databaseUrl(this.database)},
+        {"name": this.docID, "link": "#"}
       ];
     },
 

--- a/app/templates/layouts/with_sidebar.html
+++ b/app/templates/layouts/with_sidebar.html
@@ -17,7 +17,7 @@ the License.
 <div id="dashboard" class="container-fluid">
   <header class="fixed-header">
     <div id="breadcrumbs"></div>
-    <div id="api-navbar"></div>
+    <div id="api-navbar" class="window-resizeable"></div>
   </header>
 
   <div class="with-sidebar content-area">

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -1099,9 +1099,14 @@ div.add-dropdown {
   }
 }
 
+/* only specify the sidebar width when there’s a sidebar */
+.with-sidebar #breadcrumbs {
+  width: @sidebarWidth;
+}
+
 #breadcrumbs {
   height: 60px;
-  width: @sidebarWidth;
+
   /* these styles are for the new header*/
   .header-left{
     > div{


### PR DESCRIPTION
- The edit doc page now has the ID in the title as a second breadcrumb;
- minor CSS change so the second crumb doesn't wrap

One thing to note: I don't have dashboard access yet so I couldn't do regression there.
