### PR TITLE
Enable passing a single test to nightwatch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -424,8 +424,11 @@ module.exports = function(grunt) {
     }
   });
 
-  var fileArg = grunt.option('file') + '.js';
+
+  // enable running of a single test with nightwatch
+  var fileArg = grunt.option('file');
   if (fileArg) {
+    fileArg = fileArg + '.js';
     var nightwatchConf = require('./test/nightwatch_tests/nightwatch.json'),
         paths;
 

--- a/test/nightwatch_tests/nightwatch_README.md
+++ b/test/nightwatch_tests/nightwatch_README.md
@@ -18,6 +18,12 @@ Then, to run the the test:
     $ grunt nightwatch
 
 
+You can run individual single tests by running
+
+    $ grunt nightwatch --file="createsDatabase"
+
+if you want to run the testfile `createsDatabase.js`.
+
 ##Writing Tests
 You can contribute by writing tests for Fauxton as well.  
   


### PR DESCRIPTION
You can now pass single testfiles to nightwatch which makes
development of tests easier and faster.

Example:
`grunt nightwatch --file="createsDatabase"` launches the
createsDatabase.js testfile in app/databases/tests/nightwatch

The code overwrites initial command as we don't have access to
the passed options to grunt in the `initConfig` setter. Another
solution could be using `process.argv` - however I am not a
Grunt expert and would like to get some feedback which approach
is the better way to write Grunt 

For me using `process.argv` would be the way to go (I realized I 
could probably access it from here when I finished the other 
code) but maybe it is a grunt-antipattern for reasons I am not 
aware of

Happy testing!
