### PR TITLE
(Another) fix for flaky nightwatch test

### DIFF
--- a/app/addons/documents/tests/nightwatch/editDocumentsFromView.js
+++ b/app/addons/documents/tests/nightwatch/editDocumentsFromView.js
@@ -36,8 +36,7 @@ module.exports = {
       .clickWhenVisible('#nav-header-abc')
       .clickWhenVisible('#nav-design-function-abcviews')
       .clickWhenVisible('#abc_evens')
-
-      .waitForElementPresent('a[href="#/database/fauxton-selenium-tests/document_10"]', waitTime, false)
+      .waitForElementVisible('a[href="#/database/fauxton-selenium-tests/document_10"]', waitTime, false)
       .click('a[href="#/database/fauxton-selenium-tests/document_10"]')
 
       //navigated to editor


### PR DESCRIPTION
This fixes the editDocumentsFromView.js test that would
occasionally fail if the element was present but not
visible.

This caused https://github.com/apache/couchdb-fauxton/pull/265 to fail. It's unrelated.