### PR TITLE
[WIP] Nightwatch support for multiple accounts

### DIFF
--- a/settings.json.default
+++ b/settings.json.default
@@ -73,13 +73,17 @@
     },
 
     "nightwatch": {
-      "username": "tester",
-      "password": "testerpass",
-      "fauxton_host": "localhost",
-      "fauxton_port": "8000",
-      "db_host": "localhost",
-      "db_port": "5984",
       "custom_commands_path": "test/nightwatch_tests/custom-commands",
-      "globals_path": "test/nightwatch_tests/helpers/helpers.js"
+      "globals_path": "test/nightwatch_tests/helpers/helpers.js",
+      "accounts": [
+        {
+          "username": "tester",
+          "password": "testerpass",
+          "fauxton_host": "localhost",
+          "fauxton_port": "8000",
+          "db_host": "localhost",
+          "db_port": "5984"
+        }
+      ]
     }
 }


### PR DESCRIPTION
This expands on the nightwatch tests a bit so you can define multiple
accounts, which are randomly chosen when running `grunt nightwatch`. To
allow calling a specific test there's an optional --username=X param.
