### PR TITLE
Full page doc editor fixes

### DIFF
--- a/app/addons/documents/templates/code_editor.html
+++ b/app/addons/documents/templates/code_editor.html
@@ -65,7 +65,7 @@ the License.
   </div>
 </div>
 
-<div class="scrollable">
+<div class="code-region">
   <div class="bgEditorGutter"></div>
   <div id="editor-container" class="doc-code"><%- JSON.stringify(doc.attributes, null, "  ") %></div>
 </div>

--- a/app/addons/documents/views-doceditor.js
+++ b/app/addons/documents/views-doceditor.js
@@ -207,7 +207,7 @@ function (app, FauxtonAPI, Components, Documents, Databases, prettify) {
       'click button.upload': 'upload',
       'click button.string-edit': 'stringEditing',
       'click a.js-back': 'onClickGoBack',
-      'click .scrollable': 'focusOnLastLine'
+      'click .code-region': 'focusOnLastLine'
     },
 
     disableLoader: true,

--- a/app/addons/fauxton/actions.js
+++ b/app/addons/fauxton/actions.js
@@ -22,6 +22,9 @@ function (app, FauxtonAPI, ActionTypes) {
       FauxtonAPI.dispatch({
         type: ActionTypes.TOGGLE_NAVBAR_MENU 
       });
+
+      // TODO temporary patch for COUCHDB-2555
+      FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENTS.BURGER_CLICKED);
     },
 
     addHeaderLink: function (link) {

--- a/assets/less/codeeditor.less
+++ b/assets/less/codeeditor.less
@@ -102,9 +102,6 @@
   .ace_gutter-cell {
     min-width: 49px;
   }
-  .ace_scrollbar-h {
-    overflow: hidden !important;
-  }
 
   .ace_marker-layer .ace_bracket {
     margin: 0px;
@@ -125,7 +122,24 @@
     }
   }
 
-  #dashboard-content .scrollable {
+  #dashboard-content .code-region {
+    overflow-y: hidden;
+    position: absolute;
     top: 125px;
+    height: auto;
+    width: 100%;
+    padding: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
   }
+}
+
+.ace_scrollbar-h {
+  right: 0px !important;
+  height: 15px !important;
+}
+
+#editor-container {
+  height: 100% !important;
 }


### PR DESCRIPTION
It was noticed that with larger documents we needed the horizontal
scrollbar to appear, since some users don't have right-left
scrolling mice/trackpads and relying exclusively on the keyboard
wasn't sufficient. This adds the horizontal scrollbar only when
needed, and at the very bottom of the screen, regardless of the
height of the editor, to make it look ok.