### PR TITLE
Fix selenium tests for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,16 @@ git:
 services:
   - couchdb
 addons:
-  sauce_connect: true
+  firefox: "34.0"
 before_install:
+  - export DISPLAY=:99.0
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1400x900x16"
   - HOST="http://127.0.0.1:5984"
   - curl -X PUT $HOST/_config/admins/tester -d '"testerpass"'
 before_script:
   - npm install -g grunt-cli
   - grunt test
   - grunt dev &
+  - sleep 5
 script:
-  - grunt nightwatch_saucelabs
-branches:
-  only:
-    - master
-env:
-  global:
-  - secure: GZfXnEV5hwH5FKcnbFK57WZLy2C8i650rCFFU4JaHNMNqsqGN/FH4CNyPO//BveZRQWJFRAaH7WclK/4L45NeX4/iufwGf8ypcGR2GvzQtGe1VdoQCNiiDv42BVvX7riT9aCcCdJNqjoKRIL9NkFo+gln1hEymZrQGUC7dojeFY=
-  - secure: THafpI+3svqxOa9gf5wFxuF/QIngKPlNpKPo7rKTnI76pfTuG7MGeBw1S1Da3hkMx3XIYciHcoqnb7LEwI7+s6UWA7eLA1FBcsRqJbSDI5VqSfOcYVJ05oFQ21/Iofk8r8R/LtJGQWwwZxem6P74cwu2iR2VcuWdImSHGiESOKg=
-
+  - grunt nightwatch

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: node_js
 node_js:
-- '0.10'
+  - '0.10'
 git:
   depth: 10
 services:
-- couchdb
+  - couchdb
 addons:
   sauce_connect: true
 before_install:
-- HOST="http://127.0.0.1:5984"
-- curl -X PUT $HOST/_config/admins/tester -d '"testerpass"'
+  - HOST="http://127.0.0.1:5984"
+  - curl -X PUT $HOST/_config/admins/tester -d '"testerpass"'
 before_script:
-- npm install -g grunt-cli
-- grunt test
-- grunt dev &
+  - npm install -g grunt-cli
+  - grunt test
+  - grunt dev &
 script:
   - grunt nightwatch_saucelabs
 branches:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -412,10 +412,6 @@ module.exports = function(grunt) {
         ' -e saucelabs -c ' + __dirname + '/test/nightwatch_tests/nightwatch.json'
       }
     },
-    
-    selenium_start: {
-      options: { port: 4444 }
-    },
 
     // generates the nightwatch.json file with appropriate content for this env
     initNightwatch: {
@@ -491,7 +487,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
   grunt.loadNpmTasks('grunt-mocha-phantomjs');
-  grunt.loadNpmTasks('grunt-selenium-webdriver');
   grunt.loadNpmTasks('grunt-md5');
 
   /*
@@ -545,10 +540,10 @@ module.exports = function(grunt) {
   // setup and install fauxton as couchapp
   grunt.registerTask('couchapp_deploy', ['couchapp_setup', 'couchapp_install']);
 
-  /* 
+  /*
    * Nightwatch functional testing
    */
   //Start Nightwatch test from terminal, using: $ grunt nightwatch
   grunt.registerTask('nightwatch_saucelabs', [ 'initNightwatch', 'exec:start_nightWatch_saucelabs']);
-  grunt.registerTask('nightwatch', [ 'exec:check_selenium', 'selenium_start', 'exec:check_chrome_driver', 'initNightwatch', 'exec:start_nightWatch']);
+  grunt.registerTask('nightwatch', [ 'exec:check_selenium', 'exec:check_chrome_driver', 'initNightwatch', 'exec:start_nightWatch']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -402,7 +402,6 @@ module.exports = function(grunt) {
 
     exec: {
       check_selenium: helper.check_selenium,
-      check_chrome_driver : helper.check_chrome_driver,
       start_nightWatch: {
         command: __dirname + '/node_modules/nightwatch/bin/nightwatch' +
         ' -c ' + __dirname + '/test/nightwatch_tests/nightwatch.json'
@@ -541,5 +540,5 @@ module.exports = function(grunt) {
    * Nightwatch functional testing
    */
   //Start Nightwatch test from terminal, using: $ grunt nightwatch
-  grunt.registerTask('nightwatch', [ 'exec:check_selenium', 'exec:check_chrome_driver', 'initNightwatch', 'exec:start_nightWatch']);
+  grunt.registerTask('nightwatch', [ 'exec:check_selenium', 'initNightwatch', 'exec:start_nightWatch']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -405,11 +405,8 @@ module.exports = function(grunt) {
       check_chrome_driver : helper.check_chrome_driver,
       start_nightWatch: {
         command: __dirname + '/node_modules/nightwatch/bin/nightwatch' +
-        ' -e chrome -c ' + __dirname + '/test/nightwatch_tests/nightwatch.json'
-      },
-      start_nightWatch_saucelabs: {
-        command: 'sleep 10s; '+ __dirname + '/node_modules/nightwatch/bin/nightwatch' +
-        ' -e saucelabs -c ' + __dirname + '/test/nightwatch_tests/nightwatch.json'
+        ' -c ' + __dirname + '/test/nightwatch_tests/nightwatch.json'
+      }
       }
     },
 
@@ -544,6 +541,5 @@ module.exports = function(grunt) {
    * Nightwatch functional testing
    */
   //Start Nightwatch test from terminal, using: $ grunt nightwatch
-  grunt.registerTask('nightwatch_saucelabs', [ 'initNightwatch', 'exec:start_nightWatch_saucelabs']);
   grunt.registerTask('nightwatch', [ 'exec:check_selenium', 'exec:check_chrome_driver', 'initNightwatch', 'exec:start_nightWatch']);
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "nightwatch": "~0.5.33",
     "nano": "~5.12.0",
     "grunt-chmod": "^1.0.3",
-    "grunt-selenium-webdriver": "^0.2.431",
     "grunt-md5": "^0.1.11"
   }
 }

--- a/tasks/helper.js
+++ b/tasks/helper.js
@@ -74,7 +74,7 @@ exports.init = function(grunt) {
             type = 'linux64';
         }
 
-        return 'test -s ./test/nightwatch_tests/selenium/chromedriver || (curl -o ./test/nightwatch_tests/selenium/chromedriver_'+type+'.zip http://chromedriver.storage.googleapis.com/2.9/chromedriver_'+type+'.zip && open ./test/nightwatch_tests/selenium/chromedriver_'+type+'.zip)';
+        return 'test -s ./test/nightwatch_tests/selenium/chromedriver || (curl -o ./test/nightwatch_tests/selenium/chromedriver_' + type + '.zip http://chromedriver.storage.googleapis.com/2.9/chromedriver_' + type + '.zip && unzip -o ./test/nightwatch_tests/selenium/chromedriver_' + type + '.zip -d ./test/nightwatch_tests/selenium/)';
       }
     }
   };

--- a/tasks/helper.js
+++ b/tasks/helper.js
@@ -44,38 +44,9 @@ exports.init = function(grunt) {
     },
 
     check_selenium: {
-      command: 'test -s ./test/nightwatch_tests/selenium/selenium-server-standalone-2.43.1.jar || curl -o ./test/nightwatch_tests/selenium/selenium-server-standalone-2.43.1.jar  http://selenium-release.storage.googleapis.com/2.43/selenium-server-standalone-2.43.1.jar'
-    },
-
-    check_chrome_driver: {
-      command: function () {
-
-        var type;
-
-        switch (platform) {
-          case 'darwin':
-            type = 'mac32';
-            break;
-
-          case 'win32':
-            type = 'win32';
-            break;
-
-          case 'linux': 
-            var os = require('os');
-            if (os.arch() === 'x64') {
-              type = 'linux64';
-            }else{
-              type = 'linux32';
-            }
-            break;
-
-          default:
-            type = 'linux64';
-        }
-
-        return 'test -s ./test/nightwatch_tests/selenium/chromedriver || (curl -o ./test/nightwatch_tests/selenium/chromedriver_' + type + '.zip http://chromedriver.storage.googleapis.com/2.9/chromedriver_' + type + '.zip && unzip -o ./test/nightwatch_tests/selenium/chromedriver_' + type + '.zip -d ./test/nightwatch_tests/selenium/)';
-      }
+      command: 'test -s ./test/nightwatch_tests/selenium/selenium-server-standalone-2.43.1.jar || ' +
+        'curl -o ./test/nightwatch_tests/selenium/selenium-server-standalone-2.43.1.jar ' +
+        'http://selenium-release.storage.googleapis.com/2.43/selenium-server-standalone-2.43.1.jar'
     }
   };
 };

--- a/test/nightwatch_tests/nightwatch.json.underscore
+++ b/test/nightwatch_tests/nightwatch.json.underscore
@@ -8,13 +8,13 @@
   "live_output" : false,
 
   "selenium" : {
-    "start_process" : false,
-    "server_path" : "",
+    "start_process" : true,
+    "server_path" : "test/nightwatch_tests/selenium/selenium-server-standalone-2.43.1.jar",
     "log_path" : "",
     "host" : "127.0.0.1",
     "port" : 4444,
     "cli_args" : {
-      "webdriver.chrome.driver" : "",
+      "webdriver.chrome.driver" : "test/nightwatch_tests/selenium/chromedriver",
       "webdriver.ie.driver" : "",
       "webdriver.firefox.profile" : ""
     }


### PR DESCRIPTION
After some fiddling with Jenkins I had the solution for running travis ci.

This PR enables Selenium testing on the travis VM itself, without depending on secrets or ecternal services like saucelabs.

This means that we can test every PR without maintaining a Jenkins with a whitelist for comitters! :)

The browser was switched from chrome to firefox for two reasons: less dependencies we have to maintain, nightwatch/selenium supports it epr default and more importantly travis is supporting Firefox on their VMs out of the box.

Happy testing!