### PR TITLE
Constant var rename

### DIFF
--- a/app/addons/fauxton/base.js
+++ b/app/addons/fauxton/base.js
@@ -133,7 +133,7 @@ function(app, FauxtonAPI, Components, ZeroClipboard) {
       var minimized = !$selectorList.hasClass('closeMenu');
       this.setState(minimized);
        $selectorList.toggleClass('closeMenu');
-       FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENT_BURGER_CLICK, { minimized: minimized });
+       FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENTS.BURGER_CLICKED, { minimized: minimized });
     },
 
     // TODO: can we generate this list from the router?


### PR DESCRIPTION
This was an old problem that was re-introduced by a bad merge
this morning. The constant var name was just incorrect.