### PR TITLE
Fix missing confirmation when leaving editor

### DIFF
--- a/app/addons/documents/tests/nightwatch/navigateAfterEditingDocShouldShowAConfirmationBox.js
+++ b/app/addons/documents/tests/nightwatch/navigateAfterEditingDocShouldShowAConfirmationBox.js
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+
+  'Navigate to New Doc Page, editing and then clicking on the sidebar should show a confirmation dialog': function (client) {
+    var waitTime = 10000,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    var newLink = '#/database/' + newDatabaseName + '/new';
+
+    client
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .waitForElementPresent('#new-all-docs-button', waitTime, false)
+      .click('#new-all-docs-button a')
+      .waitForElementPresent('#new-all-docs-button a[href="'+ newLink + '"]', waitTime, false)
+      .click('#new-all-docs-button a[href="' + newLink + '"]')
+      .waitForElementPresent('.code-region', waitTime, false)
+      .verify.urlEquals(baseUrl+ '/' + newLink)
+
+      .keys(['.ace_variable', 'v'])
+      .click('a[href="#_config"]')
+      .accept_alert()
+      .verify.urlEquals(baseUrl + '/#_config');
+  }
+};

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -812,31 +812,29 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
         this.removeIncorrectAnnotations();
       }
 
-      var that = this;
       this.editor.getSession().on('change', function () {
-        that.setHeightToLineCount();
-        that.edited = true;
-      });
+        this.setHeightToLineCount();
+        this.edited = true;
+      }.bind(this));
 
-      $(window).on('beforeunload.editor_'+this.editorId, function() {
-        if (that.edited) {
+      $(window).on('beforeunload.editor_' + this.editorId, function () {
+        if (this.edited) {
           return 'Your changes have not been saved. Click cancel to return to the document.';
         }
-      });
+      }.bind(this));
 
-      FauxtonAPI.beforeUnload("editor_"+this.editorId, function (deferred) {
-        if (that.edited) {
+      FauxtonAPI.beforeUnload('editor_' + this.editorId, function (deferred) {
+        if (this.edited) {
           return 'Your changes have not been saved. Click cancel to return to the document.';
         }
-      });
+      }.bind(this));
     },
 
     cleanup: function () {
-      $(window).off('beforeunload.editor_'+this.editorId);
+      $(window).off('beforeunload.editor_' + this.editorId);
       $(window).off('resize.editor', this.onPageResize);
-      FauxtonAPI.removeBeforeUnload("editor_"+this.editorId);
+      FauxtonAPI.removeBeforeUnload('editor_' + this.editorId);
       this.editor.destroy();
-      this.stopListening(FauxtonAPI.Events, FauxtonAPI.constants.EVENTS.NAVBAR_SIZE_CHANGED);
     },
 
     // we need to track the possible available height of the editor to tell it how large it can grow vertically

--- a/app/addons/fauxton/components.react.jsx
+++ b/app/addons/fauxton/components.react.jsx
@@ -55,7 +55,7 @@ function(FauxtonAPI, React, Stores, Actions) {
 
       return (
         <li data-nav-name={link.title} className={liClassName} >
-          <a href={link.href} target={link.target ? '_blank' : ''} data-bypass={link.target ? 'true' : 'false'}>
+          <a href={link.href} target={link.target ? '_blank' : null} data-bypass={link.target ? 'true' : null}>
             <i className={link.icon + " fonticon "}></i>
             <span dangerouslySetInnerHTML={{__html: link.title }} /> 
           </a>


### PR DESCRIPTION
To not render a property in React we need to pass `null` to it. If
we are passing `false` or `"false"` it gets rendered into the DOM.

This fixes a bug where you edited a document and then got no
confirmation dialog if you are really sure you want to leave the
page without saving if you clicked on the navigation bar on the
left.

Having `data-bypass="false"` will mean to the selector
`:not(["data-bypass"])` that there is a `data-bypass` - containing
a String! (which then matches the selector)

What we want is _no_ `data-bypass` if we don't want to bypass.

Looking at the old DOM a month ago shows how we used `data-bypass`:

![bildschirmfoto 2015-02-12 um 19 12 19](https://cloud.githubusercontent.com/assets/298166/6174373/9092ac76-b2ee-11e4-8f26-3873cd1b4979.png)

Closes COUCHDB-2574

superseeds #263