### PR TITLE
Stay on same page after logout 

### DIFF
--- a/app/addons/auth/base.js
+++ b/app/addons/auth/base.js
@@ -62,7 +62,7 @@ function(app, FauxtonAPI, Auth) {
 
 
     var addLogoutLink = function () {
-      FauxtonAPI.addHeaderLink({footerNav: true, href: "#logout", title: "Logout", icon: "", className: 'logout'});
+      FauxtonAPI.addHeaderLink({footerNav: true, title: "Logout", icon: "", className: 'js-logout'});
     };
 
     var removeLogoutLink = function () {

--- a/app/addons/auth/routes.js
+++ b/app/addons/auth/routes.js
@@ -23,7 +23,6 @@ function(app, FauxtonAPI, Auth) {
     routes: {
       'login?*extra': 'login',
       'login': 'login',
-      'logout': 'logout',
       'createAdmin': 'createAdmin',
       'noAccess?*extra': 'noAccess',
       'noAccess': 'noAccess'
@@ -36,13 +35,6 @@ function(app, FauxtonAPI, Auth) {
         model: FauxtonAPI.session,
         urlBack: urlBack
       }));
-    },
-
-    logout: function () {
-      FauxtonAPI.addNotification({msg: 'You have been logged out.'});
-      FauxtonAPI.session.logout().then(function () {
-        FauxtonAPI.navigate('/');
-      });
     },
 
     changePassword: function () {

--- a/app/addons/fauxton/base.js
+++ b/app/addons/fauxton/base.js
@@ -126,7 +126,8 @@ function(app, FauxtonAPI, resizeColumns, Components, ZeroClipboard) {
     template: "addons/fauxton/templates/nav_bar",
 
     events:  {
-      "click .burger" : "toggleMenu"
+      "click .burger" : "toggleMenu",
+      "click .js-logout": "logout"
     },
 
     toggleMenu: function(){
@@ -164,6 +165,13 @@ function(app, FauxtonAPI, resizeColumns, Components, ZeroClipboard) {
 
     establish: function(){
       return [this.versionFooter.establish()];
+    },
+
+    logout: function (e) {
+      e.preventDefault();
+      FauxtonAPI.session.logout().then(function () {
+        FauxtonAPI.addNotification({msg: 'You have been logged out.'});
+      });
     },
 
     addLink: function(link) {

--- a/app/addons/fauxton/templates/nav_bar.html
+++ b/app/addons/fauxton/templates/nav_bar.html
@@ -63,7 +63,7 @@ the License.
       <% _.each(footerNavLinks, function(link) { %>
       <% if (link.view) {return;}  %>
         <li data-nav-name= "<%- link.title %>">
-          <a href="<%- link.href %>">
+          <a data-bypass="true" href="<%- link.href %>" class="<%- link.className %>">
             <i class="<%- link.icon %> fonticon"></i>
             <%- link.title %>
           </a>


### PR DESCRIPTION
If the anonymous user does not have the permissions, they are
redirected to the login in the next step.

Closes COUCHDB-2435

---

Only exception here are actions that don't open a new page, e.g. in a database that is only accessible as admin, logout and click `changes`. You will get a spinning wheel of death and an error notification. So far no general solution came to my mind, open for suggestions!
