### PR TITLE
tooling: don't require globally installed grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "stylecheck": "jsxcs app && jsxcs test/nightwatch_tests && jsxcs tasks && jsxcs Gruntfile.js",
     "test": "grunt test",
     "couchdebug": "grunt couchdebug",
-    "couchdb": "grunt couchdb"
+    "couchdb": "grunt couchdb",
+    "couchapp": "grunt couchapp_deploy",
+    "dev": "grunt dev",
+    "nightwatch": "grunt nightwatch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`grunt` is one of our dependencies, using `npm run dev` we can
substitute `grunt dev` which requires a globally installed grunt
which can have a completely different version than we are defining
in our `package.json`

Using `scripts` in the npm package.json file npm takes care that
our locally installed modules which provide a `bin` file are part
of the env of the executing context.

New commands:

```
npm run dev
npm run nightwatch
```