### PR TITLE
Add prefab way to get "<" in breadcrumbs

### DIFF
--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -32,14 +32,14 @@ function(app, FauxtonAPI, Documents, Changes, Index, DocEditor, Databases, Resou
   var crumbs = {
     allDocs: function (database) {
       return [
-        { "name": "", "className": "fonticon-left-open", "link": "/_all_dbs" },
+        { "type": "back", "link": "/_all_dbs" },
         { "name": database.id, "link": Databases.databaseUrl(database), className: "lookahead-tray-link" }
       ];
     },
 
     changes: function (database) {
       return [
-        { "name": "", "className": "fonticon-left-open", "link": "/_all_dbs" },
+        { "type": "back", "link": "/_all_dbs" },
         { "name": database.id, "link": Databases.databaseUrl(database), className: "lookahead-tray-link" }
       ];
     }

--- a/app/addons/fauxton/templates/breadcrumbs.html
+++ b/app/addons/fauxton/templates/breadcrumbs.html
@@ -13,13 +13,20 @@ the License.
 */%>
 
 <% _.each(_.initial(crumbs), function(crumb, index) { %>
-<li class="pull-left">
-  <a href="#<%- crumb.link %>" class="fonticon <%- crumb.className %>"><%- crumb.name %></a>
-</li>
 
-<% if (nextCrumbHasLabel(crumb, index)) { %>
-<li class="divider fonticon-right-open"></li>
-<% } %>
+  <% if (crumb.type === 'back') { %>
+    <li class="pull-left breadcrumb-back-link">
+      <a href="#<%- crumb.link %>" class="fonticon fonticon-left-open"></a>
+    </li>
+  <% } else { %>
+    <li class="pull-left">
+      <a href="#<%- crumb.link %>" class="fonticon <%- crumb.className %>"><%- crumb.name %></a>
+    </li>
+
+    <% if (nextCrumbHasLabel(crumb, index)) { %>
+    <li class="divider fonticon-right-open"></li>
+    <% } %>
+  <% }  %>
 
 <% }); %>
 

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -424,13 +424,12 @@ div.spinner {
     > div{
       display:inline-block;
     }
-    .breadcrumb {
-      li:first-child {
-        border-right: 1px solid #ccc;
-        font-size: 16px;
-      }
-    }
   }
+
+  .breadcrumb-back-link {
+    border-right: 1px solid #ccc;
+  }
+
   .breadcrumb {
     margin-bottom: 0;
     background-color: transparent;


### PR DESCRIPTION
This ticket just provides a semantic way to add the "<" to the
breadcrumbs section, containing a class that can uniquely styled.

Closes COUCHDB-2512
