### PR TITLE
Ace theme style overrides moved to Fauxton CSS

### DIFF
--- a/assets/less/codeeditor.less
+++ b/assets/less/codeeditor.less
@@ -144,6 +144,37 @@
   height: 100% !important;
 }
 
-body .ace-idle-fingers .ace_marker-layer .ace_selection {
-  background: #015F6F;
+/* Ace theme overrides */
+body {
+  .ace-idle-fingers .ace_marker-layer .ace_selection {
+    background: #015F6F;
+  }
+  .ace-idle-fingers .ace_gutter {
+    background: #3A3A3A;
+  }
+  .ace-idle-fingers {
+    background-color: #4d4d4d;
+  }
+  .ace-idle-fingers .ace_cursor {
+    color: #ffffff;
+  }
+  .ace-idle-fingers.ace_multiselect .ace_selection.ace_start {
+    box-shadow: 0 0 3px 0 #4d4d4d;
+  }
+  .ace-idle-fingers .ace_marker-layer .ace_active-line {
+    background: #000000;
+    opacity: 0.4;
+  }
+  .ace-idle-fingers .ace_constant {
+    color: #72cdf4;
+  }
+  .ace-idle-fingers .ace_boolean {
+    color: #ff6532;
+  }
+  .ace-idle-fingers .ace_string {
+    color: #29be9d;
+  }
+  .ace-idle-fingers .ace_collab.ace_user1 {
+    color: #4d4d4d;
+  }
 }


### PR DESCRIPTION
I originally committed the idle_fingers theme with some custom
style changes in it. This is going to be overridden in Robert's
Ace update ticket: https://github.com/apache/couchdb-fauxton/pull/285

This ticket moves those overridden styles into our own CSS
to prevent this from occurring again.