### PR TITLE
Switch-db-tray does not work with query options

### DIFF
--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -520,6 +520,12 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
     },
 
     cleanup: function () {
+      if (this.documentsView) {
+        this.removeView('#dashboard-lower-content');
+      }
+      if (this.rightHeader) {
+        this.removeView('#right-header');
+      }
       if (this.leftheader) {
         this.removeView('#breadcrumbs');
       }


### PR DESCRIPTION
This fixes a problem where using the db tray switch shows incorrect
results. To confirm fix:
1. Open a database (database A) and search for a single key with the
queryoption-tray: you get one document as result
2. use the new tray to switch to another database (database B)
3. you should see that all_docs from database B now shows up as you'd
expect

Closes COUCHDB-2460
