### PR TITLE
Add extension support for doc list and editor

### DIFF
--- a/app/addons/documents/assets/less/documents.less
+++ b/app/addons/documents/assets/less/documents.less
@@ -244,3 +244,7 @@ button.string-edit[disabled] {
 #react-headerbar {
   float: left;
 }
+
+.doc-editor-extension-icons {
+  display: inline-block;
+}

--- a/app/addons/documents/templates/all_docs_item.html
+++ b/app/addons/documents/templates/all_docs_item.html
@@ -32,6 +32,9 @@ the License.
         </a>
       </div>
     <% } %>
+
+    <div class="doc-item-extension-icons pull-right"></div>
+
   </header>
   <div class="doc-data">
     <pre class="prettyprint"><%- doc.prettyJSON() %></pre>

--- a/app/addons/documents/templates/code_editor.html
+++ b/app/addons/documents/templates/code_editor.html
@@ -44,6 +44,8 @@ the License.
     </div>
     <% } %>
 
+    <div class="doc-editor-extension-icons"></div>
+
     <div class="panel-section">
       <button class="panel-button upload" title="Upload attachment">
         <i class="icon icon-circle-arrow-up"></i>

--- a/app/addons/documents/views-doceditor.js
+++ b/app/addons/documents/views-doceditor.js
@@ -342,6 +342,11 @@ function (app, FauxtonAPI, Components, Documents, Databases, prettify) {
 
       // ensures it's initialized only once
       this.stringEditModal = this.stringEditModal || this.setView('#string-edit-modal', new Views.StringEditModal());
+
+      var extensions = FauxtonAPI.getExtensions('DocEditor:icons');
+      _.each(extensions, function (View) {
+        this.insertView('.doc-editor-extension-icons', new View({ doc: this.model }));
+      }, this);
     },
 
     updateValues: function () {

--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -250,6 +250,13 @@ function (app, FauxtonAPI, Components, Documents,
       };
     },
 
+    beforeRender: function () {
+      var extensions = FauxtonAPI.getExtensions('DocList:icons');
+      _.each(extensions, function (View) {
+        this.insertView('.doc-item-extension-icons', new View({ doc: this.model }));
+      }, this);
+    },
+
     establish: function() {
       return [this.model.fetch()];
     },


### PR DESCRIPTION
This adds the option to allow extensions to add icons on the
documents list and on the full page code editor page.