### PR TITLE
COUCHDB-2346 - Fix for long database names formatting improperly.

### DIFF
--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -1152,6 +1152,9 @@ div.add-dropdown {
           font-size: 19px;
           float: left;
         }
+        a {
+	        float: left;
+        }
       }
       color: @breadcrumbText;
       font-size: 24px;
@@ -1173,6 +1176,19 @@ div.add-dropdown {
         text-decoration: none;
         color: @breadcrumbText;
       }
+    }
+    .fonticon-right-open {
+	    position: absolute;
+	    
+	    &.divider {
+		    padding: 23px 0;
+	    }
+	    +li {
+		    text-overflow: inherit;
+		    overflow: auto;
+		    width: auto;
+		    margin-left: 14px;
+	    }
     }
   }
 }


### PR DESCRIPTION
This is a fix for long database names causing some wackiness in the subheader.

Tested for regression in:
Safari 7.0.6
Safari 8.0
Chrome 37.0.2062.124
Firefox 32.0.3
