### PR TITLE
Improved tooltip for ! icon on db page

### DIFF
--- a/app/addons/databases/tests/nightwatch/checkDatabaseTooltip.js
+++ b/app/addons/databases/tests/nightwatch/checkDatabaseTooltip.js
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+  'Check the tooltip icon for DB with deleted items appears': function (client) {
+    var waitTime = 10000,
+        newDatabaseName = client.globals.testDatabaseName,
+        newDocumentName = 'TemporaryDoc',
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+
+      // use nano to quickly set up a DB with a single doc
+      .deleteDatabase(newDatabaseName)
+      .createDatabase(newDatabaseName)
+      .createDocument(newDocumentName, newDatabaseName)
+
+      // delete the document manually. This'll ensure the database page has at least one "!" icon
+      .waitForElementPresent('#dashboard-content a[href="#/database/' + newDatabaseName + '/_all_docs"]', waitTime, false)
+      .click('#dashboard-content a[href="#/database/' + newDatabaseName + '/_all_docs"]')
+      .waitForElementVisible('label[for="checkbox-' + newDocumentName + '"]', waitTime, false)
+      .click('label[for="checkbox-' + newDocumentName + '"]')
+      .click('.control-toggle-alternative-header')
+      .waitForElementPresent('.control-select-all', waitTime, false)
+      .click('.control-delete')
+      .acceptAlert()
+      .waitForElementVisible('#global-notifications .alert.alert-info', waitTime, false)
+      .click('#nav-links a[href="#/_all_dbs"]')
+
+      // now let's look at the actual UI to confirm the tooltip appears
+      .waitForElementPresent('.js-db-graveyard', waitTime, false)
+      .moveToElement('.js-db-graveyard', 1, 1)
+
+      // confirm the tooltip element has been inserted
+      .waitForElementPresent('.tooltip.fade.top.in', waitTime, false)
+    .end();
+  }
+};

--- a/app/addons/databases/views.js
+++ b/app/addons/databases/views.js
@@ -53,6 +53,10 @@ function(app, Components, FauxtonAPI, Databases) {
         encoded: app.utils.safeURLName(this.model.get('name')),
         database: this.model
       };
+    },
+
+    afterRender: function () {
+      this.$el.find('.js-db-graveyard').tooltip();
     }
   });
 
@@ -173,7 +177,6 @@ function(app, Components, FauxtonAPI, Databases) {
         onUpdateEventName: 'jumptodb:update'
       });
       this.dbSearchTypeahead.render();
-      this.$el.find('.js-db-graveyard').tooltip();
     }
   });
 


### PR DESCRIPTION
This adds a jQuery tooltip for the (!) icons on the Databases
page and includes a nightwatch test to confirm the mouseover
behaviour.

Closes COUCHDB-2581