### PR TITLE
Fix COUCHDB-2543 by avoiding overlapping callbacks for two editors

### DIFF
--- a/app/addons/documents/views-doceditor.js
+++ b/app/addons/documents/views-doceditor.js
@@ -574,6 +574,17 @@ function (app, FauxtonAPI, Components, Documents, Databases, prettify) {
     },
 
     afterRender: function () {
+      var that = this;
+      this.$('.modal').on('hide', function (e) {
+        if(that.subEditor.edited){
+          if(!confirm("Close without saving changes?")){
+            e.preventDefault();
+            return;
+          }
+        }
+        /* make sure we don't have save warnings w/out change */
+        that.subEditor.editSaved();
+      });
       /* make sure we init only ONCE */
       if (!this.subEditor) {
         this.subEditor = new Components.Editor({

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -803,13 +803,13 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
         that.edited = true;
       });
 
-      $(window).on('beforeunload.editor', function() {
+      $(window).on('beforeunload.editor_'+this.editorId, function() {
         if (that.edited) {
           return 'Your changes have not been saved. Click cancel to return to the document.';
         }
       });
 
-      FauxtonAPI.beforeUnload("editor", function (deferred) {
+      FauxtonAPI.beforeUnload("editor_"+this.editorId, function (deferred) {
         if (that.edited) {
           return 'Your changes have not been saved. Click cancel to return to the document.';
         }
@@ -824,8 +824,8 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
     },
 
     cleanup: function () {
-      $(window).off('beforeunload.editor');
-      FauxtonAPI.removeBeforeUnload("editor");
+      $(window).off('beforeunload.editor_'+this.editorId);
+      FauxtonAPI.removeBeforeUnload("editor_"+this.editorId);
       this.editor.destroy();
     },
 


### PR DESCRIPTION
Effectively, I suffix the editor ID when registering for the callbacks. And when doing that (need to clean the "edited" state when hiding the modal) I can also handle the unnerving bug that one can close the string editor without warning and loose all changes.