### PR TITLE
Polling interval field CSS update

### DIFF
--- a/app/addons/activetasks/assets/less/activetasks.less
+++ b/app/addons/activetasks/assets/less/activetasks.less
@@ -44,3 +44,21 @@
     width: 23%;
   }
 }
+
+.sidebar .polling-interval {
+  li.nav-header {
+    padding: 9px 0px 0px 9px;
+  }
+  li {
+    padding: 0px 15px 3px 9px;
+    margin-left: 0px;
+
+    input {
+      width: 100%;
+    }
+
+    label span {
+      font-weight: bold;
+    }
+  }
+}

--- a/app/addons/activetasks/templates/tabs.html
+++ b/app/addons/activetasks/templates/tabs.html
@@ -12,26 +12,17 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 
-
-
-		<ul class="task-tabs nav nav-list">
-		  <% for (var filter in filters) { %>
-		      <li data-type="<%=filter%>">
-			      <a>
-			      		<%=filters[filter]%>
-			      </a>
-		    </li>
-		  <% } %>
-		</ul>
-		<ul class="nav nav-list views">
-			<li class="nav-header">Polling interval</li>
-			<li>
-				<input id="pollingRange" type="range"
-				       min="1"
-				       max="30"
-				       step="1"
-				       value="5"/>
-				<label for="pollingRange"><span>5</span> second(s)</label>
-			</li>
-		</ul>
-
+<ul class="task-tabs nav nav-list">
+  <% for (var filter in filters) { %>
+    <li data-type="<%=filter%>">
+      <a><%=filters[filter]%></a>
+    </li>
+  <% } %>
+</ul>
+<ul class="nav nav-list views polling-interval">
+  <li class="nav-header">Polling interval</li>
+  <li>
+    <input id="pollingRange" type="range" min="1" max="30" step="1" value="5">
+    <label for="pollingRange"><span>5</span> second(s)</label>
+  </li>
+</ul>

--- a/app/addons/activetasks/tests/viewsSpec.js
+++ b/app/addons/activetasks/tests/viewsSpec.js
@@ -40,7 +40,7 @@ define([
       it("Should set polling rate", function () {
         var $range = tabMenu.$('#pollingRange');
         $range.val(15);
-        $range.trigger('change');
+        $range.trigger('input');
 
         assert.equal(tabMenu.$('span').text(), 15);
       });
@@ -48,17 +48,16 @@ define([
       it("Should clearInterval", function () {
         var $range = tabMenu.$('#pollingRange');
         var clearIntervalMock = sinon.spy(window,'clearInterval');
-        $range.trigger('change');
+        $range.trigger('input');
 
         assert.ok(clearIntervalMock.calledOnce);
-
       });
 
       it("Should trigger update:poll event", function () {
         var spy = sinon.spy();
         Views.Events.on('update:poll', spy);
         var $range = tabMenu.$('#pollingRange');
-        $range.trigger('change');
+        $range.trigger('input');
 
         assert.ok(spy.calledOnce);
       });

--- a/app/addons/activetasks/views.js
+++ b/app/addons/activetasks/views.js
@@ -30,9 +30,7 @@ function (app, FauxtonAPI, ActiveTasks) {
 
   Views.View = FauxtonAPI.View.extend({
     tagName: "table",
-
     className: "table table-bordered table-striped active-tasks",
-
     template: "addons/activetasks/templates/table",
 
     events: {
@@ -121,7 +119,7 @@ function (app, FauxtonAPI, ActiveTasks) {
 
     events: {
       "click .task-tabs li": "requestByType",
-      "change #pollingRange": "changePollInterval"
+      "input #pollingRange": "changePollInterval"
     },
 
     serialize: function () {
@@ -165,7 +163,6 @@ function (app, FauxtonAPI, ActiveTasks) {
 
   Views.TableDetail = FauxtonAPI.View.extend({
     tagName: 'tr',
-
     template: "addons/activetasks/templates/tabledetail",
 
     initialize: function(){


### PR DESCRIPTION
As described in ticket: https://issues.apache.org/jira/browse/COUCHDB-2371

I also changed the slider event from onChange to onInput which continually fires when the user drags the slider. It results in more code being called but it has a much better feel, I think: i.e. the # seconds updates during dragging, not just afterwards. This was probably what was originally intended: Chrome changed the onChange event behaviour a few months back to only fire after the drag is completed.
