### PR TITLE
Fix for invalid link in changes feed

### DIFF
--- a/app/addons/documents/changes/components.react.jsx
+++ b/app/addons/documents/changes/components.react.jsx
@@ -412,7 +412,7 @@ define([
           <span className="js-doc-id">{this.props.id}</span>
         );
       } else {
-        var link = FauxtonAPI.urls('document', 'app', this.props.databaseName, this.props.id);
+        var link = '#' + FauxtonAPI.urls('document', 'app', this.props.databaseName, this.props.id);
         return (
           <a href={link} className="js-doc-link">{this.props.id}</a>
         );

--- a/app/addons/documents/tests/nightwatch/changes.js
+++ b/app/addons/documents/tests/nightwatch/changes.js
@@ -20,9 +20,27 @@ module.exports = {
       .loginToGUI()
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
       .waitForElementPresent('.control-toggle-alternative-header', waitTime, false)
-      .click('#changes')
+      .clickWhenVisible('#changes')
       .waitForElementPresent('.js-changes-view', waitTime, false)
       .assert.elementNotPresent('.control-toggle-alternative-header')
-    .end();
+      .end();
+  },
+
+  'Check doc link in Changes feed links properly': function (client) {
+    var waitTime = 10000,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .createDocument('doc_1', newDatabaseName)
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_changes')
+      .waitForElementPresent('.change-box[data-id="doc_1"]', waitTime, false)
+
+      // confirm only the single result is now listed in the page
+      .waitForElementVisible('.js-doc-link', waitTime, false)
+      .click('.js-doc-link')
+      .waitForElementPresent('#doc-editor-actions-panel', waitTime, false)
+      .end();
   }
 };


### PR DESCRIPTION
Includes a test to confirm the link redirects properly when clicked.
I also tweaked the other changes test which was a bit flakey.