### PR TITLE
Componentize footer

### DIFF
--- a/app/addons/documents/assets/less/documents.less
+++ b/app/addons/documents/assets/less/documents.less
@@ -151,7 +151,7 @@ button.string-edit[disabled] {
 
 .show-select {
   #doc-list {
-    padding: 30px 0 0 0;
+    padding: 30px 0 30px 0;
     .custom-inputs {
       display: block;
       float: left;

--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -637,8 +637,13 @@ function(app, FauxtonAPI, PagingCollection) {
       this.view = options.view;
       this.design = options.design.replace('_design/','');
       this.params = _.extend({limit: 20, reduce: false}, options.params);
-
       this.idxType = "_view";
+
+      this.viewMeta = {
+        total_rows: this.rows.length,
+        offset: 0,
+        update_seq: false
+      };
     },
 
     url: function () {
@@ -667,12 +672,6 @@ function(app, FauxtonAPI, PagingCollection) {
     fetch: function() {
       var deferred = FauxtonAPI.Deferred();
       this.reset(this.rows, {silent: true});
-
-      this.viewMeta = {
-        total_rows: this.rows.length,
-        offset: 0,
-        update_seq: false
-      };
 
       deferred.resolve();
       return deferred;

--- a/app/addons/documents/templates/all_docs_footer.html
+++ b/app/addons/documents/templates/all_docs_footer.html
@@ -1,4 +1,5 @@
-<!--
+<%
+/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,21 +11,10 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/
+%>
 
-  <!-- floats right -->
-  <div id="header-api-bar" class="button"></div>
-
-  <!-- Query Options-->
-  <div id="header-query-options" class="button">
-    <div id="query-options"></div>
-  </div>
-
-  <!-- search (jump to doc)-->
-  <div id="header-search" class="js-search searchbox-container"></div>
-
-  <!-- Select toggle -->
-  <!--<div id="header-select-all" class="button">
-    <span class="toggle-select-menu icon fonticon-ok-circled">Select</span>
-  </div>-->
-
+<footer class="index-pagination pagination-footer window-resizeable">
+  <div id="item-numbers"></div>
+  <div id="documents-pagination"></div>
+</footer>

--- a/app/addons/documents/templates/all_docs_header.html
+++ b/app/addons/documents/templates/all_docs_header.html
@@ -1,0 +1,32 @@
+<%
+/*
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+*/
+%>
+
+  <!-- floats right -->
+  <div id="header-api-bar" class="button"></div>
+
+  <!-- Query Options-->
+  <div id="header-query-options" class="button">
+    <div id="query-options"></div>
+  </div>
+
+  <!-- search (jump to doc)-->
+  <div id="header-search" class="js-search searchbox-container"></div>
+
+  <!-- Select toggle -->
+  <!--<div id="header-select-all" class="button">
+    <span class="toggle-select-menu icon fonticon-ok-circled">Select</span>
+  </div>-->
+

--- a/app/addons/documents/templates/all_docs_list.html
+++ b/app/addons/documents/templates/all_docs_list.html
@@ -36,9 +36,4 @@
     </p>
     </div>
   <% } %>
-
-  <footer class="index-pagination pagination-footer window-resizeable<%=resizeLayout%>">
-    <div id="item-numbers"> </div>
-    <div id="documents-pagination"></div>
-  </footer>
 </div>

--- a/app/addons/documents/tests/viewsSpec.js
+++ b/app/addons/documents/tests/viewsSpec.js
@@ -13,8 +13,9 @@ define([
         'addons/documents/views',
         'addons/documents/resources',
         'addons/databases/base',
+        'addons/fauxton/components',
         'testUtils'
-], function (Views, Resources, Databases, testUtils) {
+], function (Documents, Resources, Databases, Components, testUtils) {
   var assert = testUtils.assert,
       ViewSandbox = testUtils.ViewSandbox,
       viewSandbox;
@@ -29,10 +30,25 @@ define([
       params: {}
     });
 
-    var view = new Views.Views.AllDocsList({
+    var pagination = new Components.IndexPagination({
+      collection: database.allDocs,
+      scrollToSelector: '#dashboard-content',
+      docLimit: 20,
+      perPage: 20
+    });
+
+    var allDocsNumber = new Documents.Views.AllDocsNumber({
+      collection: database.allDocs,
+      pagination: pagination,
+      perPageDefault: 20
+    });
+
+    var view = new Documents.Views.AllDocsList({
       viewList: false,
       bulkDeleteDocsCollection: bulkDeleteDocCollection,
-      collection: database.allDocs
+      collection: database.allDocs,
+      pagination: pagination,
+      allDocsNumber: allDocsNumber
     });
 
     beforeEach(function (done) {
@@ -45,7 +61,7 @@ define([
     });
 
     it('should load', function () {
-      assert.equal(typeof Views.Views.AllDocsList, 'function');
+      assert.equal(typeof Documents.Views.AllDocsList, 'function');
     });
 
     it('pressing SelectAll should fill the delete-bulk-docs-collection', function () {

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -496,7 +496,12 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
     setCollection: function (collection) {
       this.collection = collection;
       this.setDefaults();
+      this.render();
     },
+
+    getPerPage: function () {
+      return this.perPage;
+    }
 
   });
 

--- a/app/templates/layouts/with_tabs_sidebar.html
+++ b/app/templates/layouts/with_tabs_sidebar.html
@@ -24,15 +24,19 @@ the License.
     <aside id="sidebar-content" class="sidebar"></aside>
 
     <section id="dashboard-content" class="list pull-right window-resizeable">
-      <div class="inner">
-        <div id="dashboard-upper-content">
+      <div class="scrollable">
+        <div class="inner">
+          <div id="dashboard-upper-content">
 
+          </div>
+
+          <div id="dashboard-lower-content"></div>
         </div>
+      </div>
+      <div id="footer">
 
-        <div id="dashboard-lower-content"></div>
       </div>
     </section>
-
   </div>
 </div>
 

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -249,6 +249,19 @@ table.databases {
   }
 }
 
+.scrollable {
+  height: auto;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  width: 100%;
+  position: absolute;
+  padding: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  top: 60px;
+}
 
 /*ONE PANEL TEMPLATE ONLY STYLES  AKA _all_dbs */
 
@@ -733,7 +746,6 @@ REUSEABLE SHADOW BORDER
 //----footer--///
 footer.pagination-footer {
   z-index: 1;
-  min-width: 600px;
   position:fixed;
   background-color:#fff;
   bottom:0;
@@ -756,10 +768,6 @@ footer.pagination-footer {
       }
     }
   }
-}
-
-footer.index-pagination {
-  margin-left: -20px;
 }
 
 #item-numbers{

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -330,6 +330,7 @@ with_tabs_sidebar.html
 
 #dashboard-content {
   padding-left: 15px;
+  padding-right: 15px;
   padding-top: 20px;
 
   &.row-fluid,
@@ -345,9 +346,9 @@ with_tabs_sidebar.html
     .left-shadow-border;
     border-right: 1px solid #999;
     width: auto;
-    padding: 0px;
+    padding: 15px;
     bottom: 0px;
-    top: 60px;
+    top: 0px;
     position: fixed;
     overflow-x: hidden;
     overflow-y: auto;


### PR DESCRIPTION
Take the elements that were all baked into all-docs-list
and inject them into the all-docs-list. This enables us to have
a separate footer component in the layout which can be initialized
without the all-docs-list viewobject.

This enables us to remove the `position: fixed` from the footer
and use `position: absolute`. Without having the element
`position: fixed;` we do not need to calculate it's width via JS
and can apply a css based pane layout.

Part of: COUCHDB-2471
