### PR TITLE
Added getter/setter utils.js methods for local storage

### DIFF
--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -425,15 +425,14 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
     },
 
     setDocPerPageLimit: function (perPage) {
-      window.localStorage.setItem('fauxton:perpage', perPage);
+      app.utils.localStorageSet('fauxton:perpage', perPage);
     },
-
 
     getDocPerPageLimit: function (urlParams, perPage) {
       var storedPerPage = perPage;
 
       if (window.localStorage) {
-        storedPerPage = window.localStorage.getItem('fauxton:perpage');
+        storedPerPage = app.utils.localStorageGet('fauxton:perpage');
 
         if (!storedPerPage) {
           this.setDocPerPageLimit(perPage);

--- a/app/core/tests/utilsSpec.js
+++ b/app/core/tests/utilsSpec.js
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+define([
+  'api',
+  'testUtils',
+  'core/utils'
+], function (FauxtonAPI, testUtils, utils) {
+  var assert = testUtils.assert;
+
+  describe('Utils', function () {
+
+    describe('localStorage', function () {
+
+      it('Should get undefined when getting a non-existent key', function () {
+        assert.isUndefined(utils.localStorageGet('qwerty'));
+      });
+
+      it ('Should get value after setting it', function () {
+        var key = 'key1';
+        utils.localStorageSet(key, 1);
+        assert.equal(utils.localStorageGet(key), 1);
+      });
+
+      it ('Set and retrieve complex object', function () {
+        var key = 'key2',
+          obj = {
+            one: 1,
+            two: ['1', 'string', 3]
+          };
+        utils.localStorageSet(key, obj);
+        assert.deepEqual(utils.localStorageGet(key), obj);
+      });
+
+    });
+  });
+
+});

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -96,6 +96,34 @@ function ($, _) {
       var testName = name || "";
       var checkforBad = testName.match(/[\$\-/,+-]/g);
       return (checkforBad !== null)?encodeURIComponent(name):name;
+    },
+
+    // a pair of simple local storage wrapper functions. These ward against problems getting or
+    // setting (e.g. local storage full) and allow you to get/set complex data structures
+    localStorageSet: function (key, value) {
+      if (_.isObject(value) || _.isArray(value)) {
+        value = JSON.stringify(value);
+      }
+      var success = true;
+      try {
+        window.localStorage.setItem(key, value);
+      } catch (e) {
+        success = false;
+      }
+      return success;
+    },
+
+    localStorageGet: function (key) {
+      var data;
+      if (_.has(window.localStorage, key)) {
+        data = window.localStorage[key];
+        try {
+          return JSON.parse(data);
+        } catch (e) {
+          return data;
+        }
+      }
+      return data;
     }
   };
 


### PR DESCRIPTION
This is primarily proactive; there are only a couple of places in the code
that use local storage, but I wanted to nip it in the bud now and use
helpers instead.

Closes COUCHDB-2432
