### PR TITLE
Remove `rightHeader` from changes view for now

### DIFF
--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -297,6 +297,9 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
        return [this.indexedDocs.urlRef("apiurl", urlParams), "docs"];
       };
 
+      this.rightHeader = this.setView("#right-header", new Documents.Views.RightAllDocsHeader({
+        database: this.database
+      }));
       this.rightHeader.showQueryOptions();
       this.rightHeader.resetQueryOptions({
         queryParams: urlParams,

--- a/app/addons/documents/tests/routeSpec.js
+++ b/app/addons/documents/tests/routeSpec.js
@@ -9,6 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
+
 define([
         'addons/documents/routes',
         'testUtils'
@@ -18,9 +19,18 @@ define([
 
   describe('Documents Route', function () {
 
-    describe('changes route', function () {
+    it('the all-documents-list has a right header', function () {
+      var routeObj = new DocumentRoute(null, null, ['test']);
+
+      routeObj.allDocs('newdatabase', null);
+      assert.equal(typeof routeObj.rightHeader, 'object');
+    });
+
+    it('the view that shows a view has a right header', function () {
+      var routeObj = new DocumentRoute(null, null, ['test']);
+
+      routeObj.viewFn('newdatabase', 'ads', 'newView');
+      assert.equal(typeof routeObj.rightHeader, 'object');
     });
   });
-
 });
-


### PR DESCRIPTION
We have a separate filter function in this view. It probably
makes sense to integrate this filter into the right header
function later, but currently the rightHeader with the search for
documents and the query-options-tray does not work with changes and
duplicates the functionality of the filter in this context.

Closes COUCHDB-2397

//cc @seanbarclay @benkeen 
