### PR TITLE
COUCHDB-2337 - Fix databases subnavigation disappearing when applying filters.

### DIFF
--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -481,11 +481,13 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
     addFilter: function (filter) {
       this.changesView.filters.push(filter);
       this.changesView.render();
+      this.leftheader.forceRender();
     },
 
     removeFilter: function (filter) {
       this.changesView.filters.splice(this.changesView.filters.indexOf(filter), 1);
       this.changesView.render();
+      this.leftheader.forceRender();
     },
 
   });


### PR DESCRIPTION
This will resolve the current issue of database breadcrumbs and sub navigation vanishing when a user applies a filter in the "Changes" view.

Tested for regression in:
Safari 7.0.6
Chrome 37.0.2062.120
Firefox 32.0.2
An iPhone running iOS 8 (Just because).
