### PR TITLE
Add API URL option to permissions page

### DIFF
--- a/app/addons/permissions/resources.js
+++ b/app/addons/permissions/resources.js
@@ -14,7 +14,7 @@ define([
   'app',
   'api'
 ],
-function (app, FauxtonAPI ) {
+function (app, FauxtonAPI) {
   var Permissions = FauxtonAPI.addon();
 
   Permissions.Security = Backbone.Model.extend({
@@ -34,6 +34,8 @@ function (app, FauxtonAPI ) {
     url: function () {
       return window.location.origin + '/' + this.database.safeID() + '/_security';
     },
+
+    documentation: FauxtonAPI.constants.DOC_URLS.DB_PERMISSION,
 
     addItem: function (value, type, section) {
       var sectionValues = this.get(section);

--- a/app/addons/permissions/routes.js
+++ b/app/addons/permissions/routes.js
@@ -44,6 +44,10 @@ function (app, FauxtonAPI, Databases, Permissions, BaseRoute) {
       this.addSidebar('permissions');
     },
 
+    apiUrl: function () {
+      return [this.security.url('apiurl'), this.security.documentation];
+    },
+
     establish: function () {
       return [
         this.database.fetch(),


### PR DESCRIPTION
This adds the API URL header link to the permissions page
which opens the /db/_security endpoint and appropriate doc link.

N.B. none of the doc links seem to be working on couch 2.0.
Separate issue.