### PR TITLE
Fix string modal and add database filter

### DIFF
--- a/app/addons/documents/views-doceditor.js
+++ b/app/addons/documents/views-doceditor.js
@@ -239,7 +239,7 @@ function (app, FauxtonAPI, Components, Documents, Databases, resizeColumns, pret
       /* one JS(ON) string can't span more than one line - we edit one string, so ensure we don't select several lines */
       if (selStart >=0 && selEnd >= 0 && selStart === selEnd && this.editor.isRowExpanded(selStart)) {
         var editLine = this.editor.getLine(selStart),
-            editMatch = editLine.match(/^([ \t]*)('[a-zA-Z0-9_]*': )?('.*',?[ \t]*)$/);
+            editMatch = editLine.match(/^([ \t]*)(["|'][a-zA-Z0-9_]*["|']: )?(["|'].*["|'],?[ \t]*)$/);
 
         if (editMatch) {
           return editMatch;

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -572,10 +572,14 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
   Components.DbSearchTypeahead = Components.Typeahead.extend({
     initialize: function (options) {
       this.dbLimit = options.dbLimit || 30;
+      if (options.filter) { 
+        this.resultFilter = options.resultFilter;
+      }
       _.bindAll(this);
     },
     source: function(query, process) {
       query = encodeURIComponent(query);
+      var resultFilter = this.resultFilter;
       var url = [
         app.host,
         "/_all_dbs?startkey=%22",
@@ -594,6 +598,9 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
         url: url,
         dataType: 'json',
         success: function(data) {
+          if (resultFilter) {
+            data = resultFilter(data);
+          }
           process(data);
         }
       });


### PR DESCRIPTION
This fixes the regex check for the string modal in the code editor. The
string modal button now works again.

It also adds a filter function to the typeahead database view so that we
can filter the databases that are returned.
