### PR TITLE
Account page style and usability fixes

### DIFF
--- a/app/addons/auth/assets/less/auth.less
+++ b/app/addons/auth/assets/less/auth.less
@@ -13,6 +13,22 @@
 
 @import "../../../../../assets/less/variables.less";
 
-#primary-navbar .navbar nav .nav li a#user-create-admin{
+/*#primary-navbar .navbar nav .nav li a#user-create-admin{
   background-color: @navBG;
+}*/
+
+.sidenav header {
+  padding-left: 24px;
+
+  h3 {
+    margin: 8px 0px 4px;
+  }
+}
+
+.auth-page {
+  padding: 20px;
+
+  h3 {
+    margin-top: 0px;
+  }
 }

--- a/app/addons/auth/resources.js
+++ b/app/addons/auth/resources.js
@@ -216,6 +216,7 @@ function (app, FauxtonAPI, CouchdbSession) {
 
   Auth.CreateAdminView = FauxtonAPI.View.extend({
     template: 'addons/auth/templates/create_admin',
+    className: "auth-page",
 
     initialize: function (options) {
       options = options || {};
@@ -256,6 +257,10 @@ function (app, FauxtonAPI, CouchdbSession) {
         msg = FauxtonAPI.session.messages.adminCreationFailedPrefix + ' ' + msg;
         errorHandler(msg);
       });
+    },
+
+    afterRender: function() {
+      $("#username").focus();
     }
   });
 
@@ -298,6 +303,7 @@ function (app, FauxtonAPI, CouchdbSession) {
 
   Auth.ChangePassword = FauxtonAPI.View.extend({
     template: 'addons/auth/templates/change_password',
+    className: "auth-page",
 
     events: {
       "submit #change-password": "changePassword"
@@ -319,6 +325,10 @@ function (app, FauxtonAPI, CouchdbSession) {
       });
 
       promise.fail(errorHandler);
+    },
+
+    afterRender: function () {
+      $("#password").focus();
     }
   });
 

--- a/app/addons/auth/routes.js
+++ b/app/addons/auth/routes.js
@@ -78,7 +78,8 @@ function(app, FauxtonAPI, Auth) {
         route: 'addAdmin'
       }
     },
-    
+    selectedHeader: "", // TODO prevents "Databases" being selected at least
+
     initialize: function () {
       this.navDrop = this.setView('#sidebar-content', new Auth.NavDropDown({model: FauxtonAPI.session}));
     },

--- a/app/addons/auth/templates/change_password.html
+++ b/app/addons/auth/templates/change_password.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,17 +10,20 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/%>
 
-<div class="span12">
-  <h2> Change Password </h2>
-  <form id="change-password">
-    <p class="help-block">
+<h3>Change Password</h3>
+
+<form id="change-password">
+  <p>
     Enter your new password.
-    </p>
-    <input id="password" type="password" name="password" placeholder= "New Password:" size="24">
-    <br/>
-    <input id="password-confirm" type="password" name="password_confirm" placeholder= "Verify New Password" size="24">
+  </p>
+  <input id="password" type="password" name="password" placeholder="Password" size="24">
+  <br/>
+  <input id="password-confirm" type="password" name="password_confirm" placeholder= "Verify Password" size="24">
+  <br/>
+
+  <p>
     <button type="submit" class="btn btn-primary">Change</button>
-  </form>
-</div>
+  </p>
+</form>

--- a/app/addons/auth/templates/create_admin.html
+++ b/app/addons/auth/templates/create_admin.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,27 +10,28 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/%>
 
-<div class="span12">
-  <p class="help-block">
-  Before a server admin is configured, all clients have admin privileges.
-  This is fine when HTTP access is restricted 
-  to trusted users. <strong>If end-users will be accessing this CouchDB, you must
-    create an admin account to prevent accidental (or malicious) data loss.</strong>
+<h3>Create Admins</h3>
+
+<p>
+  Before a server admin is configured, all clients have admin privileges. This is fine when
+  HTTP access is restricted to trusted users. <strong>If end-users will be accessing this
+  CouchDB, you must create an admin account to prevent accidental (or malicious) data
+  loss.</strong>
+</p>
+<p>
+  Server admins can create and destroy databases, install and update _design documents, run
+  the test suite, and edit all aspects of CouchDB configuration.
+</p>
+
+<form id="create-admin-form">
+  <input id="username" type="text" name="name" placeholder="Username" size="24">
+  <br/>
+  <input id="password" type="password" name="password" placeholder= "Password" size="24">
+  <p>Non-admin users have read and write access to all databases, which
+  are controlled by validation functions. CouchDB can be configured to block all
+  access to anonymous users.
   </p>
-  <p class="help-block">Server admins can create and destroy databases, install 
-    and update _design documents, run the test suite, and edit all aspects of CouchDB 
-    configuration.
-  </p>
-  <form id="create-admin-form">
-    <input id="username" type="text" name="name" placeholder="Username" size="24">
-    <br/>
-    <input id="password" type="password" name="password" placeholder= "Password" size="24">
-    <p class="help-block">Non-admin users have read and write access to all databases, which
-    are controlled by validation functions. CouchDB can be configured to block all
-    access to anonymous users.
-    </p>
-    <button type="submit" href="#" id="create-admin" class="btn btn-primary">Create Admin</button>
-  </form>
-</div>
+  <button type="submit" href="#" id="create-admin" class="btn btn-primary">Create Admin</button>
+</form>

--- a/app/addons/auth/templates/nav_dropdown.html
+++ b/app/addons/auth/templates/nav_dropdown.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,17 +10,15 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/%>
 
-<div id="sidenav">
+<div class="sidenav">
 <header class="row-fluid">
-  <h3> <%- user.name %> </h3>
+  <h3><%- user.name %></h3>
 </header>
-<nav>
+
 <ul class="nav nav-list">
   <li class="active" ><a data-select="change-password" id="user-change-password" href="#changePassword"> Change Password </a></li>
   <li ><a data-select="add-admin" href="#addAdmin"> Create Admins </a></li>
 </ul>
-</nav>
 </div>
-

--- a/app/addons/auth/templates/noAccess.html
+++ b/app/addons/auth/templates/noAccess.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/%>
 
 <div class="span12">
   <h2>Access Denied</h2>
@@ -20,7 +20,6 @@ the License.
       Please request authorization from the server administrators.
     <% } else { %>
       You might need to <a href="#login<% if (urlBack){ %>?urlback=<%-urlBack%>  <% } %> ">login</a>.
-      </a>
     <% } %>
   </p>
 </div>


### PR DESCRIPTION
This ticket is a general style clean-up of the Accounts page. Namely:
- general CSS style fixes
- sidebar styles now consistent with other pages in app
- focus is placed on first text box on page when page load (N.B.
  autofocus wouldn’t work consistently, hence the JS)
- "Databases" left nav item no longer selected

**\* Please note: the Create Admins page is still having it's text cut
off. This will be fixed once PR #123 has been merged. ***

Closes COUCHDB-2417
