### PR TITLE
Patch for misaligned document title in breadcrumbs bar in Safari 7.1

### DIFF
--- a/app/addons/fauxton/templates/breadcrumbs.html
+++ b/app/addons/fauxton/templates/breadcrumbs.html
@@ -13,7 +13,7 @@ the License.
 -->
 
 <% _.each(_.initial(crumbs), function(crumb, index) { %>
-<li>
+<li class="pull-left">
   <a href="#<%- crumb.link %>" class="fonticon <%- crumb.className %>"><%- crumb.name %></a>
 </li>
 


### PR DESCRIPTION
This patch resolves the problem without breaking anything in other browsers (tested in Firefox, Chrome & Opera). I'm not sure if there's a better solution, please tell me if you know one.

Issue: https://issues.apache.org/jira/browse/COUCHDB-2360
