### PR TITLE
scrollable sidebar

### DIFF
--- a/app/templates/layouts/with_tabs_sidebar.html
+++ b/app/templates/layouts/with_tabs_sidebar.html
@@ -29,7 +29,7 @@ the License.
           </div>
         </div>
 
-        <aside id="sidebar-content" class="sidebar"></aside>
+        <aside id="sidebar-content" class="sidebar scrollable"></aside>
 
         <section id="dashboard-content" class="list">
           <div class="scrollable">


### PR DESCRIPTION
Thanks to @robertkowalski this makes the sidebar scrollable. This fixes the issue when there are many design docs in the sidebar and a user cannot access them all.