### PR TITLE
Layout templates should limit header width

### DIFF
--- a/app/addons/databases/tests/nightwatch/confirmAPIUrlTrayOpens.js
+++ b/app/addons/databases/tests/nightwatch/confirmAPIUrlTrayOpens.js
@@ -1,0 +1,25 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+  'Confirm API Url tray opens' : function (client) {
+    var waitTime = 10000,
+        baseUrl = client.globals.baseUrl;
+
+    client
+      .loginToGUI()
+      .url(baseUrl + '/#/_all_docs')
+      .click('.api-url-btn')
+      .waitForElementVisible('.api-navbar', waitTime, false)
+      .end();
+  }
+};

--- a/app/templates/layouts/one_pane.html
+++ b/app/templates/layouts/one_pane.html
@@ -13,13 +13,12 @@ the License.
 */%>
 
 <div id="primary-navbar"></div>
-<div id="dashboard" class="container-fluid one-pane">
+<div id="dashboard" class="container-fluid one-pane window-resizeable-full">
   <header class="fixed-header">
     <div id="breadcrumbs"></div>
     <div id="api-navbar"></div>
     <div id="right-header" class="window-resizeable-right"></div>
   </header>
-
 
   <div class="row-fluid content-area">
     <div id="tabs" class="row"></div>

--- a/app/templates/layouts/two_pane.html
+++ b/app/templates/layouts/two_pane.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,11 +10,10 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
-
+*/%>
 
 <div id="primary-navbar"></div>
-<div id="dashboard" class="container-fluid">
+<div id="dashboard" class="container-fluid window-resizeable-full">
   <div class="fixed-header">
     <div id="breadcrumbs"></div>
     <div id="api-navbar"></div>

--- a/app/templates/layouts/with_sidebar.html
+++ b/app/templates/layouts/with_sidebar.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,11 +10,10 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
-
+*/%>
 
 <div id="primary-navbar"></div>
-<div id="dashboard" class="container-fluid">
+<div id="dashboard" class="container-fluid window-resizeable-full">
   <header class="fixed-header">
     <div id="breadcrumbs"></div>
     <div id="api-navbar"></div>

--- a/app/templates/layouts/with_tabs.html
+++ b/app/templates/layouts/with_tabs.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,10 +10,10 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/>
 
 <div id="primary-navbar"></div>
-<div id="dashboard" class="container-fluid">
+<div id="dashboard" class="container-fluid window-resizeable-full">
 
   <div class="fixed-header">
     <div id="breadcrumbs"></div>

--- a/app/templates/layouts/with_tabs_sidebar.html
+++ b/app/templates/layouts/with_tabs_sidebar.html
@@ -13,7 +13,7 @@ the License.
 */%>
 
 <div id="primary-navbar"></div>
-<div id="dashboard" class="container-fluid with-sidebar">
+<div id="dashboard" class="container-fluid with-sidebar window-resizeable-full">
   <header class="fixed-header row-fluid">
     <div id="breadcrumbs" class="sidebar"></div>
     <div id="api-navbar"></div>

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -176,10 +176,6 @@ table.databases {
   }
 }
 
-#dashboard {
-  width: 100%;
-}
-
 #dashboard-upper-content{
   .tab-content {
     padding-top: 70px;


### PR DESCRIPTION
This was added to fix an issue on the Databases page where the API Bar
was missing. It occurred because the <header> was filling up all
available space, taking it offscreen, thanks the #dashboard being
100%. I believe this is the only instance of the problem.
