### PR TITLE
Check bulkDeleteDocsCollection existence

### DIFF
--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -397,7 +397,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
         return;
       }
 
-      if (this.bulkDeleteDocsCollection.length === 0) {
+      if (!this.bulkDeleteDocsCollection || this.bulkDeleteDocsCollection.length === 0) {
         return;
       }
       this.$('.js-all').addClass('active');
@@ -493,7 +493,9 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
       this.allDocsNumber && this.allDocsNumber.remove();
       _.each(this.rows, function (row) {row.remove();});
 
-      this.bulkDeleteDocsCollection.reset();
+      if (this.bulkDeleteDocsCollection) {
+        this.bulkDeleteDocsCollection.reset();
+      }
     },
 
     removeNestedViews: function () {


### PR DESCRIPTION
The createsViews test would occasionally fail due to this line. I think
what was happening was that the page load DOM was ready prior to the
API data being loaded, so the cleanup function ran before there was
any data in bulkDeleteDocsCollection.
