### PR TITLE
Keep track of sidebar status

### DIFF
--- a/app/addons/fauxton/base.js
+++ b/app/addons/fauxton/base.js
@@ -130,8 +130,10 @@ function(app, FauxtonAPI, Components, ZeroClipboard) {
 
     toggleMenu: function(){
        var $selectorList = $('body');
+      var minimized = !$selectorList.hasClass('closeMenu');
+      this.setState(minimized);
        $selectorList.toggleClass('closeMenu');
-      FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENTS.BURGER_CLICKED);
+       FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENT_BURGER_CLICK, { minimized: minimized });
     },
 
     // TODO: can we generate this list from the router?
@@ -148,6 +150,11 @@ function(app, FauxtonAPI, Components, ZeroClipboard) {
       FauxtonAPI.extensions.on('add:navbar:addHeaderLink', this.addLink);
       FauxtonAPI.extensions.on('removeItem:navbar:addHeaderLink', this.removeLink);
       this.versionFooter = new Fauxton.Footer({});
+
+      // if needed, minimize the sidebar
+      if (this.isMinimized()) {
+        $('body').addClass('closeMenu');
+      }
     },
 
     serialize: function() {
@@ -223,6 +230,15 @@ function(app, FauxtonAPI, Components, ZeroClipboard) {
           that.insertView(selector, link.view).render();
         });
       }, this);
+    },
+
+    setState: function (minimized) {
+      app.utils.localStorageSet(FauxtonAPI.constants.LOCAL_STORAGE.SIDEBAR_MINIMIZED, minimized);
+    },
+
+    isMinimized: function () {
+      var isMinimized = app.utils.localStorageGet(FauxtonAPI.constants.LOCAL_STORAGE.SIDEBAR_MINIMIZED);
+      return (_.isUndefined(isMinimized)) ? false : isMinimized;
     }
 
     // TODO: ADD ACTIVE CLASS

--- a/app/constants.js
+++ b/app/constants.js
@@ -45,6 +45,10 @@ define([], function () {
       CONFIG: '/_utils/docs/config/index.html',
       VIEWS: '/_utils/docs/intro/overview.html#views',
       CHANGES: '/_utils/docs/api/database/changes.html?highlight=changes#post--db-_changes'
+    },
+
+    LOCAL_STORAGE: {
+      SIDEBAR_MINIMIZED: 'sidebar-minimized'
     }
   };
 


### PR DESCRIPTION
This is a simple usability change: it keeps track of whether the 
user has expanded or shrunk the sidebar so on future refreshes
it doesn't revert to the wrong state.

To test, just shrink the sidebar and refresh the page. Confirm the 
sidebar remains shrunk. Similarly with expanding the sidebar.