### PR TITLE
header-control-bar: fix select-all-state

### DIFF
--- a/app/addons/documents/header/header.stores.js
+++ b/app/addons/documents/header/header.stores.js
@@ -25,8 +25,6 @@ function (FauxtonAPI, ActionTypes) {
 
     reset: function () {
       this._collapsedDocuments = false;
-      this._selectedAllDocuments = false;
-
       this._selectedDocumentsCount = 0;
       this._documentsOnPageCount = FauxtonAPI.constants.MISC.DEFAULT_PAGE_SIZE;
     },
@@ -37,10 +35,6 @@ function (FauxtonAPI, ActionTypes) {
 
     getCollapsedState: function () {
       return this._collapsedDocuments;
-    },
-
-    toggleSelectAll: function () {
-      this._selectedAllDocuments = !this._selectedAllDocuments;
     },
 
     getSelectedAllState: function () {

--- a/app/addons/documents/tests/nightwatch/bulkSelect.js
+++ b/app/addons/documents/tests/nightwatch/bulkSelect.js
@@ -1,0 +1,36 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+  // When I select all documents
+  // And there are less documents than I have set to display per page
+  // Then I want the select-all-button to be selected
+  'Bulk Documents: selector': function (client) {
+    var waitTime = 10000,
+        newDatabaseName = client.globals.testDatabaseName,
+        newDocumentName1 = 'bulktest1',
+        newDocumentName2 = 'bulktest2',
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .createDocument(newDocumentName1, newDatabaseName)
+      .createDocument(newDocumentName2, newDatabaseName)
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .waitForElementPresent('.control-toggle-alternative-header', waitTime, false)
+      .click('.control-toggle-alternative-header')
+      .waitForElementPresent('.control-select-all', waitTime, false)
+      .click('.control-select-all')
+      .assert.attributeEquals('.control-select-all', 'disabled', 'true')
+      .end();
+  }
+};

--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -400,7 +400,7 @@ function (app, FauxtonAPI, Components, Documents,
 
       ReactHeaderActions.updateDocumentCount({
         selectedOnPage: this.$('.js-to-delete').length,
-        documentsOnPageCount: this.perPage()
+        documentsOnPageCount: this.$('.doc-row').length
       });
     },
 
@@ -467,7 +467,7 @@ function (app, FauxtonAPI, Components, Documents,
 
       ReactHeaderActions.updateDocumentCount({
         selectedOnPage: this.$('.js-to-delete').length,
-        documentsOnPageCount: this.perPage()
+        documentsOnPageCount: this.$('.doc-row').length
       });
     },
 
@@ -580,7 +580,7 @@ function (app, FauxtonAPI, Components, Documents,
 
       ReactHeaderActions.updateDocumentCount({
         selectedOnPage: this.$('.js-to-delete').length,
-        documentsOnPageCount: this.perPage()
+        documentsOnPageCount: this.$('.doc-row').length
       });
     },
 


### PR DESCRIPTION
When I select all documents
And there are less documents than I have set to display per page
Then I want the select-all-button to be selected/disabled

As I checked for the setting of the page compared to the selected
documents it can happen that if we have not enough documents to
show on the page that the status of the select-all was wrong.

Added test to avoid regressions in the future and to prove my fix