### PR TITLE
Show full database name in browser's tooltip

### DIFF
--- a/app/addons/fauxton/templates/breadcrumbs.html
+++ b/app/addons/fauxton/templates/breadcrumbs.html
@@ -24,4 +24,4 @@ the License.
 <% }); %>
 
 <% var last = _.last(crumbs) || {name: ''} %>
-<li class="active"><%- last.name %></li>
+<li class="active" title="<%- last.name %>"><%- last.name %></li>


### PR DESCRIPTION
After PR #74 long database names are showed trimmed and it's hard
to guess what the full name is. Parsing URL with eyes isn't handy
since there are a lot of other information presents, urlescaping
harms readability while you need to quickly figure out where you
are.
