### PR TITLE
Fine-tune what nightwatch tests to omit

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "http-proxy": "~1.1.4",
     "jsxcs": "~0.2.1",
     "nano": "~5.12.0",
-    "nightwatch": "~0.5.33",
+    "nightwatch": "^0.6.0",
     "react-tools": "^0.12.0",
     "request": "^2.54.0",
     "send": "~0.1.1",

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,30 @@ And to run the tests (in another terminal tab):
     
     grunt nightwatch
 
+##### Omitting nightwatch tests
 
+If you need to omit particular tests from running you can add a `testBlacklist` option to the nightwatch section of 
+your settings.json file. That defines an object of the following form:
+
+```javascript
+// ... 
+"nightwatch": {
+  // ... 
+  "testBlacklist": {
+    "documents": ["*"],
+    "databases": [
+      "checkDatabaseTooltip.js",
+      "createsDatabase.js"
+    ]
+  }
+}
+// ...
+
+```
+
+The properties (`documents`, `databases`) map to a particular addon folder name (see `app/addons`). The values 
+should be an array of tests that you don't want to run. `*` will flag all tests from being ran, otherwise you 
+just enter the names of the files to omit.
 
 
 ### To Deploy Fauxton

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -23,8 +23,8 @@ module.exports = function (grunt) {
   });
 
   grunt.registerMultiTask('get_deps', 'Fetch external dependencies', function (version) {
-    grunt.log.writeln("Fetching external dependencies");
 
+    grunt.log.writeln("Fetching external dependencies");
     var done = this.async(),
         data = this.data,
         target = data.target || "app/addons/",
@@ -142,8 +142,11 @@ module.exports = function (grunt) {
     // perform a little validation on the settings
     _validateNightwatchSettings(this.data.settings);
 
-    // figure out what tests we need to run by examining the settings.json file content
-    var addonsWithTests = _getNightwatchTests(this.data.settings);
+    // figure out what tests we need to run by examining the settings.json file content. This method returns
+    // the list of addon folders to test, plus a list of files to exclude
+    var result = _getNightwatchTests(this.data.settings);
+    var addonsWithTests = result.addonFolders;
+    var excludeTests = result.excludeTests;
 
     // if the user passed a --file="X" on the command line, filter out
     var singleTestToRun = grunt.option('file');
@@ -155,6 +158,7 @@ module.exports = function (grunt) {
     var nightwatchTemplate = _.template(grunt.file.read(this.data.template));
     grunt.file.write(this.data.dest, nightwatchTemplate({
       src_folders: JSON.stringify(addonsWithTests),
+      exclude_tests: JSON.stringify(excludeTests, null, '\t'),
       custom_commands_path: JSON.stringify(this.data.settings.nightwatch.custom_commands_path),
       globals_path: this.data.settings.nightwatch.globals_path,
       fauxton_username: this.data.settings.nightwatch.fauxton_username,
@@ -210,26 +214,51 @@ module.exports = function (grunt) {
   };
 
   function _getNightwatchTests (settings) {
-    var addonBlacklist = (_.has(settings.nightwatch, 'addonBlacklist')) ? settings.nightwatch.addonBlacklist : [];
+    var testBlacklist = (_.has(settings.nightwatch, 'testBlacklist')) ? settings.nightwatch.testBlacklist : {};
+    var addonFolders = [],
+        excludeTests = [];
 
-    return _.filter(settings.deps, function (addon) {
-
-      // if we've explicitly been told to ignore this addon's test, ignore 'em!
-      if (_.contains(addonBlacklist, addon.name)) {
-        return false;
-      }
-
-      var fileLocation = 'app/addons/' + addon.name + '/tests/nightwatch';
+    _.each(settings.deps, function (addon) {
+      var addonTestsFolder = 'app/addons/' + addon.name + '/tests/nightwatch';
       if (_.has(addon, 'path')) {
-        fileLocation = addon.path + '/tests/nightwatch';
+        addonTestsFolder = addon.path + '/tests/nightwatch';
       }
 
-      // see if the addon has any tests
-      return fs.existsSync(fileLocation);
+      // if this addon doesn't have any tests, just move along. Nothing to see here.
+      if (!fs.existsSync(addonTestsFolder)) {
+        return;
+      }
 
-    }).map(function (addon) {
-      return 'app/addons/' + addon.name + '/tests/nightwatch';
+      // next up: see if this addon has anything blacklisted
+      if (_.has(testBlacklist, addon.name) && _.isArray(testBlacklist[addon.name]) && testBlacklist[addon.name].length > 0) {
+
+        // a '*' means the user wants to blacklist all tests in the addon
+        if (_.contains(testBlacklist[addon.name], '*')) {
+          return;
+        }
+
+        // add the folder to test. Any specific files will be blacklisted separately
+        addonFolders.push(addonTestsFolder);
+
+        _.each(fs.readdirSync(addonTestsFolder), function (file) {
+          if (_.contains(testBlacklist[addon.name], file)) {
+            // the relative path is added to work around an oddity with nightwatch. It evaluates all exclude paths
+            // relative to the current src_folder being examined, so we need to return to the root first
+            excludeTests.push('../../../../../' + addonTestsFolder + '/' + file);
+          }
+        });
+
+      } else {
+
+        // add the whole folder
+        addonFolders.push(addonTestsFolder);
+      }
     });
+
+    return {
+      addonFolders: addonFolders,
+      excludeTests: excludeTests
+    };
   }
 
 };

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -24,11 +24,11 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask('get_deps', 'Fetch external dependencies', function (version) {
 
-    grunt.log.writeln("Fetching external dependencies");
+    grunt.log.writeln('Fetching external dependencies');
     var done = this.async(),
         data = this.data,
-        target = data.target || "app/addons/",
-        settingsFile = fs.existsSync(data.src) ? data.src : "settings.json.default",
+        target = data.target || 'app/addons/',
+        settingsFile = fs.existsSync(data.src) ? data.src : 'settings.json.default',
         settings = grunt.file.readJSON(settingsFile),
         _ = grunt.util._;
 
@@ -39,7 +39,7 @@ module.exports = function (grunt) {
       async.forEach(deps, function (dep, cb) {
         var path = target + dep.name;
         var location = dep.url || dep.path;
-        grunt.log.writeln("Fetching: " + dep.name + " (" + location + ")");
+        grunt.log.writeln('Fetching: ' + dep.name + ' (' + location + ')');
 
         child_process.exec(command(dep, path), function (error, stdout, stderr) {
           grunt.log.writeln(stderr);
@@ -48,7 +48,7 @@ module.exports = function (grunt) {
         });
       }, function (error) {
         if (error) {
-          grunt.log.writeln("ERROR: " + error.message);
+          grunt.log.writeln('ERROR: ' + error.message);
           return false;
         } else {
           return true;
@@ -57,16 +57,16 @@ module.exports = function (grunt) {
     };
 
     var remoteDeps = _.filter(settings.deps, function (dep) { return !! dep.url; });
-    grunt.log.writeln(remoteDeps.length + " remote dependencies");
+    grunt.log.writeln(remoteDeps.length + ' remote dependencies');
     var remote = fetch(remoteDeps, function (dep, destination) {
-      return "git clone " + dep.url + " " + destination;
+      return 'git clone ' + dep.url + ' ' + destination;
     });
 
     var localDeps = _.filter(settings.deps, function (dep) { return !! dep.path; });
-    grunt.log.writeln(localDeps.length + " local dependencies");
+    grunt.log.writeln(localDeps.length + ' local dependencies');
     var local = fetch(localDeps, function (dep, destination) {
       // TODO: Windows
-      var command = "cp -r " + dep.path + " " + destination;
+      var command = 'cp -r ' + dep.path + ' ' + destination;
       grunt.log.writeln(command);
       return command;
     });
@@ -78,12 +78,12 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('gen_load_addons', 'Generate the load_addons.js file', function () {
     var data = this.data,
         _ = grunt.util._,
-        settingsFile = fs.existsSync(data.src) ? data.src : "settings.json.default",
+        settingsFile = fs.existsSync(data.src) ? data.src : 'settings.json.default',
         settings = grunt.file.readJSON(settingsFile),
-        template = "app/load_addons.js.underscore",
-        dest = "app/load_addons.js",
+        template = 'app/load_addons.js.underscore',
+        dest = 'app/load_addons.js',
         deps = _.map(settings.deps, function (dep) {
-          return "addons/" + dep.name + "/base";
+          return 'addons/' + dep.name + '/base';
         });
 
     var tmpl = _.template(grunt.file.read(template));
@@ -93,8 +93,8 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('gen_initialize', 'Generate the app.js file', function () {
     var _ = grunt.util._,
         settings = this.data,
-        template = "app/initialize.js.underscore",
-        dest = "app/initialize.js",
+        template = 'app/initialize.js.underscore',
+        dest = 'app/initialize.js',
         tmpl = _.template(grunt.file.read(template)),
         app = {};
 
@@ -122,9 +122,9 @@ module.exports = function (grunt) {
     var require = {
       config: function (args) {
         configInfo = args;
-        configInfo.paths['chai'] = "../test/mocha/chai";
-        configInfo.paths['sinon-chai'] = "../test/mocha/sinon-chai";
-        configInfo.paths['testUtils'] = "../test/mocha/testUtils";
+        configInfo.paths['chai'] = '../test/mocha/chai';
+        configInfo.paths['sinon-chai'] = '../test/mocha/sinon-chai';
+        configInfo.paths['testUtils'] = '../test/mocha/testUtils';
         configInfo.baseUrl = '../app';
         delete configInfo.deps;
       }
@@ -192,7 +192,7 @@ module.exports = function (grunt) {
     if (error) {
       grunt.fail.fatal(error);
     }
-  };
+  }
 
   function _findSpecificNightwatchTest (addonsWithTests, file) {
     var filename = file + '.js';
@@ -211,7 +211,7 @@ module.exports = function (grunt) {
     }
 
     return paths[0];
-  };
+  }
 
   function _getNightwatchTests (settings) {
     var testBlacklist = (_.has(settings.nightwatch, 'testBlacklist')) ? settings.nightwatch.testBlacklist : {};

--- a/test/nightwatch_tests/nightwatch.json.underscore
+++ b/test/nightwatch_tests/nightwatch.json.underscore
@@ -38,7 +38,8 @@
         "browserName" : "firefox",
         "javascriptEnabled" : true,
         "acceptSslCerts" : true
-      }
+      },
+      "exclude": <%= exclude_tests %>
     },
 
     "chrome" : {


### PR DESCRIPTION
This PR expands on the option where you could choose to omit
specific addon test from being ran. Previously you could only
omit test on the addon-level. This now lets you fine-tune exactly
what nightwatch tests you want to omit.

See the updated readme.txt file in this commit for an explanation
of how it works.

This also updates nightwatch to 0.6.0.