### PR TITLE
Fix lookaheadTray test

### DIFF
--- a/app/addons/documents/tests/nightwatch/lookaheadTray.js
+++ b/app/addons/documents/tests/nightwatch/lookaheadTray.js
@@ -14,7 +14,7 @@ module.exports = {
   'The tray opens': function (client) {
     var waitTime = 10000,
         newDatabaseName = client.globals.testDatabaseName,
-        baseUrl = client.globals.baseUrl;
+        baseUrl = client.globals.test_settings.launch_url;
 
     client
       .loginToGUI()


### PR DESCRIPTION
`baseUrl` was undefined
