### PR TITLE
Constants: move to Api

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -20,7 +20,6 @@ define([
   'backbone',
   'bootstrap',
   'helpers',
-  'constants',
   'core/utils',
 
   // modules
@@ -32,7 +31,7 @@ define([
   'plugins/jquery.form'
 ],
 
-function(app, $, _, Backbone, Bootstrap, Helpers, constants, Utils, FauxtonAPI, Couchdb) {
+function(app, $, _, Backbone, Bootstrap, Helpers, Utils, FauxtonAPI, Couchdb) {
 
   // Make sure we have a console.log
   if (_.isUndefined(console)) {
@@ -63,9 +62,6 @@ function(app, $, _, Backbone, Bootstrap, Helpers, constants, Utils, FauxtonAPI, 
 
   // Localize or create a new JavaScript Template object
   var JST = window.JST = window.JST || {};
-
-  // Pass along all constants
-  FauxtonAPI.constants = constants;
 
   // Configure LayoutManager with Backbone Boilerplate defaults
   FauxtonAPI.Layout.configure({

--- a/app/core/api.js
+++ b/app/core/api.js
@@ -17,10 +17,12 @@ define([
   'core/routeObject',
   'core/utils',
   'core/store',
+  'constants',
+
   'flux'
 ],
 
-function(FauxtonAPI, Layout, Router, RouteObject, utils, Store, Flux) {
+function(FauxtonAPI, Layout, Router, RouteObject, utils, Store, constants, Flux) {
   FauxtonAPI = _.extend(FauxtonAPI, {
     Layout: Layout,
     Router: Router,
@@ -30,6 +32,9 @@ function(FauxtonAPI, Layout, Router, RouteObject, utils, Store, Flux) {
     Events: _.extend({}, Backbone.Events),
     dispatcher: new Flux.Dispatcher()
   });
+
+  // Pass along all constants
+  FauxtonAPI.constants = constants;
 
   FauxtonAPI.dispatch = _.bind(FauxtonAPI.dispatcher.dispatch, FauxtonAPI.dispatcher);
 


### PR DESCRIPTION
move constants to the creation of FauxtonAPI to make them
available sooner as they are a property of FauxtonAPI

Fixes the broken testsuite in a browser and App boot problems