### PR TITLE
Fix broken testsuite

### DIFF
--- a/settings.json.default
+++ b/settings.json.default
@@ -75,7 +75,10 @@
     "nightwatch": {
       "username": "tester",
       "password": "testerpass",
-      "launch_url": "localhost:8000",
+      "fauxton_host": "localhost",
+      "fauxton_port": "8000",
+      "db_host": "localhost",
+      "db_port": "5984",
       "custom_commands_path": "test/nightwatch_tests/custom-commands",
       "globals_path": "test/nightwatch_tests/helpers/helpers.js"
     }

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -158,7 +158,11 @@ module.exports = function(grunt) {
       globals_path: this.data.settings.nightwatch.globals_path,
       username: this.data.settings.nightwatch.username,
       password: this.data.settings.nightwatch.password,
-      launch_url: this.data.settings.nightwatch.launch_url
+      launch_url: this.data.settings.nightwatch.launch_url,
+      fauxton_host: this.data.settings.nightwatch.fauxton_host,
+      fauxton_port: this.data.settings.nightwatch.fauxton_port,
+      db_host: this.data.settings.nightwatch.db_host,
+      db_port: this.data.settings.nightwatch.db_port
     }));
   });
 
@@ -175,8 +179,7 @@ module.exports = function(grunt) {
     // check the requires nightwatch settings. These should always exist in the settings.json file
     } else if (!_.has(data, 'nightwatch') ||
       !_.has(data.nightwatch, 'username') ||
-      !_.has(data.nightwatch, 'password') ||
-      !_.has(data.nightwatch, 'launch_url')) {
+      !_.has(data.nightwatch, 'password')) {
       error = 'Your settings.json file doesn\'t contain valid nightwatch settings. Please check the user doc.';
     }
 

--- a/test/nightwatch_tests/helpers/helpers.js
+++ b/test/nightwatch_tests/helpers/helpers.js
@@ -1,12 +1,11 @@
+var nano = require('nano');
+
 module.exports = {
 
   testDatabaseName : 'fauxton-selenium-tests',
 
-  getNanoInstance : function () {
-    var user = this.test_settings.username,
-        pass = this.test_settings.password,
-        launch_url = this.test_settings.launch_url;
-    return require('nano')('http://' + user + ':' + pass + '@' + launch_url);
+  getNanoInstance: function () {
+    return nano(this.test_settings.db_url);
   },
 
   beforeEach: function (done) {

--- a/test/nightwatch_tests/nightwatch.json.underscore
+++ b/test/nightwatch_tests/nightwatch.json.underscore
@@ -24,7 +24,8 @@
     "default" : {
       "username": "<%- username %>",
       "password": "<%- password %>",
-      "launch_url" : "<%- launch_url %>",
+      "launch_url": "http://<%- fauxton_host %>:<%- fauxton_port %>",
+      "db_url": "http://<%- username %>:<%- password %>@<%- db_host %>:<%- db_port %>",
       "selenium_host" : "127.0.0.1",
       "selenium_port" : 4444,
       "silent" : true,


### PR DESCRIPTION
Remove shared url for db and Fauxton
Move db-url-construction to the settings.json

This enables us additionally to have the couch running on differnt
host to fauxton.
