### PR TITLE
2427 ux viewing replication documents loses context

### DIFF
--- a/app/addons/documents/templates/code_editor.html
+++ b/app/addons/documents/templates/code_editor.html
@@ -18,7 +18,7 @@ the License.
 <div id="doc-actions" class="nav">
   <div class="span3">
     <button class="save-doc btn btn-success save" type="button"><i class="icon fonticon-ok-circled"></i> Save</button>
-    <button class="btn cancel-button">Back to _all_docs</button>
+    <button class="btn cancel-button">Back</button>
   </div>
 
   <div class="span7">

--- a/app/addons/documents/views-doceditor.js
+++ b/app/addons/documents/views-doceditor.js
@@ -221,8 +221,14 @@ function(app, FauxtonAPI, Components, Documents, Databases, resizeColumns, prett
       _.bindAll(this);
     },
 
-    goback: function(){
-      FauxtonAPI.navigate(this.database.url("index") + "?limit=100");
+    goback: function () {
+      var lastPageLength = FauxtonAPI.router.lastPage.length;
+
+      if ( lastPageLength < 2 ) {
+        FauxtonAPI.navigate( this.database.url('index') + '?limit=100' );
+      }else{
+        window.history.back();
+      }
     },
 
     determineStringEditMatch: function(event) {

--- a/app/core/router.js
+++ b/app/core/router.js
@@ -97,6 +97,15 @@ function(FauxtonAPI, Auth, Backbone) {
 
       $(FauxtonAPI.el).html(FauxtonAPI.masterLayout.el);
       FauxtonAPI.masterLayout.render();
+
+      this.lastPage = [];
+      //keep last pages visited in Fauxton
+      Backbone.history.on('route', function () { 
+        this.lastPage.push(Backbone.history.fragment);
+        if (this.lastPage.length > 2) {
+          this.lastPage.shift();
+        }
+      }, this);
     },
 
     triggerRouteEvent: function(event, args) {


### PR DESCRIPTION
When navigating back from a viewing/editing a document, the user expects to 'go back' to the previous page they came from. Currently, 'back' button will always go back to all_docs of the document's database, which may not be the the previous page the user came from.
1. I changed the 'back to _all_docs' button to read 'back', so depending what page sent you to the documents page, you aren't forced to go back to _all_docs.
2. I changed the 'goback' function, so if you have been inside fauxton for more than one page, you'll be redirected there via 'window.history.back()', if pasted the page into your browser, the back button will take you back to _all_docs of the database of the document you were viewing
3. I added a history array to the router that keeps that last 2 links you visited. 
