### PR TITLE
clearValue method added to lookahead tray

### DIFF
--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -1058,6 +1058,10 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       this.dbSearchTypeahead.render();
     },
 
+    clearValue: function () {
+      this.$('.search-autocomplete').val('');
+    },
+
     cleanup: function () {
       $("body").off("click.lookaheadTray");
     },


### PR DESCRIPTION
Simple addition to allow calling code to reset the value displayed in the lookahead tray. This is helpful when selecting an item in the lookahead tray doesn't spawn a page refresh: when that occurs, the next time the tray opens it contains the last selected item - which may not be what you want, since the user will have to delete the old content to search again.
