### PR TITLE
Clicking Databases page heading changes text color red

### DIFF
--- a/assets/less/trays.less
+++ b/assets/less/trays.less
@@ -112,7 +112,7 @@
   color: @orange;
 }
 
-#breadcrumbs .breadcrumb li.active.js-enabled {
+#breadcrumbs .breadcrumb li.lookahead-tray-link.js-enabled {
   color: @red;
 }
 


### PR DESCRIPTION
This also occurred on the Config, Active Tasks and other pages. Now
when you click on them the font doesn't change color.

Closes COUCHDB-2459
