### PR TITLE
Fix for doc nav

### DIFF
--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -499,6 +499,7 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
       this.perPage = perPage;
       this.documentsView.forceRender();
       this.documentsView.collection.pageSizeReset(perPage, {fetch: false});
+      this.allDocsNumber.forceRender();
       this.setDocPerPageLimit(perPage);
     },
 
@@ -507,6 +508,8 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
       this.documentsView.collection.reset(collection);
 
       this.documentsView.forceRender();
+      this.allDocsNumber.forceRender();
+
       collection.paging.pageSize = options.perPage;
       var promise = collection[options.direction]({fetch: false});
     },

--- a/app/addons/documents/templates/all_docs_number.html
+++ b/app/addons/documents/templates/all_docs_number.html
@@ -23,7 +23,7 @@ the License.
   <% } %>
 </div>
 <div id="per-page">
-  <label id="per-page" class="drop-down inline">
+  <label for="select-per-page" class="drop-down inline">
     Per page:
     <select id="select-per-page" name="per-page" class="input-small">
       <option value="5">5</option>

--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -230,7 +230,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
       this.pagination = options.pagination;
       _.bindAll(this);
 
-      this._perPage = options.perPageDefault || 20;
+      this._perPage = options.perPageDefault || FauxtonAPI.constants.MISC.DEFAULT_PAGE_SIZE;
       this.listenTo(this.collection, 'totalRows:decrement', this.render);
     },
 

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -487,14 +487,12 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
 
     setCollection: function (collection) {
       this.collection = collection;
-      this.setDefaults();
       this.render();
     },
 
     getPerPage: function () {
       return this.perPage;
     }
-
   });
 
   // A super-simple replacement for window.confirm()


### PR DESCRIPTION
This fixes an issue with the navigation on the documents page
("Showing 1 to 30") not updating when going from page to page, 
or selecting a different # per page to show.
