### PR TITLE
Fix the flash on doc page route changes

### DIFF
--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -192,6 +192,9 @@ table.databases {
   }
 }
 
+#dashboard {
+  width: 100%;
+}
 
 #dashboard-upper-content{
   .tab-content {


### PR DESCRIPTION
This is subtle and only occurs on Chrome. To reproduce:
1. Go to the Database -> All Docs page for a database.
2. Click from the All Documents page to All Design Docs.

Click back and forth a few times. Notice that sometimes there's a
sort of quick flash that appears over the breadcrumbs section making
it look a little like the breadcrumbs are being re-rendered.

This fixes that. 

Closes COUCHDB-2467
