### PR TITLE
ZeroClipboard: Don't rely on code loading order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ services:
 addons:
   firefox: "34.0"
 before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq flashplugin-installer
   - export DISPLAY=:99.0
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1400x900x16"
   - HOST="http://127.0.0.1:5984"

--- a/app/addons/databases/tests/nightwatch/zeroclipboard.js
+++ b/app/addons/databases/tests/nightwatch/zeroclipboard.js
@@ -11,13 +11,17 @@
 // the License.
 
 var os = require('os');
-var controlOrCommandKey = os.type() === 'Darwin' ? client.Keys.COMMAND : client.Keys.CONTROL;
 
 module.exports = {
   'ZeroClipboard copies' : function (client) {
     var waitTime = 10000,
         newDatabaseName = client.globals.testDatabaseName,
         baseUrl = client.globals.test_settings.launch_url;
+
+    var controlOrCommandKey = client.Keys.CONTROL;
+    if (os.type() === 'Darwin') {
+      controlOrCommandKey = client.Keys.COMMAND;
+    }
 
     client
       .loginToGUI()

--- a/app/addons/databases/tests/nightwatch/zeroclipboard.js
+++ b/app/addons/databases/tests/nightwatch/zeroclipboard.js
@@ -1,0 +1,38 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+  'ZeroClipboard copies' : function (client) {
+    var waitTime = 10000,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .deleteDatabase(newDatabaseName) //need to delete the automatic database 'fauxton-selenium-tests' that has been set up before each test
+      .url(baseUrl)
+
+      .waitForElementPresent('.api-url-btn', waitTime, false)
+      .click('.api-url-btn')
+      .waitForElementVisible('.copy-url', waitTime, false)
+      .moveTo('.copy-url')
+      .click('.copy-url')
+      .mouseButtonDown('left')
+      .mouseButtonUp('left')
+      .closeNotification()
+      .setValue('.search-autocomplete', '')
+      .keys([client.Keys.COMMAND, 'v'])
+      .assert.value('.search-autocomplete', 'http://localhost:8000/_all_dbs')
+
+    .end();
+  }
+};

--- a/app/addons/databases/tests/nightwatch/zeroclipboard.js
+++ b/app/addons/databases/tests/nightwatch/zeroclipboard.js
@@ -10,6 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+var os = require('os');
+var controlOrCommandKey = os.type() === 'Darwin' ? client.Keys.COMMAND : client.Keys.CONTROL;
+
 module.exports = {
   'ZeroClipboard copies' : function (client) {
     var waitTime = 10000,
@@ -30,7 +33,7 @@ module.exports = {
       .mouseButtonUp('left')
       .closeNotification()
       .setValue('.search-autocomplete', '')
-      .keys([client.Keys.COMMAND, 'v'])
+      .keys([controlOrCommandKey, 'v'])
       .assert.value('.search-autocomplete', 'http://localhost:8000/_all_dbs')
 
     .end();

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -1025,13 +1025,8 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
   Components.Clipboard = FauxtonAPI.View.extend({
     initialize: function (options) {
       this.$el = options.$el;
-      this.moviePath = FauxtonAPI.getExtensions('zeroclipboard:movielist')[0];
 
-      if (_.isUndefined(this.moviePath)) {
-       this.moviePath = 'js/zeroclipboard/ZeroClipboard.swf';
-      }
-
-      ZeroClipboard.config({ moviePath: this.moviePath });
+      ZeroClipboard.config({ moviePath: app.zeroClipboardPath });
       this.client = new ZeroClipboard(this.$el);
     },
 

--- a/app/initialize.js.underscore
+++ b/app/initialize.js.underscore
@@ -25,7 +25,8 @@ function() {
     root: "<%= root %>",
     version: "<%= version %>",
     // Host is used as prefix for urls
-    host: "<%= host %>" ,
+    host: "<%= host %>",
+    zeroClipboardPath: "<%= zeroClipboardPath %>"
   };
 
   return app; 

--- a/settings.json.default
+++ b/settings.json.default
@@ -25,7 +25,8 @@
         "app": {
           "root": "/",
           "host": "../..",
-          "version": "1.0.dev"
+          "version": "1.0.dev",
+          "zeroClipboardPath": "js/zeroclipboard/ZeroClipboard.swf"
         }
       },
       "release": {
@@ -39,7 +40,8 @@
         "app": {
           "root": "/_utils/",
           "host": "../..",
-          "version": "1.0"
+          "version": "1.0",
+          "zeroClipboardPath": "js/zeroclipboard/ZeroClipboard.swf"
         }
       },
       "couchapp": {
@@ -53,7 +55,8 @@
         "app": {
           "root": "/",
           "host": "../../..",
-          "version": "1.0"
+          "version": "1.0",
+          "zeroClipboardPath": "js/zeroclipboard/ZeroClipboard.swf"
         }
       }
     },


### PR DESCRIPTION
Bake path to swf-file into release at build time and make it
configurable for different environments.

Relying on the synchronous `registerExtensions` for configuration
is not reliable in an asynchronous bootstrapping application like
Fauxton