### PR TITLE
Fix Api-Bar button position

### DIFF
--- a/app/templates/layouts/one_pane.html
+++ b/app/templates/layouts/one_pane.html
@@ -17,7 +17,7 @@ the License.
   <div id="global-notifications" class="container errors-container window-resizeable"></div>
   <div class="fixed-header">
     <div id="breadcrumbs"></div>
-    <div id="api-navbar" class="window-resizeable"></div>
+    <div id="api-navbar"></div>
   </div>
 
 

--- a/app/templates/layouts/with_sidebar.html
+++ b/app/templates/layouts/with_sidebar.html
@@ -17,7 +17,7 @@ the License.
 <div id="dashboard" class="container-fluid">
   <header class="fixed-header">
     <div id="breadcrumbs"></div>
-    <div id="api-navbar" class="window-resizeable"></div>
+    <div id="api-navbar"></div>
   </header>
 
   <div class="with-sidebar content-area">

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -525,12 +525,9 @@ REUSEABLE SHADOW BORDER
   .right-header{
   }
 }
-#api-navbar{
+#api-navbar {
   height: 60px;
-  position: absolute;
-  /* these styles are for the new header*/
-  .right-header{
-  }
+  float: right;
 }
 
 /* only specify the sidebar width when there’s a sidebar */


### PR DESCRIPTION
In some layouts the button was on the next line

this is a sliceoff of my port-views branch

![2-api-url](https://cloud.githubusercontent.com/assets/298166/4662052/eda7d8a8-552b-11e4-9a69-8c2262338074.png)
