### PR TITLE
all-dbs, all-docs: more responsiveness

### DIFF
--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -771,3 +771,44 @@ footer.pagination-footer {
   z-index: 6;
 }
 
+// left navigationbar is opened
+@media (max-width: 780px) {
+  .closeMenu {
+    .one-pane {
+      .searchbox-wrapper {
+        display: none;
+      }
+    }
+  }
+}
+
+@media (max-width: 1050px) {
+  .closeMenu {
+    .with-sidebar {
+      .searchbox-wrapper {
+        display: none;
+      }
+    }
+  }
+}
+
+// left navigationbar is closed
+@media (max-width: 925px) {
+  body:not(.closeMenu) {
+    .one-pane {
+      .searchbox-wrapper {
+        display: none;
+      }
+    }
+  }
+}
+
+@media (max-width: 1225px) {
+  body:not(.closeMenu) {
+    .with-sidebar {
+      .searchbox-wrapper {
+        display: none;
+      }
+    }
+  }
+}


### PR DESCRIPTION
don't display search-label if screensize is too small.

before that the searchlabel jumped out of the headerbar