### PR TITLE
Rename index.css and require.js with md5 hash

### DIFF
--- a/assets/index.underscore
+++ b/assets/index.underscore
@@ -24,7 +24,7 @@
   <title>Project Fauxton</title>
 
   <!-- Application styles. -->
-  <link rel="stylesheet" href="<%= css %><%=cachebuster%>">
+  <link rel="stylesheet" href="<%= css %>">
   <% if (base) { %>
   <base href="<%= base %>"></base>
   <% } %>
@@ -38,6 +38,6 @@
   </div>
 
   <!-- Application source. -->
-  <script data-main="/config" src="<%= requirejs %><%=cachebuster%>"></script>
+  <script data-main="/config" src="<%= requirejs %>"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "nightwatch": "~0.5.33",
     "nano": "~5.12.0",
     "grunt-chmod": "^1.0.3",
-    "grunt-selenium-webdriver": "^0.2.431"
+    "grunt-selenium-webdriver": "^0.2.431",
+    "grunt-md5": "^0.1.11"
   }
 }

--- a/settings.json.default
+++ b/settings.json.default
@@ -21,8 +21,7 @@
         "variables": {
           "requirejs": "/assets/js/libs/require.js",
           "css": "./css/index.css",
-          "base": null,
-          "cachebuster": ""
+          "base": null
         },
         "app": {
           "root": "/",
@@ -34,10 +33,9 @@
         "src": "assets/index.underscore",
         "dest": "dist/debug/index.html",
         "variables": {
-          "requirejs": "./js/require.js",
-          "css": "./css/index.css",
-          "base": null,
-          "cachebuster": "?v1.0"
+          "requirejs": "./js/REQUIREJS_FILE",
+          "css": "./css/CSS_FILE",
+          "base": null
         },
         "app": {
           "root": "/_utils/fauxton/",
@@ -49,10 +47,9 @@
         "src": "assets/index.underscore",
         "dest": "dist/debug/index.html",
         "variables": {
-          "requirejs": "./js/require.js",
-          "css": "./css/index.css",
-          "base": null,
-          "cachebuster": "?v1.0"
+          "requirejs": "./js/REQUIREJS_FILE",
+          "css": "./css/CSS_FILE",
+          "base": null
         },
         "app": {
           "root": "/",


### PR DESCRIPTION
- removes obsolete "cache buster" setting
- replaces hardcoded require.js and index.css filenames in settings
  files for non-dev build processes with variables.
- `release` and `couchapp_deploy` tasks now rename those two files to
  include their hashes, and reference them in the generated index.html
  file
