### PR TITLE
Firefox: Add z-index for sidebar

### DIFF
--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -377,7 +377,7 @@ table.databases {
         .transition(all @transitionSpeed @transitionEaseType);
         padding: 22px 0 0 18px;
         position: fixed;
-        z-index: 100;
+        z-index: 50;
         width: 64px;
         top: 0;
         background-color: @primaryNav;
@@ -559,6 +559,7 @@ table.databases {
   with_tabs_sidebar.html
 */
 #dashboard {
+  z-index: 51;
   .left-shadow-border;
   position: absolute;
   left: @navWidth;
@@ -607,7 +608,7 @@ table.databases {
   }
   //border-bottom: 5px solid @breadcrumbBorder;
   .box-shadow(0 4px 6px -2px #808080);
-  z-index: 100;
+  z-index: 50;
   .one-pane & {
     position: relative;
     border: none;
@@ -1082,7 +1083,7 @@ div.add-dropdown {
   .closeMenu & {
     left: @collapsedNavWidth;
   }
-  z-index: 100;
+  z-index: 50;
   .two-pane & {
     border: none;
   }


### PR DESCRIPTION
Adjust other z-index values to 50, and give the dashboard 51

COUCHDB-2234

Screenshot (scroll the sidebar down a little bit to reproduce it): 

![firefox-zindex](https://cloud.githubusercontent.com/assets/298166/4444376/739542dc-47f0-11e4-9eff-a90e79df75d5.png)
