### PR TITLE
Fix path for ZeroClipboard

### DIFF
--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -835,7 +835,7 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       this.moviePath = FauxtonAPI.getExtensions('zeroclipboard:movielist')[0];
 
       if (_.isUndefined(this.moviePath)) {
-       this.moviePath = app.host + app.root + "js/zeroclipboard/ZeroClipboard.swf";
+       this.moviePath = 'js/zeroclipboard/ZeroClipboard.swf';
       }
 
       ZeroClipboard.config({ moviePath: this.moviePath });


### PR DESCRIPTION
If deployed as an CouchApp, the path for ZeroClipboard did not
match

Steps to reproduce:
- run `grunt couchapp_deploy` with a Couch in Admin-Party
- open http://localhost:5984/fauxton/_design/fauxton/index.html

Closes COUCHDB-2323
