### PR TITLE
Invalid constant name bug fix

### DIFF
--- a/app/addons/fauxton/base.js
+++ b/app/addons/fauxton/base.js
@@ -131,7 +131,7 @@ function(app, FauxtonAPI, Components, ZeroClipboard) {
     toggleMenu: function(){
        var $selectorList = $('body');
        $selectorList.toggleClass('closeMenu');
-       FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENT_BURGER_CLICK);
+      FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENTS.BURGER_CLICKED);
     },
 
     // TODO: can we generate this list from the router?

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -820,7 +820,7 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       }, 500);
     
       $(window).resize(resizeEditor);
-      this.listenTo(FauxtonAPI.Events, FauxtonAPI.constants.EVENT_BURGER_CLICK, resizeEditor);
+      this.listenTo(FauxtonAPI.Events, FauxtonAPI.constants.EVENTS.BURGER_CLICKED, resizeEditor);
 
     },
 


### PR DESCRIPTION
This just fixes an invalid constant name. It worked previously because the API published an event of name `undefined` which could be subscribed to.