### PR TITLE
Fix for polling interval label not updating

### DIFF
--- a/app/addons/activetasks/views.js
+++ b/app/addons/activetasks/views.js
@@ -117,7 +117,8 @@ function (app, FauxtonAPI, ActiveTasks) {
 
     events: {
       'click .task-tabs li': 'requestByType',
-      'input #pollingRange': 'changePollInterval'
+      'input #pollingRange': 'changePollInterval',
+      'change #pollingRange': 'changePollInterval'
     },
 
     serialize: function () {


### PR DESCRIPTION
Due to a bug in IE11, the onInput event doesn't fire on the range
slider on incremental changes. This adds both onInput and onChange
events to ensure it works for all browser environments.

Closes COUCHDB-2579