### PR TITLE
Fix Views toggle with dot symbol in ddoc name

### DIFF
--- a/app/addons/documents/shared-views.js
+++ b/app/addons/documents/shared-views.js
@@ -164,8 +164,15 @@ function (app, FauxtonAPI, Components, Documents, Databases) {
     },
 
     toggleArrow:  function (e) {
-      this.$(e.currentTarget).toggleClass("down");
+      this.$('[id*="' + this.sanitizeForJquery(e.currentTarget.id) + '"]').toggleClass('down');
+      // if there is a '.' in the design doc name, jquery interprets that as a class
+      // see: couchdb-fauxton/assets/js/libs/bootstrap.js line 1739
     },
+
+    sanitizeForJquery: function (jquerySelector) {
+      return jquerySelector.replace(/\//g, '\\\/').replace(/\./g, '\\.').replace(/\%/g, '\\%');
+    },
+
     buildIndexList: function (designDocs, info) {
       var design = this.model.id.replace(/^_design\//, "");
       var databaseId = this.model.database.id;
@@ -184,12 +191,14 @@ function (app, FauxtonAPI, Components, Documents, Databases) {
     serialize: function () {
       var ddocName = this.model.id.replace(/^_design\//, ""),
           docSafe = app.utils.safeURLName(ddocName),
-          databaseName = this.collection.database.safeID();
+          databaseName = this.collection.database.safeID(),
+          data_target = app.utils.safeURLName(ddocName).replace(/%/g, '_percent_').replace(/\./g, '_dot_');
 
       return {
-        designDocMetaUrl: FauxtonAPI.urls('designDocs', 'app', databaseName, docSafe),
+        designDocMetaUrl: FauxtonAPI.urls('designDocs', 'app', databaseName, docSafe).replace(/\./g, '%2E'),
         designDoc: ddocName,
         ddoc_clean: docSafe,
+        data_target: data_target
       };
     },
 
@@ -277,7 +286,7 @@ function (app, FauxtonAPI, Components, Documents, Databases) {
         database: this.database,
         selected: this.selected,
         collection: this.collection,
-        href: FauxtonAPI.urls(this.indexTypeMap[this.selector].type, 'app', this.database, this.ddoc)
+        href: FauxtonAPI.urls(this.indexTypeMap[this.selector].type, 'app', this.database, this.ddoc.replace(/\//g, '%2F')).replace(/\./g, '%2E')
       };
     },
 

--- a/app/addons/documents/templates/design_doc_menu.html
+++ b/app/addons/documents/templates/design_doc_menu.html
@@ -13,16 +13,16 @@ the License.
 -->
 <li class="nav-header">
 
-<div  class="js-collapse-toggle accordion-header" data-toggle="collapse" data-target="#<%- ddoc_clean %>" id="nav-header-<%- ddoc_clean %>" >
+<div  class="js-collapse-toggle accordion-header" data-toggle="collapse" data-target="#<%- data_target %>" id="nav-header-<%- ddoc_clean %>" >
   <div class="accordion-list-item">
     <div class="fonticon-play"></div>
     <p>_design/<%- designDoc%></p>
   </div>
   <div class="new-button add-dropdown"></div>
 </div>
-<ul class="accordion-body collapse" id="<%- ddoc_clean %>">
+<ul class="accordion-body collapse" id="<%- data_target %>">
   <li>
-  <a id="<%- ddoc_clean %>_metadata" href="#/<%- designDocMetaUrl %>" class="toggle-view accordion-header">
+  <a id="<%- data_target %>_metadata" href="#/<%- designDocMetaUrl %>" class="toggle-view accordion-header">
     <span class="fonticon-sidenav-info fonticon"></span>
     Design Doc Metadata
   </a>

--- a/app/addons/documents/templates/index_menu_item.html
+++ b/app/addons/documents/templates/index_menu_item.html
@@ -22,7 +22,7 @@ the License.
   <a
     data-ddoctype="<%- ddocType %>"
     id="<%- removeSpecialCharacters(ddoc) %>_<%- removeSpecialCharacters(index) %>"
-    href="#/<%- href%><%- index%>"
+    href="#/<%- href%><%- safeURL(index)%>"
     class="toggle-view">
     <%- index %>
   </a>

--- a/app/addons/documents/tests/nightwatch/checkSidebarBehavior.js
+++ b/app/addons/documents/tests/nightwatch/checkSidebarBehavior.js
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+
+  'Checks if design docs that have a dot symbol in the id show up in the UI': function (client) {
+    var waitTime = 10000,
+        newDatabaseName = client.globals.testDatabaseName,
+        designPrefix = '_design/',
+        newDocumentName1 = 'ddoc_normal',
+        newDocumentName2 = 'ddoc.with.specialcharacters',
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .createDocument(designPrefix + newDocumentName1, newDatabaseName)
+      .createDocument(designPrefix + newDocumentName2, newDatabaseName)
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .clickWhenVisible('#nav-header-' + newDocumentName1.replace(/\./g, '\\.'))
+      .clickWhenVisible('#nav-header-' + newDocumentName2.replace(/\./g, '\\.'))
+      .waitForElementPresent('#' + newDocumentName2.replace(/%/g, '_percent_').replace(/\./g, '_dot_'), waitTime, false)
+    .end();
+  }
+};


### PR DESCRIPTION
Toggling Views won't work if there is a dot (.) in the design doc name


Before: ![screen shot 2015-03-16 at 10 12 48 pm](https://cloud.githubusercontent.com/assets/836039/6680131/c7cf91f0-cc29-11e4-909d-8de55ebedf9e.png)

After: 
![screen shot 2015-03-16 at 10 14 59 pm](https://cloud.githubusercontent.com/assets/836039/6680141/e7cad5b4-cc29-11e4-9afc-d7634cb40b17.png)
