### PR TITLE
Invalid 'undefined' class in All Docs header button element

### DIFF
--- a/app/addons/documents/header/header.stores.js
+++ b/app/addons/documents/header/header.stores.js
@@ -91,6 +91,7 @@ function (FauxtonAPI, ActionTypes) {
     },
 
     reset: function () {
+      this._toggleClass = '';
       this._isToggled = false;
     },
 

--- a/app/addons/documents/tests/headerSpec.react.jsx
+++ b/app/addons/documents/tests/headerSpec.react.jsx
@@ -59,6 +59,12 @@ define([
       TestUtils.Simulate.click($el[0]);
       assert.equal($(toggleEl.getDOMNode()).find('.alternative-header').length, 1);
     });
+
+    it('should not include invalid calssname', function () {
+      toggleEl = TestUtils.renderIntoDocument(<Views.HeaderBarController />, container);
+      var $el = $(toggleEl.getDOMNode()).find('.control-toggle-alternative-header');
+      assert.equal($(toggleEl.getDOMNode()).find('.undefined').length, 0);
+    });
   });
 
   describe('Bulkdocument Headerbar Controller', function () {


### PR DESCRIPTION
This remove the invalide undefined class in select button of All Docs header which appear when landing the page

Closes COUCHDB-2577