### PR TITLE
Input field in clone doc modal full width

### DIFF
--- a/app/addons/documents/templates/duplicate_doc_modal.html
+++ b/app/addons/documents/templates/duplicate_doc_modal.html
@@ -23,7 +23,7 @@ the License.
       <p class="help-block">
       Set new documents ID:
       </p>
-      <input id="dup-id" type="text" class="input-xlarge">
+      <input id="dup-id" type="text" class="input-block-level" >
     </form>
 
   </div>


### PR DESCRIPTION
Just a small style fix. There wasn't enough space so the input field
in the modal now spans 100%.
