### PR TITLE
Style fix for Add Database tray

### DIFF
--- a/app/addons/databases/assets/less/databases.less
+++ b/app/addons/databases/assets/less/databases.less
@@ -49,7 +49,7 @@
     right: 153px;
   }
 
-  .input-xxlarge {
+  input.input-xxlarge {
     margin-bottom: 0px;
     width: 250px;
     .border-radius(5px 0 0 5px);


### PR DESCRIPTION
Very small thing. The rounded corners should only appear on the left of the
input box in the Add Database tray. This increases the specificity of the
rule so it properly applies.
