### PR TITLE
Design doc names truncated in sidebar

### DIFF
--- a/app/addons/databases/tests/nightwatch/checkDatabaseTooltip.js
+++ b/app/addons/databases/tests/nightwatch/checkDatabaseTooltip.js
@@ -35,7 +35,7 @@ module.exports = {
       .click('.control-delete')
       .acceptAlert()
       .waitForElementVisible('#global-notifications .alert.alert-info', waitTime, false)
-      .click('#nav-links a[href="#/_all_dbs"]')
+      .clickWhenVisible('#nav-links a[href="#/_all_dbs"]')
 
       // now let's look at the actual UI to confirm the tooltip appears
       .waitForElementPresent('.js-db-graveyard', waitTime, false)

--- a/app/addons/documents/assets/less/sidenav.less
+++ b/app/addons/documents/assets/less/sidenav.less
@@ -84,11 +84,19 @@
       .accordion-list-item p{
         .transition(all 0.25s linear);
       }
-      .accordion-list-item p{
+      .design-doc-name {
+        cursor: pointer;
         margin: 0;
-        padding: 10px 13px 10px 36px;
         color: @linkColor;
+        span {
+          width: @sidebarWidth - 30px;
+          display: block;
+          padding: 10px 13px 10px 36px;
+          text-overflow: ellipsis;
+          overflow: hidden;
+        }
       }
+
       .fonticon-play{
         font-size: 12px;
         top: 12px;

--- a/app/addons/documents/templates/design_doc_menu.html
+++ b/app/addons/documents/templates/design_doc_menu.html
@@ -13,10 +13,10 @@ the License.
 -->
 <li class="nav-header">
 
-<div  class="js-collapse-toggle accordion-header" data-toggle="collapse" data-target="#<%- ddoc_clean %>" id="nav-header-<%- ddoc_clean %>" >
+<div class="js-collapse-toggle accordion-header" data-toggle="collapse" data-target="#<%- ddoc_clean %>" id="nav-header-<%- ddoc_clean %>" >
   <div class="accordion-list-item">
     <div class="fonticon-play"></div>
-    <p>_design/<%- designDoc%></p>
+    <p class="design-doc-name"><span title="_design/<%- designDoc%>">_design/<%- designDoc%></span></p>
   </div>
   <div class="new-button add-dropdown"></div>
 </div>


### PR DESCRIPTION
Long design doc names displayed in the sidebar of the Docs page would
overlap with the rightmost ("+") icon. This truncates them with an
ellipsis and adds a tooltip (just a title attr) to provide a means to
let user see the full design doc name.