### PR TITLE
[DISCUSS] Write up expectations we have for contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,40 @@ CouchDB is an Apache project, which is why we keep all our issues in Jira.  You 
 
 We try to keep all tickets up to date with Skill level for you to have an idea of the level of effort or comfortability with the framework you'd need to complete the task.
 
-To fix an issue in Fauxton, fork the project to your GitHub account. The [Readme file](https://github.com/apache/couchdb-fauxton/blob/master/readme.md) has information about how to get the project running.  To start working on a specific ticket, create a branch with the Jira ID # followed by a traincase description of the issue.
+The [Readme file](https://github.com/apache/couchdb-fauxton/blob/master/readme.md) has information about how to get the project running.
+
+##Guide to Contributions
+We follow our coding-styleguide to make it easier for everyone to write, read and review code: [https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md](https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md)
+
+To start working on a specific ticket, create a branch with the Jira ID # followed by a traincase description of the issue.
 
 > e.g.   1234-Added-support-for-list-functions
 
-If there is no Jira ticket for the issue you have, please create one.
+If there is no Jira ticket for the issue you have, you don't have to create one.
+
+Please describe the issue, how it happens and how you fixed it in the commit message. Before you submit the Pull-Request, please run our testsuite and make sure that it passes:
+
+```
+grunt test
+```
+
+You can also open `couchdb-fauxton/test/runner.html` in a browser. Click on the headlines of the testcases to just run a specific test that fails - it should be faster than running the whole testsuite every time.
+
+Commit messages should follow the following style:
+
+```
+A brief one line description < 72 chars
+
+Followed by further explanation if needed, this should be wrapped at
+around 72 characters. Most commits should reference an existing
+issue
+
+Closes COUCHDB-XXXX (if there is a Jira ticket)
+```
 
 When you're ready for a review, submit a Pull Request. We regularly check the PR list for Fauxton and should get back to you with a code review.  If no one has responded to you yet, you can find us on IRC in #couchdb-dev.  Ping **Garren**, **robertkowalski** or **Deathbear**, though anyone in the room should be able to help you.
 
+## Get in Touch
 We appreciate constructive feedback from people who use CouchDB, so don't be shy. We know there are bugs and we know there is room for improvement.
 
 ʕ´•ᴥ•`ʔ Thanks!

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,9 @@ And then...
 
 You should be able to access Fauxton on `http://localhost:8000`
 
+### Styleguide
+We follow our coding-styleguide to make it easier for everyone to write, read and review code: [https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md](https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md)
+
 ### Prepare Fauxton Release
 Follow the "Fauxton Setup" section, edit settings.json variable root where the document will live,
 e.g. "/_utils/fauxton/" then:


### PR DESCRIPTION
We recently got a styleguide and we also have other expectations for contributions like commit message char-length and a green passing testsuite, but it is not written up somewhere. This costs time for the contributor and the reviewer.

I changed our doc a bit which is also linked when you create a PR in a yellow box above (`Please review the guidelines for contributing to this repository.`) and started to mention the things that we expect:
- mention styleguide
- mention commit message format

I also changed a point which did not make sense to me:
- small bugfixes do not need a Jira ticket

Summed up over a year it takes a lot of time to find each extra for a PR created Jira ticket and close it, often people forget to close the ticket after the PR is merged (or do not have the karma for it?). 

My main reason for removing this rule is that we do not act to the rule in the project - the theory differs a lot from the practical day-to-day business here. It also raises the entry barrier for folks which just want to fix a small bug, but have to register an account on Jira first, then verify their email, find out how to create a bug on Jira and then write it and just after that are able to submit a patch for a bug.
