### PR TITLE
Only render doc page breadcrumbs as needed

### DIFF
--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -52,7 +52,13 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       this.listenTo(FauxtonAPI.Events, 'lookaheadTray:close', this.unselectLastBreadcrumb);
     },
 
-    updateCrumbs: function(crumbs){
+    updateCrumbs: function (crumbs) {
+
+      // if the breadcrumbs haven't changed, don't bother re-rendering the component
+      if (_.isEqual(this.crumbs, crumbs)) {
+        return;
+      }
+
       this.crumbs = crumbs;
       this.breadcrumbs && this.breadcrumbs.update(crumbs);
     },


### PR DESCRIPTION
All routes changes used to cause the breadcrumbs to be re-rendered,
even though they often don't change. This small change checks to see
if the crumbs have in fact changed, and only re-renders if so.

Closes COUCHDB-2465
