### PR TITLE
Include new Ace theme in bundle

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -345,6 +345,7 @@ module.exports = function(grunt) {
           {src: "assets/js/libs/ace/worker-json.js", dest: "dist/release/js/ace/worker-json.js"},
           {src: "assets/js/libs/ace/mode-json.js", dest: "dist/release/js/ace/mode-json.js"},
           {src: "assets/js/libs/ace/theme-crimson_editor.js", dest: "dist/release/js/ace/theme-crimson_editor.js"},
+          {src: "assets/js/libs/ace/theme-idle_fingers.js", dest: "dist/release/js/ace/theme-idle_fingers.js"},
           {src: "assets/js/libs/ace/mode-javascript.js", dest: "dist/release/js/ace/mode-javascript.js"},
           {src: "assets/js/libs/ace/worker-javascript.js", dest: "dist/release/js/ace/worker-javascript.js"},
         ]


### PR DESCRIPTION
The new Ace editor theme needs to be explicitly included in the
generated bundle file.