### PR TITLE
Ensure save changes conf appears

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -27,9 +27,9 @@ function(app, FauxtonAPI, LoadAddons) {
 
 
   // All navigation that is relative should be passed through the navigate
-  // method, to be processed by the router. If the link has a `data-bypass`
+  // method, to be processed by the router. If the link has a `data-bypass=true`
   // attribute, bypass the delegation completely.
-  $(document).on("click", "a:not([data-bypass])", function(evt) {
+  $(document).on("click", "a:not([data-bypass=true])", function(evt) {
 
     // Get the absolute anchor href.
     var href = { prop: $(this).prop("href"), attr: $(this).attr("href") };


### PR DESCRIPTION
Extra eyes on this ticket are appreciated! It's a very small change
but there's a bit of explanation needed.

Whenever you make a change to content in an Ace editor then
navigate away, you should see a confirmation alert saying "Are you
sure you don't want to save these changes?". Right now this
appears sometimes, but not always. This ticket makes a small
change to the main event delegation function in main.js that runs
on all `<a>` tags. Before, as long as the `<a>` didn't contain a
`data-bypass` attribute, it did a `FauxtonAPI.navigate` call, which
meant that all beforeUnload functions got ran prior to redirecting: 
and that was where the confirmation alert code got ran.

This has now been changed to only NOT run when the `data-bypass`
attribute is set to `true`, which I think is what was originally
intended. This small change will ensure any pages containing the
Ace editor will have their beforeUnload functions ran prior to
redirecting from any link.

Closes COUCHDB-2574