### PR TITLE
Style fix for clicking on doc line nums

### DIFF
--- a/assets/js/libs/ace/theme-idle_fingers.js
+++ b/assets/js/libs/ace/theme-idle_fingers.js
@@ -18,7 +18,9 @@ color: #FFFFFF\
 color: #ffffff\
 }\
 .ace-idle-fingers .ace_marker-layer .ace_selection {\
-background: rgba(90, 100, 126, 0.88)\
+background: #000000;\
+opacity: 0.4;\
+left: 0px !important;\
 }\
 .ace-idle-fingers.ace_multiselect .ace_selection.ace_start {\
 box-shadow: 0 0 3px 0px #4d4d4d;\


### PR DESCRIPTION
@seanbarclay noticed that clicking on the gutter (line numbers)
on the full page document editor made the row be highlighted in a
blue. This changes it to be dark grey.