### PR TITLE
Display the view name instead of DB name in Breadcrumb

### DIFF
--- a/app/addons/documents/routes-index-editor.js
+++ b/app/addons/documents/routes-index-editor.js
@@ -78,7 +78,7 @@ function (app, FauxtonAPI, Helpers, BaseRoute, Documents, Index,
         toggleDisabled: true,
         crumbs: [
           {'type': 'back', 'link': Helpers.getPreviousPage(this.database)},
-          {'name': this.database.id, 'link': Databases.databaseUrl(this.database) }
+          {'name': viewName, 'link': Databases.databaseUrl(this.database) }
         ]
       }));
 


### PR DESCRIPTION
Removes the doubled display of the db name in the view editor

cc @kxepal @seanbarclay 