### PR TITLE
Fix for deleting database with '/' in name

### DIFF
--- a/app/addons/databases/tests/nightwatch/deletesDatabaseSpecialChars.js
+++ b/app/addons/databases/tests/nightwatch/deletesDatabaseSpecialChars.js
@@ -1,0 +1,42 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+  'Deletes a database with special chars': function (client) {
+    var waitTime = 8000,
+        newDatabaseName = 'one/two-three/_four', // add any other chars here you want to test
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .createDatabase(newDatabaseName)
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + encodeURIComponent(newDatabaseName) + '/_all_docs')
+      .waitForElementPresent('#header-dropdown-menu a.dropdown-toggle.icon.fonticon-cog', waitTime, false)
+      .click("#header-dropdown-menu a.dropdown-toggle.icon.fonticon-cog")
+      .waitForElementPresent('#header-dropdown-menu .fonticon-trash', waitTime, false)
+      .click('#header-dropdown-menu .fonticon-trash')
+      .waitForElementVisible('#db_name', waitTime, false)
+      .click('#db_name')
+      .setValue('input#db_name', [newDatabaseName, client.Keys.ENTER] )
+      .waitForElementVisible('#global-notifications .alert.alert-info', waitTime, false)
+      .url(baseUrl + '/_all_dbs')
+      .waitForElementPresent('pre', waitTime, false)
+      .getText('body', function (result) {
+        var data = result.value,
+            createdDatabaseIsNotPresent = data.indexOf('"' + newDatabaseName + '"');
+
+        this.verify.ok(createdDatabaseIsNotPresent === -1,
+          'Checking if new database no longer shows up in _all_dbs.');
+      })
+    .end();
+  }
+};

--- a/app/addons/documents/views.js
+++ b/app/addons/documents/views.js
@@ -196,7 +196,7 @@ function (app, FauxtonAPI, Components, Documents,
         clear: true
       });
 
-      this.database.url = FauxtonAPI.urls('databaseBaseURL', 'server', this.database.id, '');
+      this.database.url = FauxtonAPI.urls('databaseBaseURL', 'server', this.database.safeID(), '');
 
       this.database.destroy().then(function () {
         FauxtonAPI.navigate(FauxtonAPI.urls('allDBs', 'app'));


### PR DESCRIPTION
Previously you'd get an error when trying to delete a database
that contained a slash in the name.