### PR TITLE
Remove raf

### DIFF
--- a/app/addons/documents/tests/views-changesSpec.js
+++ b/app/addons/documents/tests/views-changesSpec.js
@@ -39,8 +39,7 @@ define([
       handlerSpy = sinon.spy(Views.Changes.prototype, 'toggleJson');
 
       view = new Views.Changes({
-        model: model,
-        useRAF: false
+        model: model
       });
       viewSandbox = new ViewSandbox();
       viewSandbox.renderView(view, done);
@@ -55,8 +54,7 @@ define([
     it('does not keep filters in memory', function () {
       view.filters.push('cat');
       view = new Views.Changes({
-        model: model,
-        useRAF: false
+        model: model
       });
 
       view.filters.push('mat');

--- a/app/addons/fauxton/tests/filterViewSpec.js
+++ b/app/addons/fauxton/tests/filterViewSpec.js
@@ -32,8 +32,6 @@ define([
         eventNamespace: 'mynamespace'
       });
 
-      Components.FilterItemView.prototype.useRAF = false;
-
       viewSandbox = new ViewSandbox();
       viewSandbox.renderView(filterView, done);
     });
@@ -74,8 +72,7 @@ define([
     it('should add tooltips when a text for it is defined', function () {
       filterView = new Components.FilterView({
         eventNamespace: 'mynamespace',
-        tooltipText: 'ente ente',
-        useRAF: false
+        tooltipText: 'ente ente'
       });
       viewSandbox.renderView(filterView);
       assert.equal(1, filterView.$('.js-filter-tooltip').length);

--- a/app/core/base.js
+++ b/app/core/base.js
@@ -62,8 +62,6 @@ function(Backbone, LayoutManager) {
     manage: true,
     disableLoader: false,
 
-    useRAF: false,
-
     forceRender: function () {
       this.hasRendered = false;
     }


### PR DESCRIPTION
Garren and me tried to use the latest layoutmanager in summer
2014 - the experiment lead to performance improvements regarding
the rendering of our application, but we had to disable it as we
as it lead to timing issues.

As we are moving to React it does not make sense to me to invest
further time into the issues we had in summer.

This commit removes the leftovers of the experiment that are not
needed any more and cleans up.

See apache#29