### PR TITLE
Global notifications now full width

### DIFF
--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -24,7 +24,6 @@
   top: 0px;
   display: block;
   z-index: 100000;
-  left: @navWidth;
   .closeMenu & {
     left: @collapsedNavWidth;
   }


### PR DESCRIPTION
This makes a small change to the global notifications so that it goes
full page width. This was done partly to solve the missing close "x"
that was getting put off screen, but also because it just looks better
this way.

Closes COUCHDB-2473
