### PR TITLE
removing old unused event

### DIFF
--- a/app/addons/fauxton/actions.js
+++ b/app/addons/fauxton/actions.js
@@ -22,9 +22,6 @@ function (app, FauxtonAPI, ActionTypes) {
       FauxtonAPI.dispatch({
         type: ActionTypes.TOGGLE_NAVBAR_MENU
       });
-
-      // TODO temporary patch for COUCHDB-2555
-      FauxtonAPI.Events.trigger(FauxtonAPI.constants.EVENTS.BURGER_CLICKED);
     },
 
     addHeaderLink: function (link) {


### PR DESCRIPTION
This event is no longer used & was replaced with NAVBAR_SIZE_CHANGED