### PR TITLE
Fix URL paths for Views to be _view not _views

### DIFF
--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -54,7 +54,7 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
         route: "allDocs",
         roles: ["fx_loggedIn"]
       },
-      "database/:database/_design/:ddoc/_views/:view": {
+      "database/:database/_design/:ddoc/_view/:view": {
         route: "viewFn",
         roles: ['fx_loggedIn']
       },

--- a/app/addons/documents/templates/index_menu_item.html
+++ b/app/addons/documents/templates/index_menu_item.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,7 +10,7 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/%>
 <a class="js-toggle-<%-ddocType%> accordion-header js-collapse-toggle" data-toggle="collapse"  data-target="#<%- removeSpecialCharacters(ddoc) + ddocType %>" id="nav-design-function-<%= removeSpecialCharacters(ddoc) + ddocType %>">
   <div class="fonticon-play"></div>
   <span class="<%- icon %> fonticon"></span>
@@ -19,10 +19,9 @@ the License.
   <ul class="accordion-body collapse" id="<%- removeSpecialCharacters(ddoc) + ddocType %>">
   <% _.each(collection, function (item, index) { %>
   <li>
-  <a data-ddoctype="<%- ddocType %>" id="<%- removeSpecialCharacters(ddoc) %>_<%- removeSpecialCharacters(index) %>" href="#/database/<%- safeURL(database) %>/_design/<%= safeURL(ddoc)%>/_<%-ddocType%>/<%= safeURL(index) %>" class="toggle-view">
+  <a data-ddoctype="<%- ddocType %>" id="<%- removeSpecialCharacters(ddoc) %>_<%- removeSpecialCharacters(index) %>" href="#/database/<%- safeURL(database) %>/_design/<%= safeURL(ddoc)%>/<%-urlFolder%>/<%= safeURL(index) %>" class="toggle-view">
     <%- index %>
   </a>
   </li>
   <% }); %>
 </ul>
-

--- a/app/addons/documents/views-index.js
+++ b/app/addons/documents/views-index.js
@@ -187,7 +187,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, pouchdb, QueryOption
           });
 
           if (that.newView || viewNameChange) {
-            var fragment = '/database/' + that.database.safeID() +'/' + ddoc.safeID() + '/_views/' + app.utils.safeURLName(viewName);
+            var fragment = '/database/' + that.database.safeID() +'/' + ddoc.safeID() + '/_view/' + app.utils.safeURLName(viewName);
 
             FauxtonAPI.navigate(fragment);
             that.newView = false;

--- a/app/addons/documents/views-sidebar.js
+++ b/app/addons/documents/views-sidebar.js
@@ -244,16 +244,17 @@ function(app, FauxtonAPI, Components, Documents, Databases) {
       this.selected = !! options.selected;
       this.selector = options.selector;
       this.name = options.name;
-      this.icons = {
-        "Views": "fonticon-sidenav-map-reduce",
-        "indexes": "fonticon-sidenav-search"
-      };
 
+      this.indexTypeMap = {
+        views:   { icon: 'fonticon-sidenav-map-reduce', urlFolder: '_view' },
+        indexes: { icon: 'fonticon-sidenav-search', urlFolder: '_indexes' }
+      };
     },
 
     serialize: function() {
       return {
-        icon: this.icons[this.ddocType],
+        icon: this.indexTypeMap[this.selector].icon,
+        urlFolder: this.indexTypeMap[this.selector].urlFolder,
         ddocType:  this.selector,
         name: this.name,
         index: this.index,


### PR DESCRIPTION
This changes the URL paths for Views within Fauxton for compatibility
with the API URLs. To test, just create/edit a View and confirm the URL
ends with /_view/theViewName not /_views/theViewName

Closes COUCHDB-2415
