### PR TITLE
fix broken api-url link

### DIFF
--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -194,7 +194,7 @@ function(app, FauxtonAPI, Documents, PagingCollection) {
       }
     },
 
-    urlRef: function(context, params) {
+    urlRef: function (params) {
       var query = "";
 
       if (params) {
@@ -208,17 +208,10 @@ function(app, FauxtonAPI, Documents, PagingCollection) {
         query = "?" + $.param(parsedParam);
       }
 
-      var startOfUrl = app.host;
-      if (context === 'app') {
-        startOfUrl = 'database';
-      } else if (context === "apiurl"){
-        startOfUrl = window.location.origin;
-      }
-
       var database = this.database.safeID(),
           design = app.utils.safeURLName(this.design),
           view = app.utils.safeURLName(this.view),
-          url = FauxtonAPI.urls('view', 'server', database, design, view);
+          url = FauxtonAPI.urls('view', 'apiurl', database, design, view);
 
       return url + query;
     },

--- a/app/addons/documents/routes-index-editor.js
+++ b/app/addons/documents/routes-index-editor.js
@@ -113,7 +113,7 @@ function (app, FauxtonAPI, Helpers, BaseRoute, Documents, Index, Databases, Comp
       });
 
       this.apiUrl = function () {
-        return [this.indexedDocs.urlRef('apiurl', urlParams), FauxtonAPI.constants.DOC_URLS.GENERAL];
+        return [this.indexedDocs.urlRef(urlParams), FauxtonAPI.constants.DOC_URLS.GENERAL];
       };
 
       this.showQueryOptions(urlParams, ddoc, viewName);

--- a/app/addons/documents/tests/resourcesSpec.js
+++ b/app/addons/documents/tests/resourcesSpec.js
@@ -29,7 +29,11 @@ define([
         database: {id: 'databaseId', safeID: function () { return this.id; }},
         design: '_design/myDoc'
       });
+    });
 
+    it('does not remove an id attribute', function () {
+
+      assert.ok(/file:/.test(collection.urlRef('')));
     });
 
   });


### PR DESCRIPTION
also removes unused parameter from function, the only usage of
`indexedDocs.urlRef` is in `routes-index-editor.js`