### PR TITLE
Add borders for docs

### DIFF
--- a/app/addons/documents/assets/less/documents.less
+++ b/app/addons/documents/assets/less/documents.less
@@ -190,6 +190,11 @@ button.string-edit[disabled] {
       vertical-align: top;
       position: relative;
       .box-shadow(3px 4px 0 rgba(0, 0, 0, 0.3));
+      .doc-data {
+        border-bottom: 1px solid @docHeaderBorderBottom;
+        border-left: 1px solid @docHeaderOtherBorders;
+        border-right: 1px solid @docHeaderOtherBorders;
+      }
       header {
         font-weight: bold;
         position: relative;


### PR DESCRIPTION
Add missing borders to docs in alldocs-list

Based on feedback from Sean Barclay <fudd1011@hotmail.com>
(@seanbarclay)

**OLD**
![bildschirmfoto 2015-01-23 um 16 22 39](https://cloud.githubusercontent.com/assets/298166/5877017/6b7ac392-a31c-11e4-88ff-446cce617cd9.png)


**NEW**
![bildschirmfoto 2015-01-23 um 16 22 49](https://cloud.githubusercontent.com/assets/298166/5876992/3038c932-a31c-11e4-8757-c6b1bf17a7e4.png)



