### PR TITLE
Fix rendering on view-list after creating a view

### DIFF
--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -355,10 +355,13 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
           urlParams = params.urlParams,
           docParams = params.docParams,
           ddoc = event.ddoc,
+          defaultPageSize,
+          isLazyInit,
           pageSize,
           collection;
 
-      var defaultPageSize = _.isUndefined(this.documentsView) ? 20 : this.documentsView.perPage();
+      isLazyInit = _.isUndefined(this.documentsView) || _.isUndefined(this.documentsView.allDocsNumber);
+      defaultPageSize = isLazyInit ? 20 : this.documentsView.perPage();
       docParams.limit = pageSize = this.getDocPerPageLimit(urlParams, defaultPageSize);
 
       if (event.allDocs) {
@@ -390,15 +393,10 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
         }
       }
 
-      this.documentsView.setCollection(collection);
       this.documentsView.setParams(docParams, urlParams);
-      this.documentsView.forceRender();
 
-      // this has been commented out because it causes the header bar to disappear after a search (i.e the "Query
-      // Options" link disappears). This issue is being addressed in a separate ticket (not sure about the Jira ID)
-//      this.apiUrl = function() {
-//        return [this.indexedDocs.urlRef("apiurl", urlParams), "docs"];
-//      };
+      // this will lazily initialize all sub-views and render them
+      this.documentsView.forceRender();
     },
 
     perPageChange: function (perPage) {

--- a/app/addons/documents/tests/routeSpec.js
+++ b/app/addons/documents/tests/routeSpec.js
@@ -18,9 +18,17 @@ define([
 
   describe('Documents Route', function () {
 
-    describe('changes route', function () {
+    // after saving a new CouchDB-View we are calling the updateAllDocsFromView function.
+    // The backbone-view AllDocsList is lazily initializing other views, in particular the
+    // view AllDocsNumber and the pagination in the beforeRender method.
+    // That means the we can not access .setCollection and .perPage from outside
+    // before we render the view.
+    it('does not fail because of lazy initializing race conditions', function () {
+      var routeObj = new DocumentRoute(null, null, ['test']);
+      routeObj.updateAllDocsFromView({ddoc: "_design/asdfsadf", view: "newView"});
+
+      assert.equal(typeof routeObj.documentsView, 'object');
     });
   });
-
 });
 

--- a/app/addons/documents/views-index.js
+++ b/app/addons/documents/views-index.js
@@ -189,7 +189,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, pouchdb, QueryOption
           if (that.newView || viewNameChange) {
             var fragment = '/database/' + that.database.safeID() +'/' + ddoc.safeID() + '/_views/' + app.utils.safeURLName(viewName);
 
-            FauxtonAPI.navigate(fragment, { trigger: false });
+            FauxtonAPI.navigate(fragment);
             that.newView = false;
             that.ddocID = ddoc.safeID();
             that.viewName = viewName;


### PR DESCRIPTION
AllDocsList is lazily adding subviews in the `beforeRender` method,
which causes that it will throw an error for all methods that
access these subviews from outside before explicitly rendering
the view.

As the beforeRender is adding paging, subviews, and the establish
takes care of our collection, we are fine with just rendering.

After we got this working, we can navigate without a
`trigger: false` and are getting a view on the indexed doc after
creating the view.
