### PR TITLE
Detect system databases on _

### DIFF
--- a/app/addons/databases/resources.js
+++ b/app/addons/databases/resources.js
@@ -82,45 +82,6 @@ function(app, FauxtonAPI, Documents) {
     }
   });
 
-  Databases.IsSystemDatabaseModel = FauxtonAPI.Model.extend({
-
-    initialize: function (options) {
-      this.name = options.name;
-    },
-
-    url: function () {
-      return app.host + '/_stats';
-    },
-
-    sync: function (method, model, options) {
-      options.url = this.url();
-      return $.ajax(options);
-    },
-
-    parse: function (data) {
-      var isOnFrontendNode,
-        isSystemDatabase = false,
-        systemDatabases = [
-          '_replicator',
-          '_users',
-          'nodes',
-          'dbs',
-          'cassim'
-        ];
-      try {
-        JSON.parse(data);
-        isOnFrontendNode = false;
-
-      } catch (e) {
-        isOnFrontendNode = true;
-      }
-      if (systemDatabases.indexOf(this.name) !== -1 && !isOnFrontendNode) {
-        isSystemDatabase = true;
-      }
-      this.set('isSystemDatabase', isSystemDatabase);
-    }
-  });
-
   Databases.Changes = FauxtonAPI.Collection.extend({
 
     initialize: function(options) {

--- a/app/addons/databases/resources.js
+++ b/app/addons/databases/resources.js
@@ -50,7 +50,7 @@ function(app, FauxtonAPI, Documents) {
     },
 
     isSystemDatabase: function () {
-      return /^_/.test(this.id);
+      return (/^_/).test(this.id);
     },
 
     url: function(context) {

--- a/app/addons/databases/resources.js
+++ b/app/addons/databases/resources.js
@@ -49,6 +49,10 @@ function(app, FauxtonAPI, Documents) {
       return false;
     },
 
+    isSystemDatabase: function () {
+      return /^_/.test(this.id);
+    },
+
     url: function(context) {
       if (context === "index") {
         return "/database/" + this.safeID() + "/_all_docs";

--- a/app/addons/databases/tests/resourcesSpec.js
+++ b/app/addons/databases/tests/resourcesSpec.js
@@ -50,22 +50,5 @@ define([
         assert.equal(databaseNames[1], 'rocko');
       });
     });
-    describe('Is system Database', function () {
-      it('checks if the current database is a systemDatabase if /_stats returns json', function () {
-        var isSystemDatabase = new Resources.IsSystemDatabaseModel({name: '_users'});
-        isSystemDatabase.parse('{"couch_replicator":{}}');
-        assert.ok(isSystemDatabase.get('isSystemDatabase'));
-      });
-      it('checks if the current database is a systemDatabase if /_stats returns no json', function () {
-        var isSystemDatabase = new Resources.IsSystemDatabaseModel({name: '_users'});
-        isSystemDatabase.parse('<html></html>');
-        assert.notOk(isSystemDatabase.get('isSystemDatabase'));
-      });
-      it('checks if the "cassim" internal database is a system database', function () {
-        var isSystemDatabase = new Resources.IsSystemDatabaseModel({name: 'cassim'});
-        isSystemDatabase.parse('{"couch_replicator":{}}');
-        assert.ok(isSystemDatabase.get('isSystemDatabase'));
-      });
-    });
   });
 });

--- a/app/addons/documents/assets/less/documents.less
+++ b/app/addons/documents/assets/less/documents.less
@@ -90,6 +90,12 @@ button.string-edit[disabled] {
   display: none;
 }
 
+#delete-db-check {
+  .warning {
+    color: #d14;
+  }
+}
+
 #string-edit-modal {
   div.modal {
     overflow-x: visible;

--- a/app/addons/documents/shared-routes.js
+++ b/app/addons/documents/shared-routes.js
@@ -65,8 +65,7 @@ define([
     addSidebar: function (selectedTab) {
       var params = {
         collection: this.designDocs,
-        database: this.database,
-        isSystemDatabaseModel: new Databases.IsSystemDatabaseModel({name: this.database.get('id')})
+        database: this.database
       };
       if (selectedTab) {
         params.selectedTab = selectedTab;

--- a/app/addons/documents/shared-views.js
+++ b/app/addons/documents/shared-views.js
@@ -97,7 +97,7 @@ function(app, FauxtonAPI, Components, Documents, Databases) {
         '#delete-db-modal',
         new Views.DeleteDBModal({
           database: this.database,
-          isSystemDatabase: /^_/.test(this.database.id)
+          isSystemDatabase: this.database.isSystemDatabase()
         })
       );
 

--- a/app/addons/documents/shared-views.js
+++ b/app/addons/documents/shared-views.js
@@ -30,7 +30,6 @@ function(app, FauxtonAPI, Components, Documents, Databases) {
 
     initialize: function(options) {
       this.database = options.database;
-      this.isSystemDatabaseModel = options.isSystemDatabaseModel;
 
       if (options.ddocInfo) {
         this.ddocID = options.ddocInfo.id;
@@ -93,15 +92,13 @@ function(app, FauxtonAPI, Components, Documents, Databases) {
         }]);
     },
 
-    establish: function () {
-      return [this.isSystemDatabaseModel.fetch({reset: true})];
-
-    },
-
     beforeRender: function(manage) {
       this.deleteDBModal = this.setView(
         '#delete-db-modal',
-        new Views.DeleteDBModal({database: this.database, isSystemDatabase: this.isSystemDatabaseModel.get('isSystemDatabase')})
+        new Views.DeleteDBModal({
+          database: this.database,
+          isSystemDatabase: /^_/.test(this.database.id)
+        })
       );
 
       var newLinks = [{

--- a/app/addons/documents/templates/delete_database_modal.html
+++ b/app/addons/documents/templates/delete_database_modal.html
@@ -20,7 +20,7 @@ the License.
   <div class="modal-body">
     <form id="delete-db-check" class="form" method="post">
       <% if (isSystemDatabase) { %>
-      <p>You are about to delete a system database, be careful!</p>
+      <p class="warning"><b>You are about to delete a system database, be careful!</b></p>
       <% } %>
       <p>
       You've asked to <b>permanently delete</b> <code><%- database.id %></code>.

--- a/app/addons/documents/tests/nightwatch/deleteDatabaseModal.js
+++ b/app/addons/documents/tests/nightwatch/deleteDatabaseModal.js
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+  'Shows a warning for system databases (prefixed with _)': function (client) {
+    var waitTime = 8000,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .url(baseUrl + '/#/database/_replicator/_all_docs')
+      .waitForElementPresent('#header-dropdown-menu a.dropdown-toggle.icon.fonticon-cog', waitTime, false)
+      .click("#header-dropdown-menu a.dropdown-toggle.icon.fonticon-cog")
+      .waitForElementPresent('#header-dropdown-menu .fonticon-trash', waitTime, false)
+      .click('#header-dropdown-menu .fonticon-trash')
+      .waitForElementVisible('#db_name', waitTime, false)
+      .assert.elementPresent('.warning')
+    .end();
+  },
+
+  'Shows no warning for non system databases': function (client) {
+    var waitTime = 8000,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .waitForElementPresent('#header-dropdown-menu a.dropdown-toggle.icon.fonticon-cog', waitTime, false)
+      .click("#header-dropdown-menu a.dropdown-toggle.icon.fonticon-cog")
+      .waitForElementPresent('#header-dropdown-menu .fonticon-trash', waitTime, false)
+      .click('#header-dropdown-menu .fonticon-trash')
+      .waitForElementVisible('#db_name', waitTime, false)
+      .assert.elementNotPresent('.warning')
+    .end();
+  }
+};

--- a/test/nightwatch_tests/helpers/helpers.js
+++ b/test/nightwatch_tests/helpers/helpers.js
@@ -22,9 +22,11 @@ module.exports = {
       // create a new database
       nano.db.create(database, function (err, body, header) {
         if (err) {
-         console.log('Error in setting up '+database, err.message);
+         console.log('Error in setting up ' + database, err.message);
         }
-      done();
+        nano.db.create('_replicator', function (err, body, header) {
+          done();
+        });
       });
     });
   },


### PR DESCRIPTION
All system databases are now prefixed by `_`, so we can remove
a lot of detection logic.

Additionally colored the warning in red.

closes COUCHDB-2607