### PR TITLE
Style fix for selecting text in Ace editor

### DIFF
--- a/assets/js/libs/ace/theme-idle_fingers.js
+++ b/assets/js/libs/ace/theme-idle_fingers.js
@@ -18,9 +18,7 @@ color: #FFFFFF\
 color: #ffffff\
 }\
 .ace-idle-fingers .ace_marker-layer .ace_selection {\
-background: #000000;\
-opacity: 0.4;\
-left: 0px !important;\
+background: rgba(90, 100, 126, 0.88)\
 }\
 .ace-idle-fingers.ace_multiselect .ace_selection.ace_start {\
 box-shadow: 0 0 3px 0px #4d4d4d;\

--- a/assets/less/codeeditor.less
+++ b/assets/less/codeeditor.less
@@ -143,3 +143,7 @@
 #editor-container {
   height: 100% !important;
 }
+
+body .ace-idle-fingers .ace_marker-layer .ace_selection {
+  background: #015F6F;
+}


### PR DESCRIPTION
This PR contains two things:
1. reverts an old custom change to the Ace editor theme file
2. updates the select text style, as per: https://issues.apache.org/jira/browse/COUCHDB-2573