### PR TITLE
Create generic Tray component

### DIFF
--- a/app/addons/databases/views.js
+++ b/app/addons/databases/views.js
@@ -184,71 +184,21 @@ function(app, Components, FauxtonAPI, Databases) {
     }
   });
 
-  var NewDatabaseView = FauxtonAPI.View.extend({
+  var NewDatabaseView = Components.Tray.extend({
     template: 'addons/databases/templates/newdatabase',
     events: {
-      'click #add-new-database': 'toggleTray',
       'click #js-create-database': 'createDatabase',
       'keyup #js-new-database-name': 'processKey'
     },
 
     initialize: function () {
-      var hideTray = _.bind(this.hideTray, this),
-        trayVisible = _.bind(this.trayVisible, this);
-
-      $('body').on('click.add-new-database', function(e) {
-        var $clickEl = $(e.target);
-
-        if (!trayVisible()) { return; }
-        if ($clickEl.closest('.add-new-database-btn').length) { return; }
-
-        if (!$clickEl.closest('.new-database-tray').length) {
-          hideTray();
-        }
-      });
-    },
-
-    cleanup: function() {
-      $('body').off('click.add-new-database');
+      this.initTray({ toggleTrayBtnSelector: '#add-new-database' });
     },
 
     processKey: function (e) {
       if (e.which === 13) {
         this.createDatabase(e);
       }
-    },
-
-    toggleTray: function (e) {
-      e.preventDefault();
-
-      // curious. If we don't prevent bubbling, the parent View is redrawn (?)
-      e.stopImmediatePropagation();
-
-      if (this.trayVisible()) {
-        this.hideTray();
-      } else {
-        this.showTray();
-      }
-    },
-
-    hideTray: function () {
-      var $tray = this.$('.tray');
-      $tray.velocity('reverse', 250, function () {
-        $tray.hide();
-      });
-      this.$('#add-new-database').removeClass('enabled');
-    },
-
-    showTray: function () {
-      // boo! to be refactored out later (see COUCHDB-2401)
-      FauxtonAPI.Events.trigger("APIbar:closeTray");
-
-      this.$('.tray').velocity('transition.slideDownIn', 250);
-      this.$('#add-new-database').addClass('enabled');
-    },
-
-    trayVisible: function () {
-      return this.$('.tray').is(':visible');
     },
 
     createDatabase: function (e) {

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -99,60 +99,121 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
     }
   });
 
-  Components.ApiBar = FauxtonAPI.View.extend({
-    template: "addons/fauxton/templates/api_bar",
+  /**
+   * Our generic Tray component. All trays should extend this guy - it offers some convenient boilerplate code for
+   * hiding/showing, event publishing and so on. The important functions that can be called on the child Views are:
+   * - hideTray
+   * - showTray
+   * - toggleTray
+   */
+  Components.Tray = FauxtonAPI.View.extend({
 
-    events:  {
-      "click .api-url-btn": "showAPIbar"
+    // populated dynamically
+    events: {},
+
+    initTray: function (opts) {
+      this.toggleTrayBtnSelector = (_.has(opts, 'toggleTrayBtnSelector')) ? opts.toggleTrayBtnSelector : null;
+      this.onShowTray = (_.has(opts, 'onShowTray')) ? opts.onShowTray : null;
+
+      // if the component extending this one passed along the selector of the element that toggles the tray,
+      // add the appropriate events
+      if (!_.isNull(this.toggleTrayBtnSelector)) {
+        this.events['click ' + this.toggleTrayBtnSelector] = 'toggleTray';
+      }
+
+      _.bind(this.toggleTray, this);
+      _.bind(this.trayVisible, this);
+      _.bind(this.hideTray, this);
+      _.bind(this.showTray, this);
+
+      // a unique identifier for this tray
+      this.trayId = 'tray-' + this.cid;
+
+      var that = this;
+      $('body').on('click.' + this.trayId, function(e) {
+        var $clickEl = $(e.target);
+
+        if (!that.trayVisible()) {
+          return;
+        }
+        if (!_.isNull(that.toggleTrayBtnSelector) && $clickEl.closest(that.toggleTrayBtnSelector).length) {
+          return;
+        }
+        if (!$clickEl.closest('.tray').length) {
+          that.hideTray();
+        }
+      });
+
+      FauxtonAPI.Events.on(FauxtonAPI.constants.EVENT_TRAY_OPENED, this.onTrayOpenEvent, this);
     },
+
+    cleanup: function() {
+      $('body').off('click.' + this.trayId);
+    },
+
+    // all trays publish a EVENT_TRAY_OPENED event containing their unique ID. This listens for those events and
+    // closes the current tray if it's already open
+    onTrayOpenEvent: function (msg) {
+      if (!_.has(msg, 'trayId')) {
+        return;
+      }
+      if (msg.trayId !== this.trayId && this.trayVisible()) {
+        this.hideTray();
+      }
+    },
+
+    toggleTray: function (e) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
+      if (this.trayVisible()) {
+        this.hideTray();
+      } else {
+        this.showTray();
+      }
+    },
+
+    hideTray: function () {
+      var $tray = this.$('.tray');
+      $tray.velocity('reverse', FauxtonAPI.constants.TRAY_TOGGLE_SPEED, function () {
+        $tray.hide();
+      });
+
+      if (!_.isNull(this.toggleTrayBtnSelector)) {
+        this.$(this.toggleTrayBtnSelector).removeClass('enabled');
+      }
+      // announce that the tray is being closed
+      FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENT_TRAY_CLOSED, { trayId: this.trayId });
+    },
+
+    showTray: function () {
+      this.$('.tray').velocity('transition.slideDownIn', FauxtonAPI.constants.TRAY_TOGGLE_SPEED);
+      if (!_.isNull(this.toggleTrayBtnSelector)) {
+        this.$(this.toggleTrayBtnSelector).addClass('enabled');
+      }
+
+      if (!_.isNull(this.onShowTray)) {
+        this.onShowTray();
+      }
+
+      FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENT_TRAY_OPENED, { trayId: this.trayId });
+    },
+
+    trayVisible: function () {
+      return this.$('.tray').is(':visible');
+    }
+  });
+
+
+  Components.ApiBar = Components.Tray.extend({
+    template: "addons/fauxton/templates/api_bar",
 
     initialize: function (options) {
       var _options = options || {};
       this.endpoint = _options.endpoint || '_all_docs';
       this.documentation = _options.documentation || 'docs';
 
-      var hideAPIbar = _.bind(this.hideAPIbar, this),
-          navbarVisible = _.bind(this.navbarVisible, this);
-
-      $('body').on('click.apibar', function(e) {
-        var $navbar = $(e.target);
-
-        if (!navbarVisible()) { return;}
-        if ($navbar.hasClass('.api-url-btn')) { return; }
-
-        if (!$navbar.closest('#api-navbar').length){
-          hideAPIbar();
-        }
-      });
-
-      FauxtonAPI.Events.on('APIbar:closeTray', this.hideAPIbar, this);
-    },
-
-    navbarVisible: function () {
-      return this.$('.api-navbar').is(':visible');
-    },
-
-    cleanup: function () {
-      $('body').off('click.apibar');
-      FauxtonAPI.Events.off('APIbar:closeTray');
-    },
-
-    hideAPIbar: function () {
-      var $navBar = this.$('.api-navbar');
-      $navBar.velocity("reverse", 250, function () {
-        $navBar.hide();
-      });
-      this.$('.api-url-btn').removeClass('enabled');
-    },
-
-    //we only need to show the api-bar here. The `click.apibar` event 
-    //in the initialize will close the api bar if a user clicks the api button
-    //and the api bar is visible.
-    showAPIbar: function() {
-      if (!this.navbarVisible()) {
-        this.$('.api-navbar').velocity("transition.slideDownIn", 250);
-        this.$('.api-url-btn').addClass('enabled');
-      }
+      this.initTray({ toggleTrayBtnSelector: '.api-url-btn' });
     },
 
     serialize: function() {
@@ -173,7 +234,6 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
     update: function(endpoint) {
       this.endpoint = endpoint[0];
       this.documentation = endpoint[1];
-
       this.render();
     },
 
@@ -195,7 +255,6 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       });
     }
   });
-
 
   Components.Pagination = FauxtonAPI.View.extend({
     tagName: "ul",

--- a/app/constants.js
+++ b/app/constants.js
@@ -14,7 +14,11 @@ define([], function () {
 
   var constants = {
     TRAY_TOGGLE_SPEED: 250,
-    DEFAULT_PAGE_SIZE: 20
+    DEFAULT_PAGE_SIZE: 20,
+
+    // events
+    EVENT_TRAY_CLOSED: 'tray:closed',
+    EVENT_TRAY_OPENED: 'tray:opened'
   };
 
   return constants;


### PR DESCRIPTION
This moves a lot of the logic from the individual trays (Add Database,
Query Options, API Url) and into a generic Tray component.

**\* Note: the trays should function exactly as before. ***

Closes COUCHDB-2401
