### PR TITLE
COUCHDB-2342 - Url-encode document-ids properly

### DIFF
--- a/app/addons/documents/views-doceditor.js
+++ b/app/addons/documents/views-doceditor.js
@@ -386,7 +386,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, resizeColumns, prett
 
         this.model.save().then(function () {
           editor.editSaved();
-          FauxtonAPI.navigate('/database/' + that.database.safeID() + '/' + that.model.id);
+          FauxtonAPI.navigate('/database/' + that.database.safeID() + '/' + app.utils.safeURLName(that.model.id));
         }).fail(function(xhr) {
           var responseText = JSON.parse(xhr.responseText).reason;
           FauxtonAPI.addNotification({
@@ -423,6 +423,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, resizeColumns, prett
       }
 
       json = JSON.parse(this.editor.getValue());
+      json._id = app.utils.safeURLName(json._id);
 
       this.model.clear().set(json, {validate: true});
       if (this.model.validationError) {

--- a/app/core/tests/utilsSpec.js
+++ b/app/core/tests/utilsSpec.js
@@ -1,0 +1,27 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  "app",
+  "testUtils"
+], function (app, testUtils) {
+  var assert = testUtils.assert;
+
+  describe("utils", function () {
+    describe("safeURLName", function () {
+      it("should encode urls with a % (COUCHDB-2342)", function () {
+        var res = app.utils.safeURLName("design%20foo");
+        assert.equal(res, "design%2520foo");
+      });
+    });
+  });
+});

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -82,10 +82,11 @@ function ($, _) {
       return name.replace(/[^\w\s]/gi,"");
     },
 
-    safeURLName: function(name){
-      var testName = name || "";
-      var checkforBad = testName.match(/[\$\-/,+-]/g);
-      return (checkforBad !== null)?encodeURIComponent(name):name;
+    safeURLName: function (name) {
+      var testName = name || "",
+          hasBadChar = /[\$\-/%,+-]/g.test(testName);
+
+      return hasBadChar ? encodeURIComponent(name) : name;
     }
   };
 


### PR DESCRIPTION
Url-encode document-ids properly
- modify the helper to also urlencode on `%`

Closes COUCHDB-2342
