### PR TITLE
Fix for encoding unicode char

### DIFF
--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -615,19 +615,24 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
       }
       _.bindAll(this);
     },
-    source: function(query, process) {
+
+    getURL: function (query, dbLimit) {
       query = encodeURIComponent(query);
-      var resultFilter = this.resultFilter;
-      var url = [
+      return [
         app.host,
         "/_all_dbs?startkey=%22",
         query,
         "%22&endkey=%22",
         query,
-        "\u9999",
+        encodeURIComponent("\u9999"),
         "%22&limit=",
-        this.dbLimit
+        dbLimit
       ].join('');
+    },
+
+    source: function(query, process) {
+      var url = this.getURL(query, this.dbLimit);
+      var resultFilter = this.resultFilter;
 
       if (this.ajaxReq) { this.ajaxReq.abort(); }
 

--- a/app/addons/fauxton/tests/componentsSpec.js
+++ b/app/addons/fauxton/tests/componentsSpec.js
@@ -1,0 +1,40 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+define([
+  'testUtils',
+  'api',
+  'addons/fauxton/components'
+], function (testUtils, FauxtonAPI, Components) {
+  var assert = testUtils.assert;
+
+
+  describe('DbSearchTypeahead', function () {
+
+    // simple test to confirm that the query part of the URL and the \u9999 search end char
+    // are URL encoded
+    it('should URI encode parts of URL', function () {
+      var dbLimit = 30;
+      var typeahead = new Components.DbSearchTypeahead({
+        dbLimit: dbLimit
+      });
+      var url = typeahead.getURL('querywith[]chars', dbLimit);
+
+      // confirm the [] chars have been encoded
+      assert.isTrue(/%5B%5D/.test(url));
+
+      // confirm the \u9999 char has been encoded
+      assert.isFalse(/\u9999/.test(url));
+      assert.isTrue(/%E9%A6%99/.test(url));
+    });
+  });
+
+});


### PR DESCRIPTION
Contains a small fix to ensure a unicode char in the db typeahead
component is URL encoded. If the server needed to recognize the
endkey parameter it would cause problems on IE.

This doesn't currently cause any problems on Fauxton, note, so 
there's nothing to test there.

Closes COUCHDB-2587