### PR TITLE
COUCHDB-2340 - Remove extra subnav breadcrumb.

### DIFF
--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -40,8 +40,7 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
     changes: function (database) {
       return [
         {"name": "", "className": "fonticon-left-open", "link": "/_all_dbs"},
-        {"name": database.id, "link": Databases.databaseUrl(database)},
-        {"name": "_changes", "link": "/_changes"}
+        {"name": database.id, "link": Databases.databaseUrl(database)}
       ];
     }
   };

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -1142,9 +1142,8 @@ div.add-dropdown {
     background-color: transparent;
     padding: 0;
     li {
-      padding:20px 10px;
+      padding: 20px 10px;
       height: 60px;
-      vertical-align: top;
       &:first-child {
         font-size: 24px;
         .with-sidebar &,
@@ -1154,7 +1153,7 @@ div.add-dropdown {
         }
       }
       color: @breadcrumbText;
-      font-size: 18px;
+      font-size: 24px;
       text-shadow: none;
       &.active{
         color: #333;


### PR DESCRIPTION
This removes the extra "_changes" breadcrumb in the databases subnav, as well as a few minor style tweaks to get the database name to line up all nice-like.

Tested for regression in:
Safari 7.0.6
Chrome 37.0.2062.124
Firefox 32.0.2
An iPhone running iOS 8 (Just because).
