### PR TITLE
Add auto focus to Delete DB modal

### DIFF
--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -149,7 +149,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
 
       var enteredName = $('#db_name').val();
       if (this.database.id != enteredName) {
-        this.set_error_msg(enteredName + " does not match database id - are you sure you want to delete " + this.database.id + "?");
+        this.set_error_msg(enteredName + " does not match the database name.");
         return;
       }
 

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -553,6 +553,13 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       _.bindAll(this);
     },
 
+    afterRender: function () {
+      var that = this;
+      this.$('.modal').on('shown', function () {
+        that.$('input:text:visible:first').focus();
+      });
+    },
+
     showModal: function () {
       if (this._showModal){ this._showModal();}
       this.clear_error_msg();


### PR DESCRIPTION
This ticket:
- Updates ModalView to default to focus on the first visible text field
  by default.
- Updates the error message when the user fails to type in the database
  name correctly.

Closes COUCHDB-2508
