### PR TITLE
COUCHDB-2336 - Fix for auto-closing nav after clicking menu items.

### DIFF
--- a/app/addons/fauxton/base.js
+++ b/app/addons/fauxton/base.js
@@ -204,20 +204,7 @@ function(app, FauxtonAPI, resizeColumns, Components, ZeroClipboard) {
 
     afterRender: function(){
       $('#primary-navbar li[data-nav-name="' + app.selectedHeader + '"]').addClass('active');
-
-      var $selectorList = $('body');
-      var that = this;
-      $('#primary-navbar').on("click", ".nav a", function(){
-        if (!($selectorList.hasClass('closeMenu'))){
-          setTimeout(
-            function(){
-            $selectorList.addClass('closeMenu');
-            that.resizeColumns.onResizeHandler();
-          },3000);
-
-        }
-      });
-
+      
       this.resizeColumns.initialize();
     },
 


### PR DESCRIPTION
This will fix the current issue where the navbar collapses automatically after a moment when a user is navigating throughout fauxton.

Tested for regression in:
Safari 7.0.6
Safari 8.0
Chrome 37.0.2062.124
Firefox 32.0.3
