### PR TITLE
Erase console logs in api.js

### DIFF
--- a/app/core/api.js
+++ b/app/core/api.js
@@ -75,16 +75,16 @@ function(FauxtonAPI, Layout, Router, RouteObject, utils, Store, Flux) {
       }
       return false;
     });
-    
+
     if (!_.isUndefined(url)) { return url; }
 
     if (!urlPaths[name]) {
-      console.log('could not find name ', name);
+      console.error('could not find name ', name);
       return '';
     }
 
     if (!urlPaths[name][context]) {
-      console.log('could not find context ', context);
+      console.error('could not find context ', context);
       return '';
     }
 


### PR DESCRIPTION
These were left in with commit 92834eae02eadc361de3a21ee1079d8f47af6492 (Centralize URLs)