### PR TITLE
Typeahead component needs to urlencode query params

### DIFF
--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -566,6 +566,7 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       _.bindAll(this);
     },
     source: function(query, process) {
+      query = encodeURIComponent(query);
       var url = [
         app.host,
         "/_all_dbs?startkey=%22",


### PR DESCRIPTION
Closes COUCHDB-2456
