### PR TITLE
Add confirmation modal component

### DIFF
--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -505,7 +505,45 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
 
   });
 
+  // A super-simple replacement for window.confirm()
+  Components.ConfirmationModal = FauxtonAPI.View.extend({
+    template: 'addons/fauxton/templates/confirmation_modal',
 
+    events: {
+      'click .js-btn-success': 'onSelectOkay'
+    },
+
+    initialize: function (options) {
+      this.options = _.extend({
+        title: 'Please confirm',
+        text: '',
+        action: null
+      }, options);
+    },
+
+    onSelectOkay: function () {
+      this.hideModal();
+      if (_.isFunction(this.options.action)) {
+        this.options.action();
+      }
+    },
+
+    showModal: function () {
+      this.$('.modal').modal();
+      $('.modal-backdrop').css('z-index', FauxtonAPI.constants.MISC.MODAL_BACKDROP_Z_INDEX);
+    },
+
+    hideModal: function () {
+      this.$('.modal').modal('hide');
+    },
+
+    serialize: function () {
+      return {
+        title: this.options.title,
+        text: this.options.text
+      };
+    }
+  });
 
   Components.ModalView = FauxtonAPI.View.extend({
 
@@ -520,7 +558,7 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       this.clear_error_msg();
       this.$('.modal').modal();
       // hack to get modal visible
-      $('.modal-backdrop').css('z-index',1025);
+      $('.modal-backdrop').css('z-index', FauxtonAPI.constants.MISC.MODAL_BACKDROP_Z_INDEX);
     },
 
     hideModal: function () {

--- a/app/addons/fauxton/templates/confirmation_modal.html
+++ b/app/addons/fauxton/templates/confirmation_modal.html
@@ -1,0 +1,29 @@
+<% /*
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+*/ %>
+
+<div class="modal hide fade">
+  <div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+    <h3><%- title %></h3>
+  </div>
+  <div class="modal-body">
+    <p>
+      <%- text %>
+    </p>
+  </div>
+  <div class="modal-footer">
+    <button data-dismiss="modal" class="btn"><i class="icon fonticon-cancel-circled"></i> Cancel</button>
+    <button class="btn btn-success js-btn-success"><i class="fonticon-ok-circled"></i> Okay</button>
+  </div>
+</div>

--- a/app/constants.js
+++ b/app/constants.js
@@ -16,7 +16,8 @@ define([], function () {
 
     MISC: {
       TRAY_TOGGLE_SPEED: 250,
-      DEFAULT_PAGE_SIZE: 20
+      DEFAULT_PAGE_SIZE: 20,
+      MODAL_BACKDROP_Z_INDEX: 1025
     },
 
     // events


### PR DESCRIPTION
This ticket adds a simple confirmation modal that can be used in
place of window.confirm().

Closes COUCHDB-2445
