### PR TITLE
Improvements to doc collapsed state

### DIFF
--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -424,5 +424,18 @@ function(app, FauxtonAPI, Documents, PagingCollection) {
     }, menuLinks);
   };
 
+  Documents.ListExpandedState = {
+    set: function (isExpanded) {
+      app.utils.localStorageSet('docListCollapsedState', isExpanded);
+    },
+
+    // returns a boolean indicating whether the doc list is expanded or not. Defaults to true if the user
+    // hasn't selected anything
+    get: function () {
+      var docListCollapsedState = app.utils.localStorageGet('docListCollapsedState');
+      return !_.isUndefined(docListCollapsedState) ? docListCollapsedState : true;
+    }
+  };
+
   return Documents;
 });

--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -256,20 +256,6 @@ define([
       return this.urlRef.apply(this, arguments);
     },
 
-    simple: function () {
-      var docs = this.map(function (item) {
-        return {
-          _id: item.id,
-          _rev: item.get('_rev'),
-        };
-      });
-
-      return new Documents.AllDocs(docs, {
-        database: this.database,
-        params: this.params
-      });
-    },
-
     totalRows: function() {
       return this.viewMeta.total_rows || "unknown";
     },

--- a/app/addons/documents/templates/all_docs_item.html
+++ b/app/addons/documents/templates/all_docs_item.html
@@ -33,8 +33,10 @@ the License.
       </div>
     <% } %>
   </header>
+  <% if (doc.get('expanded')) { %>
   <div class="doc-data">
     <pre class="prettyprint"><%- doc.prettyJSON() %></pre>
   </div>
+  <% } %>
 </div>
 <div class="clearfix"></div>

--- a/app/addons/documents/templates/all_docs_item.html
+++ b/app/addons/documents/templates/all_docs_item.html
@@ -34,9 +34,9 @@ the License.
     <% } %>
   </header>
   <% if (doc.get('expanded')) { %>
-  <div class="doc-data">
-    <pre class="prettyprint"><%- doc.prettyJSON() %></pre>
-  </div>
+    <div class="doc-data">
+      <pre class="prettyprint"><%- doc.prettyJSON() %></pre>
+    </div>
   <% } %>
 </div>
 <div class="clearfix"></div>

--- a/app/addons/documents/templates/all_docs_list.html
+++ b/app/addons/documents/templates/all_docs_list.html
@@ -18,11 +18,7 @@
       <div class="btn-toolbar span6">
         <button type="button" class="btn btn-small js-all" data-toggle="button">✓ All</button>
         <button class="btn btn-small disabled js-bulk-delete"><i class="icon-trash"></i></button>
-        <% if (expandDocs) { %>
-        <button id="collapse" class="btn btn-small"><i class="icon-minus"></i> Collapse</button>
-        <% } else { %>
-        <button id="collapse" class="btn btn-small"><i class="icon-plus"></i> Expand</button>
-        <% } %>
+        <button id="collapse" class="btn btn-small"></button>
       </div>
     </div>
   <% } %>

--- a/app/addons/documents/tests/nightwatch/expandCollapseRows.js
+++ b/app/addons/documents/tests/nightwatch/expandCollapseRows.js
@@ -19,11 +19,11 @@ module.exports = {
 
     client
       .loginToGUI()
-      .createDocument("doc 1", newDatabaseName)
-      .createDocument("doc 2", newDatabaseName)
-      .createDocument("doc 3", newDatabaseName)
-      .createDocument("doc 4", newDatabaseName)
-      .createDocument("doc 5", newDatabaseName)
+      .createDocument('doc 1', newDatabaseName)
+      .createDocument('doc 2', newDatabaseName)
+      .createDocument('doc 3', newDatabaseName)
+      .createDocument('doc 4', newDatabaseName)
+      .createDocument('doc 5', newDatabaseName)
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
       .waitForElementVisible('#collapse', waitTime, false)
 
@@ -38,11 +38,9 @@ module.exports = {
       .waitForElementNotPresent('.doc-data', waitTime, false)
 
       // lastly, expand a single one and confirm there's only one that's been expanded
-
-      // this is done because we're unable to click() on hidden input, or the :before styled checkbox
-      .execute('$(".js-row-select").first().trigger("click");')
-      .pause(500)
+      .click('.label-checkbox-doclist')
       .click('#collapse')
+      .waitForElementPresent('.doc-data', waitTime, false)
       .source(function (result) {
         var numExpandedDocs = result.value.match(/doc-data/g).length;
         this.verify.ok(numExpandedDocs === 1, 'Checking there is 1 expanded row');

--- a/app/addons/documents/tests/nightwatch/expandCollapseRows.js
+++ b/app/addons/documents/tests/nightwatch/expandCollapseRows.js
@@ -1,0 +1,52 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+
+  'Expand/Collapse works on documents': function (client) {
+    var waitTime = 10000,
+      newDatabaseName = client.globals.testDatabaseName,
+      baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .createDocument("doc 1", newDatabaseName)
+      .createDocument("doc 2", newDatabaseName)
+      .createDocument("doc 3", newDatabaseName)
+      .createDocument("doc 4", newDatabaseName)
+      .createDocument("doc 5", newDatabaseName)
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .waitForElementVisible('#collapse', waitTime, false)
+
+      // confirm all rows are expanded by default (more elegant way to do this?)
+      .source(function (result) {
+        var numExpandedDocs = result.value.match(/doc-data/g).length;
+        this.verify.ok(numExpandedDocs === 5, 'Checking there are 5 expanded rows');
+      })
+
+      // now toggle the items and confirm there are NO expanded items
+      .click('#collapse')
+      .waitForElementNotPresent('.doc-data', waitTime, false)
+
+      // lastly, expand a single one and confirm there's only one that's been expanded
+
+      // this is done because we're unable to click() on hidden input, or the :before styled checkbox
+      .execute('$(".js-row-select").first().trigger("click");')
+      .pause(500)
+      .click('#collapse')
+      .source(function (result) {
+        var numExpandedDocs = result.value.match(/doc-data/g).length;
+        this.verify.ok(numExpandedDocs === 1, 'Checking there is 1 expanded row');
+      })
+      .end();
+  }
+};

--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -464,7 +464,6 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
     serialize: function() {
       return {
         viewList: this.viewList,
-        expandDocs: true, // TODO
         endOfResults: !this.pagination.canShowNextfn()
       };
     },

--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -190,6 +190,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
 
     initialize: function (options) {
       this.checked = options.checked;
+      this.expanded = options.expanded;
     },
 
     events: {
@@ -204,6 +205,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
 
     serialize: function() {
       return {
+        expanded: this.expanded,
         docIdentifier: this.model.isReducedShown() ? this.model.get('key') : this.model.get('_id'),
         doc: this.model,
         checked: this.checked
@@ -301,7 +303,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
     events: {
       'click button.js-all': 'selectAll',
       "click button.js-bulk-delete": "bulkDelete",
-      "click #collapse": "collapse",
+      "click #collapse": "toggleExpandCollapse",
       'change input': 'toggleDocument',
       "click #js-end-results": "openQueryOptionsTray"
     },
@@ -315,7 +317,9 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
         this.ddocID = options.ddocInfo.id;
       }
       this.docParams = options.docParams || {};
-      this.expandDocs = true;
+
+      // specifies whether the default state for the docs are expanded (true) or collapsed (false)
+      this.defaultDocsStateExpanded = Documents.ListExpandedState.get();
       this.perPageDefault = options.perPageDefault;
 
       // some doclists don't have an option to delete
@@ -369,7 +373,8 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
           rev = this.collection.get(docId).get('_rev'),
           data = {_id: docId, _rev: rev, _deleted: true};
 
-      if (!$row.hasClass('js-to-delete')) {
+      var addItem = !$row.hasClass('js-to-delete');
+      if (addItem) {
         this.bulkDeleteDocsCollection.add(data);
         $row.find('.js-row-select').prop('checked', true);
       } else {
@@ -379,15 +384,16 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
 
       $row.toggleClass('js-to-delete');
       this.toggleTrash();
+      this.updateExpandButtonLabel();
     },
 
     toggleTrash: function () {
-      var $bulkdDeleteButton = this.$('.js-bulk-delete');
+      var $bulkDeleteButton = this.$('.js-bulk-delete');
 
       if (this.bulkDeleteDocsCollection && this.bulkDeleteDocsCollection.length > 0) {
-        $bulkdDeleteButton.removeClass('disabled');
+        $bulkDeleteButton.removeClass('disabled');
       } else {
-        $bulkdDeleteButton.addClass('disabled');
+        $bulkDeleteButton.addClass('disabled');
       }
     },
 
@@ -395,7 +401,6 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
       if (this.$('.js-to-delete').length < this.$('.all-docs-item').length) {
         return;
       }
-
       if (!this.bulkDeleteDocsCollection || this.bulkDeleteDocsCollection.length === 0) {
         return;
       }
@@ -453,25 +458,32 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
       }
 
       this.toggleTrash();
+      this.updateExpandButtonLabel();
     },
 
     serialize: function() {
       return {
         viewList: this.viewList,
-        expandDocs: this.expandDocs,
+        expandDocs: true, // TODO
         endOfResults: !this.pagination.canShowNextfn()
       };
     },
 
-    collapse: function (event) {
-      event.preventDefault();
+    toggleExpandCollapse: function (e) {
+      e.preventDefault();
+      var expand = this.$(e.target).find("i").hasClass('icon-plus');
 
-      if (this.expandDocs) {
-        this.expandDocs = false;
+      // only change the actual (local storage + in memory) expand / collapse button state if all or none are
+      // selected. Otherwise just toggle selected rows
+      var rowsToToggle = this.collection.models;
+      if (this.pageHasSelectedSubset()) {
+        rowsToToggle = this.getSelectedRows();
       } else {
-        this.expandDocs = true;
+        this.defaultDocsStateExpanded = !this.defaultDocsStateExpanded;
+        Documents.ListExpandedState.set(this.defaultDocsStateExpanded);
       }
 
+      this.setRowExpandedState(rowsToToggle, expand);
       this.render();
     },
 
@@ -505,19 +517,35 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
     },
 
     beforeRender: function() {
-      var docs;
-
       this.removeNestedViews();
 
       this.pagination.setCollection(this.collection);
       this.allDocsNumber.setCollection(this.collection);
 
-      docs = this.expandDocs ? this.collection : this.collection.simple();
+      // on new page loads, the doc models don't have their state defined
+      var isNewPage = true;
+      var allSelected = false;
+      if (this.collection.length) {
+        var firstItem = this.collection.first();
+        isNewPage = _.isUndefined(firstItem.get('expanded'));
+        if (this.numSelectedOnPage() === this.collection.length) {
+          allSelected = true;
+        }
+      }
 
-      docs.each(function(doc) {
+      this.collection.each(function(doc) {
         var isChecked;
         if (this.bulkDeleteDocsCollection) {
           isChecked = this.bulkDeleteDocsCollection.get(doc.id);
+        }
+
+        // if we're loading a new page we need to set the expanded state on the item
+        if (isNewPage) {
+          if (allSelected) {
+            doc.set('expanded', this.defaultDocsStateExpanded);
+          } else {
+            doc.set('expanded', (isChecked) ? !this.defaultDocsStateExpanded : this.defaultDocsStateExpanded);
+          }
         }
 
         // the location of the ID attribute varies depending on the model. Also, for reduced view searches, the ID isn't
@@ -564,13 +592,77 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
 
       this.toggleTrash();
       this.maybeHighlightAllButton();
+      this.updateExpandButtonLabel();
     },
 
     perPage: function () {
       return this.allDocsNumber.perPage();
+    },
+
+    // a bit dense, but necessary. It decides on what the Expand/Collapse button label should be and takes into
+    // account the default expand/collapse state, what rows are checked and their states
+    updateExpandButtonLabel: function () {
+
+      if (this.defaultDocsStateExpanded) {
+        this.setExpandButtonLabel(false);
+
+        // override the default label and show "Expand" if ALL checked rows have state === collapse (false)
+        if (this.numSelectedOnPage() && this.allCheckedRowsHaveState(false)) {
+          this.setExpandButtonLabel(true);
+        }
+      } else {
+        this.setExpandButtonLabel(true); // default show "Expand"
+
+        // show "Collapse" if ALL checked rows have state === expanded (true)
+        if (this.numSelectedOnPage() && this.allCheckedRowsHaveState(true)) {
+          this.setExpandButtonLabel(false);
+        }
+      }
+    },
+
+    setExpandButtonLabel: function(expanded) {
+      if (expanded) {
+        this.$('#collapse').html('<i class="icon-plus"></i> Expand');
+      } else {
+        this.$('#collapse').html('<i class="icon-minus"></i> Collapse');
+      }
+    },
+
+    setRowExpandedState: function (rows, state) {
+      _.each(rows, function(model) {
+        model.set('expanded', state);
+      });
+    },
+
+    allCheckedRowsHaveState: function (expanded) {
+      return _.every(this.getSelectedRows(), function (item) {
+        return item.get('expanded') === expanded;
+      });
+    },
+
+    // returns true if a subset of the rows on this page (1 to N-1) have been checked. That info is needed in
+    // determining the behaviour of the expand/collapse button
+    pageHasSelectedSubset: function () {
+      var numSelectedInPage = this.numSelectedOnPage();
+      return (numSelectedInPage !== 0 && numSelectedInPage !== this.collection.models.length);
+    },
+
+    // returns the models of selected items in the current page
+    getSelectedRows: function () {
+      if (!this.bulkDeleteDocsCollection) {
+        return [];
+      }
+      var allSelectedIDs = this.bulkDeleteDocsCollection.pluck('_id');
+      return _.filter(this.collection.models, function(item) {
+        return _.contains(allSelectedIDs, item.id);
+      }, this);
+    },
+
+    numSelectedOnPage: function () {
+      var selectedRows = this.getSelectedRows();
+      return selectedRows.length;
     }
   });
-
 
 
   Views.JumpToDoc = FauxtonAPI.View.extend({

--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -532,7 +532,7 @@ function(app, FauxtonAPI, Components, Documents, Databases, Views, QueryOptions)
         }
       }
 
-      this.collection.each(function(doc) {
+      this.collection.each(function (doc) {
         var isChecked;
         if (this.bulkDeleteDocsCollection) {
           isChecked = this.bulkDeleteDocsCollection.get(doc.id);


### PR DESCRIPTION
- This applies to all lists (All Docs / Views)
- Collapsing the list of documents now just shows a single row
for each doc
- The collapsed/expanded state is now stored in memory so doesn't
get lost on subsequent page loads

Closes COUCHDB-2548