### PR TITLE
Adding right header back to databases page.

### DIFF
--- a/app/addons/databases/routes.js
+++ b/app/addons/databases/routes.js
@@ -24,7 +24,7 @@ define([
 function(app, FauxtonAPI, Databases, Views) {
 
   var AllDbsRouteObject = FauxtonAPI.RouteObject.extend({
-    layout: "one_pane",
+    layout: "one_pane_db",
 
     crumbs: [
       {"name": "Databases", "link": "/_all_dbs"}
@@ -48,6 +48,12 @@ function(app, FauxtonAPI, Databases, Views) {
 
       this.databasesView = this.setView("#dashboard-content", new Views.List({
         collection: this.databases
+      }));
+
+      this.rightHeader = this.setView("#right-header", new Views.RightAllDBsHeader({
+        collection: this.databases,
+        endpoint: this.databases.url("apiurl"),
+        documentation: this.databases.documentation()
       }));
 
       this.databasesView.setPage(dbPage);

--- a/app/templates/layouts/one_pane_db.html
+++ b/app/templates/layouts/one_pane_db.html
@@ -1,0 +1,31 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<div id="primary-navbar"></div>
+<div id="dashboard" class="container-fluid one-pane">
+  <div id="global-notifications" class="container errors-container window-resizeable"></div>
+  <div class="fixed-header">
+    <div id="breadcrumbs"></div>
+    <div id="api-navbar"></div>
+    <div id="right-header" class="window-resizeable"></div>
+  </div>
+
+
+  <div class="row-fluid content-area">
+  	<div id="tabs" class="row"></div>
+    <div id="dashboard-content" class="window-resizeable-full"></div>
+  </div>
+</div>
+
+


### PR DESCRIPTION
This was broken in the recent right refactor of the right header.

Tested for regression in:
Chrome 37.0.2062.124
Safari 7.0.6
Safari 8.0
Firefox 32.0.3
