### PR TITLE
Save button back

### DIFF
--- a/app/addons/documents/views-doceditor.js
+++ b/app/addons/documents/views-doceditor.js
@@ -221,9 +221,11 @@ function (app, FauxtonAPI, Components, Documents, Databases, resizeColumns, pret
     },
 
     goback: function () {
-      var lastPageLength = FauxtonAPI.router.lastPage.length;
+      var lastPages = FauxtonAPI.router.lastPages;
 
-      if (lastPageLength < 2) {
+      // we copy/pasted the url into the browser or came from
+      // creating a document with "/new" in the end of the path
+      if (lastPages.length < 2 || /\/new$/.test(lastPages[0])) {
         FauxtonAPI.navigate(this.database.url('index') + '?limit=100');
       } else {
         window.history.back();

--- a/app/core/router.js
+++ b/app/core/router.js
@@ -98,12 +98,12 @@ function(FauxtonAPI, Auth, Backbone) {
       $(FauxtonAPI.el).html(FauxtonAPI.masterLayout.el);
       FauxtonAPI.masterLayout.render();
 
-      this.lastPage = [];
+      this.lastPages = [];
       //keep last pages visited in Fauxton
-      Backbone.history.on('route', function () { 
-        this.lastPage.push(Backbone.history.fragment);
-        if (this.lastPage.length > 2) {
-          this.lastPage.shift();
+      Backbone.history.on('route', function () {
+        this.lastPages.push(Backbone.history.fragment);
+        if (this.lastPages.length > 2) {
+          this.lastPages.shift();
         }
       }, this);
     },


### PR DESCRIPTION
When you were creating a new document and then clicking save
the back button would bring you to the editor for new documents.
To get back to the Documentslist you were coming from, you had
to hit the "back"-button twice.

Additionally renamed lastPage to lastPages as it contains
multiple pages.

**Note**

to review without the whitespace-noise, click on the marked commit in the image:

![commit](https://cloud.githubusercontent.com/assets/298166/4956829/3a6bb022-669f-11e4-9175-3138d0486ec0.png)
