### PR TITLE
Minor fix for invalid API Url on Config page

### DIFF
--- a/app/addons/config/resources.js
+++ b/app/addons/config/resources.js
@@ -62,7 +62,7 @@ function (app, FauxtonAPI) {
     },
 
     url: function () {
-      return app.host + '/_config';
+      return window.location.origin + '/_config';
     },
 
     findEntryInSection: function (sectionName, entry) {


### PR DESCRIPTION
I didn't bother creating a ticket for this because it's so minor, and it sounds
like that's no longer going to be necessary.

The API Url tray showed an unusable relative link for the _config API path. This
fixes that.
