### PR TITLE
Fix for DB page not updating after new db added

### DIFF
--- a/app/addons/databases/routes.js
+++ b/app/addons/databases/routes.js
@@ -82,7 +82,7 @@ function (app, FauxtonAPI, Databases, Views, Components) {
     },
 
     establish: function() {
-     return [this.databases.fetchOnce()];
+      return [this.databases.fetch({ cache: false })];
     }
   });
 


### PR DESCRIPTION
Note: there's no new test for this because a test already
existed to confirm exactly this, except it would have failed on IE
if it ran on that browser.

Closes COUCHDB-2580