### PR TITLE
Fix for page body widths being incorrect on Stats #2

### DIFF
--- a/app/addons/fauxton/resizeColumns.js
+++ b/app/addons/fauxton/resizeColumns.js
@@ -39,16 +39,13 @@ function(FauxtonAPI) {
 
     onResizeHandler: function (){
       var fullWidth = this.getFullWidth(),
-          halfWidth = this.getHalfWidth(),
           sidebarWidth = this.getSidebarContentWidth(),
-          left = $('.window-resizeable-half').length > 0? halfWidth : sidebarWidth;
+          widthMinusBreadcrumb = this.getFullWidthMinusBreadcrumb();
 
       $('.window-resizeable').innerWidth(sidebarWidth);
-      $('.window-resizeable-half').innerWidth(halfWidth);
+      $('.window-resizeable-right').innerWidth(widthMinusBreadcrumb);
       $('.window-resizeable-full').innerWidth(fullWidth);
 
-      //set left
-      this.setLeftPosition(left);
       //if there is a callback, run that
       this.options.callback && this.options.callback();
       this.trigger('resize');
@@ -58,9 +55,13 @@ function(FauxtonAPI) {
       this.callback = null;
     },
 
+    getFullWidthMinusBreadcrumb: function () {
+      var breadcrumbWidth = ($('#breadcrumbs').length) ? $('#breadcrumbs').outerWidth() : 0;
+      return this.getFullWidth() - breadcrumbWidth;
+    },
+
     getPrimaryNavWidth: function(){
       var primaryNavWidth  = $('body').hasClass('closeMenu') ? 64 : $('#primary-navbar').outerWidth();
-      //$('body').hasClass('closeMenu') ? 64 : 220;
       return primaryNavWidth;
     },
 
@@ -73,21 +74,11 @@ function(FauxtonAPI) {
     },
 
     getSidebarWidth: function(){
-      return $('#breadcrumbs').length > 0 ? $('#breadcrumbs').outerWidth() : 0;
+      return ($('#sidebar-content').length) ? $('#sidebar-content').outerWidth() : 0;
     },
 
     getSidebarContentWidth: function(){
-      return this.getFullWidth() - this.getSidebarWidth() -5;
-    },
-
-    getHalfWidth: function(){
-      var fullWidth = this.getFullWidth();
-      return fullWidth/2;
-    },
-
-    setLeftPosition: function(panelWidth){
-      var primary = this.getPrimaryNavWidth();
-      $('.set-left-position').css('left',panelWidth+primary+4);
+      return this.getFullWidth() - this.getSidebarWidth();
     }
   };
 

--- a/app/templates/layouts/one_pane_db.html
+++ b/app/templates/layouts/one_pane_db.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/%>
 
 <div id="primary-navbar"></div>
 <div id="dashboard" class="container-fluid one-pane">
@@ -18,7 +18,7 @@ the License.
   <header class="fixed-header">
     <div id="breadcrumbs"></div>
     <div id="api-navbar"></div>
-    <div id="right-header" class="window-resizeable"></div>
+    <div id="right-header" class="window-resizeable-right"></div>
   </header>
 
 

--- a/app/templates/layouts/with_tabs_sidebar.html
+++ b/app/templates/layouts/with_tabs_sidebar.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/%>
 
 <div id="primary-navbar"></div>
 <div id="dashboard" class="container-fluid with-sidebar">
@@ -18,7 +18,7 @@ the License.
   <header class="fixed-header row-fluid">
     <div id="breadcrumbs" class="sidebar"></div>
     <div id="api-navbar"></div>
-    <div id="right-header" class="window-resizeable"></div>
+    <div id="right-header" class="window-resizeable-right"></div>
   </header>
 
   <div class="with-sidebar content-area">


### PR DESCRIPTION
This is the second version of this ticket that doesn't contain whitespace fixes.

As noted in the ticket, the widths of the main body of the Stats and Accounts
page were incorrect. On the stats page, the rightmost column was offscreen; on the
Accounts page the text gets cut off.

This ticket fixes the stats page. The Create Admins page still has the text get
cut off. This is unrelated to this issue - I'll fix that in a separate ticket
(COUCHDB-2417).

Closes COUCHDB-2428
