### PR TITLE
Truncates pagination if more than 10 pages of pagination

### DIFF
--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -326,22 +326,58 @@ function(app, FauxtonAPI, ace, spin, ZeroClipboard) {
     className: 'pagination',
     template: "addons/fauxton/templates/pagination",
 
-    initialize: function(options) {
+    initialize: function (options) {
       this.page = parseInt(options.page, 10);
       this.perPage = options.perPage;
       this.urlFun = options.urlFun;
     },
 
-    serialize: function() {
+    serialize: function () {
       var total = this.collection.length;
       var totalPages = Math.ceil(total / this.perPage);
+
+      var visiblePagesObject = this.getVisiblePages(this.page, totalPages);
+
+      var from = visiblePagesObject.from,
+          to = visiblePagesObject.to;
+
       return {
         page: this.page,
         perPage: this.perPage,
         total: total,
         totalPages: totalPages,
-        urlFun: this.urlFun
+        urlFun: this.urlFun,
+        from: from,
+        to: to
       };
+    },
+
+    getVisiblePages: function (page, totalPages) {
+      var from, to;
+
+      if (totalPages < 10) {
+        from = 1;
+        to = totalPages + 1;
+      } else { // if totalPages is more than 10
+        from = page - 5;
+        to = page + 5;
+
+        if (from <= 1) {
+          from = 1;
+          to = 11;
+        }
+        if (to > totalPages + 1) {
+          from =  totalPages - 9;
+          to = totalPages + 1;
+        }
+
+      }
+
+      return {
+        from: from,
+        to: to
+      };
+
     }
   });
 

--- a/app/addons/fauxton/templates/pagination.html
+++ b/app/addons/fauxton/templates/pagination.html
@@ -16,7 +16,7 @@ the License.
 <% } else { %>
   <li class="disabled"> <a href="<%- urlFun(page) %>">&laquo;</a></li>
 <% } %>
-<% _.each(_.range(1, totalPages+1), function(i) { %>
+<% _.each(_.range(from, to), function(i) { %>
   <li <% if (page == i) { %>class="active"<% } %>> <a href="<%- urlFun(i) %>"><%- i %></a></li>
 <% }) %>
 <% if (page < totalPages) { %>

--- a/app/addons/fauxton/tests/paginateSpec.js
+++ b/app/addons/fauxton/tests/paginateSpec.js
@@ -1,0 +1,66 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+define([
+       'app',
+       'addons/fauxton/components',
+       'addons/documents/resources',
+       'testUtils',
+       'api'
+], function (app, Views, Models, testUtils, FauxtonAPI) {
+  var assert = testUtils.assert;
+
+  describe('DatabasePaginate', function () {
+    var totalPages, pageComponent, testObject, currentPage;
+
+    beforeEach(function () {
+      pageComponent = new Views.Pagination({page: 1});
+    });
+
+    it('Should return all the pages, if there are less than 10 total pages', function () {
+      for (totalPages = 1; totalPages < 11; totalPages++) {
+        for (currentPage = 1; currentPage < totalPages; currentPage++) {
+          testObject = pageComponent.getVisiblePages(currentPage, totalPages);
+          assert.deepEqual(testObject , {from: 1, to: totalPages + 1});
+        }
+      }
+    });
+
+    it('Should return only a ten page range, if more than 10 total pages', function () {
+      var difference;
+      for (totalPages = 10; totalPages < 50; totalPages++) {
+        for (currentPage = totalPages; currentPage < totalPages; currentPage++) {
+          testObject = pageComponent.getVisiblePages(currentPage, totalPages);
+          difference = testObject.to - testObject.from;
+          assert.equal(difference, 10);
+        }
+      }
+    });
+
+    it('Should return from 1 to 10, if accessing the first 6 pages', function () {
+      totalPages = 50;
+      for (currentPage = 1; currentPage <= 6; currentPage++) {
+        testObject = pageComponent.getVisiblePages(currentPage, totalPages);
+        assert.deepEqual(testObject , {from: 1, to: 11});
+      }
+
+    });
+
+    it('Should return from totalpages-10 to totalPages, if accessing one of the last 4 pages', function () {
+      totalPages = 50;
+      for (currentPage = 46; currentPage <= totalPages; currentPage++) {
+        testObject = pageComponent.getVisiblePages(currentPage, totalPages);
+        assert.deepEqual(testObject , {from: 41, to: 51});
+      }
+    });
+
+  });
+});


### PR DESCRIPTION
Current: if there are many pages, you can't reach the later databases, depending on the screen size
![screen shot 2015-02-27 at 3 06 27 pm](https://cloud.githubusercontent.com/assets/836039/6420243/7b04ab02-be92-11e4-821d-05faa28e694b.png)

After this commit, you'll only be able to see 10 pages of pagination at a time

![screen shot 2015-02-27 at 3 06 48 pm](https://cloud.githubusercontent.com/assets/836039/6420247/84da58a2-be92-11e4-9a9c-aae37e951c70.png)
![screen shot 2015-02-27 at 3 10 17 pm](https://cloud.githubusercontent.com/assets/836039/6420279/c5f3786e-be92-11e4-9a3d-70f41982135b.png)

