### PR TITLE
Mango: creation and listing of indexes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,6 +121,13 @@ module.exports = function (grunt) {
     };
 
     var settings = helper.readSettingsFile();
+
+    var i18n = JSON.stringify(helper.readI18nFile(), null, ' ');
+
+    ['development', 'release', 'couchapp'].forEach(function (key) {
+      settings.template[key].app.i18n = i18n;
+    });
+
     return settings.template || defaultSettings;
   }();
 

--- a/app/addons/components/assets/less/docs.less
+++ b/app/addons/components/assets/less/docs.less
@@ -76,6 +76,12 @@
       padding-left: 23px; // 7px to the right-border + 16px around
     }
   }
+  .checkbox-dummy {
+    width: 20px;
+    height: 20px;
+    padding-left: 23px;
+    margin-right: 15px;
+  }
   .doc-item {
     width: auto;
     overflow: hidden;

--- a/app/addons/components/react-components.react.jsx
+++ b/app/addons/components/react-components.react.jsx
@@ -65,27 +65,32 @@ function (app, FauxtonAPI, React, Components, beautifyHelper) {
   var CodeEditor = React.createClass({
     render: function () {
       var code = this.aceEditor ? this.aceEditor.getValue() : this.props.code;
-      var docsLink;
-      if (this.props.docs) {
-        docsLink = <a
-                      className="help-link"
-                      data-bypass="true"
-                      href={this.props.docs}
-                      target="_blank"
-                    >
-                    <i className="icon-question-sign"></i>
-                   </a>;
-
-      }
       return (
         <div className="control-group">
-          <label htmlFor="ace-function">
-            <strong>{this.props.title}</strong>
-            {docsLink}
-          </label>
+          {this.getTitleFragment()}
           <div className="js-editor" id={this.props.id}>{this.props.code}</div>
           <Beautify code={code} beautifiedCode={this.setEditorValue} />
         </div>
+      );
+    },
+
+    getTitleFragment: function () {
+      if (!this.props.docs) {
+        return <strong>{this.props.title}</strong>;
+      }
+
+      return (
+        <label>
+          <strong>{this.props.title}</strong>
+          <a
+            className="help-link"
+            data-bypass="true"
+            href={this.props.docs}
+            target="_blank"
+          >
+          <i className="icon-question-sign"></i>
+          </a>;
+        </label>
       );
     },
 
@@ -213,6 +218,11 @@ function (app, FauxtonAPI, React, Components, beautifyHelper) {
     },
 
     getCheckbox: function () {
+
+      if (!this.props.isDeletable) {
+        return <div className="checkbox-dummy"></div>;
+      }
+
       return (
         <div className="checkbox inline">
           <input
@@ -285,7 +295,6 @@ function (app, FauxtonAPI, React, Components, beautifyHelper) {
       );
     }
   });
-
 
   var ReactComponents = {
     ConfirmButton: ConfirmButton,

--- a/app/addons/components/tests/docSpec.react.jsx
+++ b/app/addons/components/tests/docSpec.react.jsx
@@ -51,7 +51,7 @@ define([
 
     it('you can check it', function () {
       el = TestUtils.renderIntoDocument(
-        <ReactComponents.Document checked={true} docIdentifier="foo" />,
+        <ReactComponents.Document isDeletable={true} checked={true} docIdentifier="foo" />,
         container
       );
       assert.equal($(el.getDOMNode()).find('input[type="checkbox"]').attr('checked'), 'checked');
@@ -59,7 +59,7 @@ define([
 
     it('you can uncheck it', function () {
       el = TestUtils.renderIntoDocument(
-        <ReactComponents.Document docIdentifier="foo" />,
+        <ReactComponents.Document isDeletable={true} docIdentifier="foo" />,
         container
       );
       assert.equal($(el.getDOMNode()).find('input[type="checkbox"]').attr('checked'), undefined);
@@ -69,7 +69,7 @@ define([
       var spy = sinon.spy();
 
       el = TestUtils.renderIntoDocument(
-        <ReactComponents.Document docChecked={spy} docIdentifier="foo" />,
+        <ReactComponents.Document isDeletable={true} docChecked={spy} docIdentifier="foo" />,
         container
       );
       var testEl = $(el.getDOMNode()).find('input[type="checkbox"]')[0];
@@ -81,11 +81,22 @@ define([
       var spy = sinon.spy();
 
       el = TestUtils.renderIntoDocument(
-        <ReactComponents.Document onDoubleClick={spy} docIdentifier="foo" />,
+        <ReactComponents.Document isDeletable={true} onDoubleClick={spy} docIdentifier="foo" />,
         container
       );
       React.addons.TestUtils.Simulate.doubleClick(el.getDOMNode());
       assert.ok(spy.calledOnce);
+    });
+
+    it('can render without checkbox', function () {
+      var spy = sinon.spy();
+
+      el = TestUtils.renderIntoDocument(
+        <ReactComponents.Document isDeletable={false} onDoubleClick={spy} docIdentifier="foo" />,
+        container
+      );
+      assert.notOk($(el.getDOMNode()).find('input[type="checkbox"]').length);
+      assert.ok($(el.getDOMNode()).find('.checkbox-dummy').length);
     });
   });
 

--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -110,5 +110,33 @@ function (app, FauxtonAPI, Documents) {
       return '/database/' + database + '/' ;
     },
   });
+
+  FauxtonAPI.registerUrls('mango', {
+
+    'index-server': function (db, query) {
+      if (!query) {
+        query = '';
+      }
+
+      return app.host + '/' + db + '/_index' + query;
+    },
+
+    'index-apiurl': function (db, query) {
+      if (!query) {
+        query = '';
+      }
+
+      return window.location.origin + '/' + db + '/_index' + query;
+    },
+
+    'index-app': function (db, query) {
+      if (!query) {
+        query = '';
+      }
+
+      return 'database/' + db + '/_index' + query;
+    }
+  });
+
   return Documents;
 });

--- a/app/addons/documents/index-editor/stores.js
+++ b/app/addons/documents/index-editor/stores.js
@@ -71,7 +71,9 @@ function (FauxtonAPI, ActionTypes) {
     },
 
     getDesignDocs: function () {
-      return this._designDocs;
+      return this._designDocs.filter(function (ddoc) {
+        return ddoc.get('doc').language !== 'query';
+      });
     },
 
     getDesignDocId: function () {

--- a/app/addons/documents/index-results/actions.js
+++ b/app/addons/documents/index-results/actions.js
@@ -74,7 +74,7 @@ function (app, FauxtonAPI, ActionTypes, Stores, HeaderStores, HeaderActions, Doc
     reloadResultsList: function () {
       return this.newResultsList({
         collection: indexResultsStore.getCollection(),
-        deleteable: indexResultsStore.isDeleteable()
+        isListDeletable: indexResultsStore.isListDeletable()
       });
     },
 

--- a/app/addons/documents/index-results/index-results.components.react.jsx
+++ b/app/addons/documents/index-results/index-results.components.react.jsx
@@ -43,7 +43,7 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents) {
     },
 
     getUrlFragment: function (url) {
-      if (this.props.hasReduce) {
+      if (!this.props.isEditable) {
         return null;
       }
 
@@ -55,6 +55,7 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents) {
 
     getDocumentList: function () {
       return _.map(this.props.results, function (doc) {
+
         return (
          <Components.Document
            key={doc.id}
@@ -64,6 +65,7 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents) {
            docContent={doc.content}
            checked={this.props.isSelected(doc.id)}
            docChecked={this.props.docChecked}
+           isDeletable={doc.isDeletable}
            docIdentifier={doc.id} >
            {this.getUrlFragment('#' + doc.url)}
          </Components.Document>
@@ -79,7 +81,7 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents) {
         loadLines = <Components.LoadLines />;
       }
 
-      if (this.props.isDeleteable) {
+      if (this.props.isListDeletable) {
         classNames += ' show-select';
       }
 
@@ -111,10 +113,10 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents) {
       return {
         hasResults: store.hasResults(),
         results: store.getResults(),
-        isDeleteable: store.isDeleteable(),
+        isListDeletable: store.isListDeletable(),
         isSelected: store.isSelected,
-        hasReduce: store.hasReduce(),
-        isLoading: store.isLoading()
+        isLoading: store.isLoading(),
+        isEditable: store.isEditable()
       };
     },
 
@@ -149,8 +151,8 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents) {
         view = <ResultsScreen
           isCollapsed={this.isCollapsed}
           isSelected={this.isSelected}
-          hasReduce={this.state.hasReduce}
-          isDeleteable={this.state.isDeleteable}
+          isEditable={this.state.isEditable}
+          isListDeletable={this.state.isListDeletable}
           docChecked={this.docChecked}
           isLoading={this.state.isLoading}
           results={this.state.results} />;

--- a/app/addons/documents/index-results/stores.js
+++ b/app/addons/documents/index-results/stores.js
@@ -27,7 +27,7 @@ function (FauxtonAPI, ActionTypes, HeaderActionTypes, Documents) {
   Stores.IndexResultsStore = FauxtonAPI.Store.extend({
 
     initialize: function () {
-      this._deleteable = false;
+      this._isListDeletable = false;
       this._collection = [];
       this.clearSelectedItems();
       this.clearCollapsedDocs();
@@ -44,16 +44,29 @@ function (FauxtonAPI, ActionTypes, HeaderActionTypes, Documents) {
 
     newResults: function (options) {
       this._collection = options.collection;
-      this._deleteable = options.deleteable;
+      this._isListDeletable = options.isListDeletable;
       this.clearSelectedItems();
       this.clearCollapsedDocs();
     },
 
-    hasReduce: function () {
-      if (!this._collection || !this._collection.params) {
+    isEditable: function (doc) {
+      if (!this._collection) {
         return false;
       }
-      return this._collection.params.reduce;
+
+      if (!this._collection.isEditable) {
+        return false;
+      }
+
+      return this._collection.isEditable();
+    },
+
+    isDeletable: function (doc) {
+      return doc.isDeletable();
+    },
+
+    isListDeletable: function () {
+      return this._isListDeletable;
     },
 
     getCollection: function () {
@@ -79,7 +92,7 @@ function (FauxtonAPI, ActionTypes, HeaderActionTypes, Documents) {
         return doc.id;
       }
 
-      if (!_.isNull(doc.get('key'))) {
+      if (doc.get('key')) {
         return doc.get('key').toString();
       }
 
@@ -92,7 +105,9 @@ function (FauxtonAPI, ActionTypes, HeaderActionTypes, Documents) {
           content: this.getDocContent(doc),
           id: this.getDocId(doc),
           keylabel: doc.isFromView() ? 'key' : 'id',
-          url: doc.isFromView() ? doc.url('app') : doc.url('web-index')
+          url: doc.isFromView() ? doc.url('app') : doc.url('web-index'),
+          isDeletable: this.isDeletable(doc),
+          isEditable: this.isEditable(doc),
         };
       }, this);
     },

--- a/app/addons/documents/index-results/tests/index-results.actionsSpec.js
+++ b/app/addons/documents/index-results/tests/index-results.actionsSpec.js
@@ -153,6 +153,10 @@ define([
       };
       var stub = sinon.stub(store, 'createBulkDeleteFromSelected');
       stub.returns(bulkDelete);
+      var reloadResultsListStub = sinon.stub(Actions, 'reloadResultsList');
+      var stubPromise = FauxtonAPI.Deferred();
+      stubPromise.resolve();
+      reloadResultsListStub.returns(stubPromise);
 
       Actions.deleteSelected();
 
@@ -196,6 +200,10 @@ define([
       };
       var stub = sinon.stub(store, 'createBulkDeleteFromSelected');
       stub.returns(bulkDelete);
+      var reloadResultsListStub = sinon.stub(Actions, 'reloadResultsList');
+      var stubPromise = FauxtonAPI.Deferred();
+      stubPromise.resolve();
+      reloadResultsListStub.returns(stubPromise);
 
       Actions.deleteSelected();
 

--- a/app/addons/documents/index-results/tests/index-results.storesSpec.js
+++ b/app/addons/documents/index-results/tests/index-results.storesSpec.js
@@ -347,26 +347,22 @@ define([
     });
   });
 
-  describe('hasReduce', function () {
+  describe('isEditable', function () {
 
     it('returns false for no collection', function () {
       store._collection = null;
-      assert.notOk(store.hasReduce());
+      assert.notOk(store.isEditable());
     });
 
-    it('returns false for no params', function () {
+    it('returns false for empty collection', function () {
       store._collection = [];
-      assert.notOk(store.hasReduce());
+      assert.notOk(store.isEditable());
     });
 
-    it('returns true for reduce param', function () {
-      store._collection = [];
-      store._collection.param = {
-        reduce: true
-      };
-      assert.notOk(store.hasReduce());
-
+    it('delegates to collection', function () {
+      store._collection = {};
+      store._collection.isEditable = function () { return 'stub'; };
+      assert.equal(store.isEditable(), 'stub');
     });
-
   });
 });

--- a/app/addons/documents/mango/mango.actions.js
+++ b/app/addons/documents/mango/mango.actions.js
@@ -1,0 +1,58 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  'app',
+  'api',
+  'addons/documents/resources',
+  'addons/documents/mango/mango.actiontypes',
+  'addons/documents/mango/mango.stores',
+  'addons/documents/index-results/actions'
+
+],
+function (app, FauxtonAPI, Documents, ActionTypes, Stores, IndexResultsActions) {
+  var store = Stores.mangoStore;
+
+  return {
+
+    setDatabase: function (options) {
+      FauxtonAPI.dispatch({
+        type: ActionTypes.MANGO_SET_DB,
+        options: options
+      });
+    },
+
+    saveQuery: function (options) {
+      var mangoIndex = new Documents.MangoIndex(JSON.parse(options.queryCode), {database: options.database});
+
+      FauxtonAPI.addNotification({
+        msg:  'Saving Index for Query...',
+        type: 'info',
+        clear: true
+      });
+
+      mangoIndex.save().then(function (res) {
+        var msg = res.result === 'created' ? 'Index created' : 'Index already exits',
+            url = FauxtonAPI.urls('mango', 'index-app', options.database.safeID());
+
+        FauxtonAPI.addNotification({
+          msg:  msg,
+          type: 'success',
+          clear: true
+        });
+
+        IndexResultsActions.reloadResultsList();
+      }.bind(this));
+
+    }
+  };
+});

--- a/app/addons/documents/mango/mango.actiontypes.js
+++ b/app/addons/documents/mango/mango.actiontypes.js
@@ -10,26 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-/*
- * ::WARNING::
- * THIS IS A GENERATED FILE. DO NOT EDIT.
- */
-
-
-define([],
-function () {
-  // Provide a global location to place configuration settings and module
-  // creation.
-  var app = {
-    // The root path to run the application.
-    root: "<%= root %>",
-    version: "<%= version %>",
-    // Host is used as prefix for urls
-    host: "<%= host %>",
-    zeroClipboardPath: "<%= zeroClipboardPath %>",
-    i18n: <%= i18n %>
+define([], function () {
+  return {
+    MANGO_SET_DB: 'MANGO_SET_DB',
   };
-
-  return app;
 });
-

--- a/app/addons/documents/mango/mango.components.react.jsx
+++ b/app/addons/documents/mango/mango.components.react.jsx
@@ -1,0 +1,156 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  'app',
+  'api',
+  'react',
+  'addons/documents/mango/mango.stores',
+  'addons/documents/mango/mango.actions',
+  'addons/components/react-components.react',
+
+  'plugins/prettify'
+],
+
+function (app, FauxtonAPI, React, Stores, Actions, ReactComponents) {
+  var mangoStore = Stores.mangoStore;
+
+  var PaddedBorderedBox = ReactComponents.PaddedBorderedBox;
+  var CodeEditor = ReactComponents.CodeEditor;
+  var ConfirmButton = ReactComponents.ConfirmButton;
+
+  var HelpScreen = React.createClass({
+    render: function () {
+      return (
+        <div className="watermark-logo">
+          <h3>{this.props.title}</h3>
+          <div>
+            Create an Index to query it afterwards.<br/><br/>
+            The example on the left shows how to create an index for the field '_id'
+          </div>
+        </div>
+      );
+    }
+  });
+
+  var MangoIndexEditorController = React.createClass({
+    getInitialState: function () {
+      return this.getStoreState();
+    },
+
+    getStoreState: function () {
+      return {
+        queryCode: mangoStore.getQueryCode(),
+        database: mangoStore.getDatabase(),
+      };
+    },
+
+    onChange: function () {
+      this.setState(this.getStoreState());
+    },
+
+    componentDidMount: function () {
+      mangoStore.on('change', this.onChange, this);
+    },
+
+    componentWillUnmount: function () {
+      mangoStore.off('change', this.onChange);
+    },
+
+    render: function () {
+      return (
+        <div className="editor-wrapper span5 scrollable">
+          <PaddedBorderedBox>
+            <div className="editor-description">{this.props.description}</div>
+          </PaddedBorderedBox>
+          <PaddedBorderedBox>
+            <strong>Database</strong>
+            <div className="db-title">{this.state.database.id}</div>
+          </PaddedBorderedBox>
+          <form className="form-horizontal" onSubmit={this.saveQuery}>
+            <PaddedBorderedBox>
+              <CodeEditor
+                id="query-field"
+                ref="indexQueryEditor"
+                title={'Index'}
+                docs={false}
+                code={this.state.queryCode} />
+            </PaddedBorderedBox>
+            <div className="padded-box">
+              <div className="control-group">
+                <ConfirmButton text="Create Index" />
+              </div>
+            </div>
+          </form>
+        </div>
+      );
+    },
+
+    getEditor: function () {
+      return this.refs.indexQueryEditor.getEditor();
+    },
+
+    hasValidCode: function () {
+      var editor = this.getEditor();
+      return editor.hadValidCode();
+    },
+
+    clearNotifications: function () {
+      var editor = this.getEditor();
+      editor.editSaved();
+    },
+
+    saveQuery: function (event) {
+      event.preventDefault();
+
+      if (!this.hasValidCode()) {
+        FauxtonAPI.addNotification({
+          msg:  'Please fix the Javascript errors and try again.',
+          type: 'error',
+          clear: true
+        });
+        return;
+      }
+
+      this.clearNotifications();
+
+      Actions.saveQuery({
+        database: this.state.database,
+        queryCode: this.refs.indexQueryEditor.getValue()
+      });
+    }
+  });
+
+  var Views = {
+    renderHelpScreen: function (el) {
+      React.render(
+        <HelpScreen title={app.i18n.en_US['mango-help-title']} />,
+        el
+      );
+    },
+    removeHelpScreen: function (el) {
+      React.unmountComponentAtNode(el);
+    },
+    renderMangoIndexEditor: function (el) {
+      React.render(
+        <MangoIndexEditorController description={app.i18n.en_US['mango-descripton']} />,
+        el
+      );
+    },
+    removeMangoIndexEditor: function (el) {
+      React.unmountComponentAtNode(el);
+    },
+    MangoIndexEditorController: MangoIndexEditorController
+  };
+
+  return Views;
+});

--- a/app/addons/documents/mango/mango.stores.js
+++ b/app/addons/documents/mango/mango.stores.js
@@ -1,0 +1,63 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  'api',
+  'addons/documents/mango/mango.actiontypes'
+],
+
+function (FauxtonAPI, ActionTypes) {
+
+
+  var defaultQuery = '{\n' +
+      '  "index": {\n' +
+      '    "fields": ["_id"]\n' +
+      '  },\n' +
+      '  "type" : "json"\n' +
+      '}';
+
+  var Stores = {};
+
+  Stores.MangoStore = FauxtonAPI.Store.extend({
+
+    getQueryCode: function () {
+      return defaultQuery;
+    },
+
+    setDatabase: function (options) {
+      this._database = options.database;
+    },
+
+    getDatabase: function () {
+      return this._database;
+    },
+
+    dispatch: function (action) {
+      switch (action.type) {
+
+        case ActionTypes.MANGO_SET_DB:
+          this.setDatabase(action.options);
+          this.triggerChange();
+        break;
+
+      }
+    }
+
+  });
+
+  Stores.mangoStore = new Stores.MangoStore();
+
+  Stores.mangoStore.dispatchToken = FauxtonAPI.dispatcher.register(Stores.mangoStore.dispatch);
+
+  return Stores;
+
+});

--- a/app/addons/documents/mango/tests/mango.componentsSpec.react.jsx
+++ b/app/addons/documents/mango/tests/mango.componentsSpec.react.jsx
@@ -1,0 +1,93 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  'api',
+  'addons/documents/mango/mango.components.react',
+  'addons/documents/mango/mango.stores',
+  'addons/documents/mango/mango.actions',
+
+  'addons/documents/resources',
+  'addons/databases/resources',
+
+  'testUtils',
+  'react'
+], function (FauxtonAPI, Views, Stores, MangoActions, Resources, Databases, utils, React) {
+
+  var assert = utils.assert;
+  var TestUtils = React.addons.TestUtils;
+
+  var fakeData = [
+      {
+        ddoc: '_design/e4d338e5d6f047749f5399ab998b4fa04ba0c816',
+        def: {
+          fields: [{
+            '_id': 'asc'
+          }]
+        },
+        name: 'e4d338e5d6f047749f5399ab998b4fa04ba0c816',
+        type: 'json'
+      },
+      {
+        ddoc: null,
+        def: {
+          fields: [{
+            '_id': 'asc'
+          }]
+        },
+        name: '_all_docs',
+        type: 'special'
+      }
+    ];
+
+
+  describe('Mango IndexEditor', function () {
+    var database = new Databases.Model({id: 'testdb'}),
+        container,
+        editor;
+
+    beforeEach(function () {
+      container = document.createElement('div');
+      MangoActions.setDatabase({
+        database: database
+      });
+      $('body').append('<div id="query-field"></div>');
+    });
+
+    afterEach(function () {
+      React.unmountComponentAtNode(container);
+      $('#query-field').remove();
+    });
+
+    it('renders a default index definition', function () {
+      editor = TestUtils.renderIntoDocument(<Views.MangoIndexEditorController description="foo" />, container);
+      var $el = $(editor.getDOMNode());
+      var payload = JSON.parse($el.find('.js-editor').text());
+      assert.equal(payload.index.fields[0], '_id');
+    });
+
+    it('renders the current database', function () {
+      editor = TestUtils.renderIntoDocument(<Views.MangoIndexEditorController description="foo" />, container);
+      var $el = $(editor.getDOMNode());
+
+      assert.equal($el.find('.db-title').text(), 'testdb');
+    });
+
+    it('renders a description', function () {
+      editor = TestUtils.renderIntoDocument(<Views.MangoIndexEditorController description="CouchDB Query is great!" />, container);
+      var $el = $(editor.getDOMNode());
+
+      assert.equal($el.find('.editor-description').text(), 'CouchDB Query is great!');
+    });
+  });
+
+});

--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -20,6 +20,7 @@ define([
   'addons/documents/views-changes',
   'addons/documents/views-index',
   'addons/documents/views-doceditor',
+  'addons/documents/views-mango',
 
   'addons/databases/base',
   'addons/documents/resources',
@@ -28,7 +29,7 @@ define([
   'addons/documents/index-results/actions'
 ],
 
-function (app, FauxtonAPI, BaseRoute, Documents, Changes, Index, DocEditor,
+function (app, FauxtonAPI, BaseRoute, Documents, Changes, Index, DocEditor, Mango,
   Databases, Resources, Components, PaginationStores, IndexResultsActions) {
 
 
@@ -44,6 +45,7 @@ function (app, FauxtonAPI, BaseRoute, Documents, Changes, Index, DocEditor,
           roles: ['fx_loggedIn']
         },
         'database/:database/_changes': 'changes'
+
       },
 
       events: {
@@ -75,29 +77,6 @@ function (app, FauxtonAPI, BaseRoute, Documents, Changes, Index, DocEditor,
 
         this.addLeftHeader();
         this.addSidebar();
-      },
-
-      getAllDatabases: function () {
-        return new Databases.List();  //getAllDatabases() can be overwritten instead of hard coded into initViews
-      },
-
-      // this safely assumes the db name is valid
-      onSelectDatabase: function (dbName) {
-        this.cleanup();
-        this.initViews(dbName);
-
-        var url = FauxtonAPI.urls('allDocs', 'app',  app.utils.safeURLName(dbName), '');
-        FauxtonAPI.navigate(url, {
-          trigger: true
-        });
-
-        // we need to start listening again because cleanup() removed the listener, but in this case
-        // initialize() doesn't fire to re-set up the listener
-        this.listenToLookaheadTray();
-      },
-
-      listenToLookaheadTray: function () {
-        this.listenTo(FauxtonAPI.Events, 'lookaheadTray:update', this.onSelectDatabase);
       },
 
       designDocMetadata: function (database, ddoc) {
@@ -159,7 +138,7 @@ function (app, FauxtonAPI, BaseRoute, Documents, Changes, Index, DocEditor,
 
         IndexResultsActions.newResultsList({
           collection: collection,
-          deleteable: true
+          isListDeletable: true
         });
 
         this.database.allDocs.paging.pageSize = PaginationStores.indexPaginationStore.getPerPage();

--- a/app/addons/documents/routes-index-editor.js
+++ b/app/addons/documents/routes-index-editor.js
@@ -92,7 +92,7 @@ function (app, FauxtonAPI, Helpers, BaseRoute, Documents, Index,
 
       IndexResultsActions.newResultsList({
         collection: this.indexedDocs,
-        deleteable: false
+        isListDeletable: false
       });
 
       this.viewEditor = this.setView('#left-content', new Index.ViewEditorReact({
@@ -142,7 +142,7 @@ function (app, FauxtonAPI, Helpers, BaseRoute, Documents, Index,
       this.resultList = this.setView('#dashboard-lower-content', new Index.ViewResultListReact({}));
       IndexResultsActions.newResultsList({
         collection: [],
-        deleteable: false
+        isListDeletable: false
       });
     }
 

--- a/app/addons/documents/routes-mango.js
+++ b/app/addons/documents/routes-mango.js
@@ -1,0 +1,154 @@
+// Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  'app',
+  'api',
+
+  // Modules
+  'addons/documents/helpers',
+  'addons/documents/shared-routes',
+  'addons/documents/views-mango',
+  'addons/databases/resources',
+  'addons/fauxton/components',
+  'addons/documents/resources',
+  'addons/documents/views',
+
+
+  'addons/documents/index-results/actions',
+  'addons/documents/pagination/stores',
+
+],
+
+function (app, FauxtonAPI, Helpers, BaseRoute, Mango, Databases,
+  Components, Resources, Documents, IndexResultsActions, PaginationStores) {
+
+  var MangoIndexList = BaseRoute.extend({
+    layout: 'with_tabs_sidebar',
+    routes: {
+      'database/:database/_indexlist(:extra)': {
+        route: 'mangoIndexList',
+        roles: ['fx_loggedIn']
+      },
+
+    },
+
+    establish: function () {
+      return [
+        this.designDocs.fetch({reset: true}),
+        this.allDatabases.fetchOnce()
+      ];
+    },
+
+    initialize: function (route, masterLayout, options) {
+      var databaseName = options[0];
+      this.databaseName = databaseName;
+      this.database = new Databases.Model({id: databaseName});
+
+      // magic methods
+      this.allDatabases = this.getAllDatabases();
+      this.createDesignDocsCollection();
+      this.addLeftHeader();
+      this.addSidebar();
+
+      this.rightHeader = this.setView('#right-header', new Documents.Views.RightAllDocsHeader({
+        database: this.database
+      }));
+    },
+
+    mangoIndexList: function () {
+      var params = this.createParams(),
+          urlParams = params.urlParams,
+          mangoIndexCollection = new Resources.MangoIndexCollection(null, {
+            database: this.database,
+            params: null,
+            paging: {
+              pageSize: PaginationStores.indexPaginationStore.getPerPage()
+            }
+          });
+
+      this.viewEditor && this.viewEditor.remove();
+      this.headerView && this.headerView.remove();
+
+      this.sidebar.setSelectedTab('mango-indexes');
+
+      IndexResultsActions.newResultsList({
+        collection: mangoIndexCollection,
+        isListDeletable: false
+      });
+
+      this.reactHeader = this.setView('#react-headerbar', new Documents.Views.ReactHeaderbar());
+
+      this.leftheader.updateCrumbs(this.getCrumbs(this.database));
+      this.rightHeader.hideQueryOptions();
+
+      this.resultList = this.setView('#dashboard-lower-content', new Mango.MangoIndexListReact());
+
+      this.apiUrl = function () {
+        return [mangoIndexCollection.urlRef(urlParams), FauxtonAPI.constants.DOC_URLS.GENERAL];
+      };
+    }
+  });
+
+  var MangoIndexEditorAndResults = BaseRoute.extend({
+    layout: 'two_pane',
+    routes: {
+      'database/:database/_index': {
+        route: 'createIndex',
+        roles: ['fx_loggedIn']
+      }
+    },
+
+    initialize: function (route, masterLayout, options) {
+      var databaseName = options[0];
+
+      this.databaseName = databaseName;
+      this.database = new Databases.Model({id: databaseName});
+    },
+
+    createIndex: function (database) {
+      var params = this.createParams(),
+          urlParams = params.urlParams,
+          mangoIndexCollection = new Resources.MangoIndexCollection(null, {
+            database: this.database
+          });
+
+      IndexResultsActions.newResultsList({
+        collection: mangoIndexCollection,
+        isListDeletable: false
+      });
+
+      this.breadcrumbs = this.setView('#breadcrumbs', new Components.Breadcrumbs({
+        toggleDisabled: true,
+        crumbs: [
+          {'type': 'back', 'link': Helpers.getPreviousPage(this.database)},
+          {'name': 'Create new index', 'link': Databases.databaseUrl(this.database) }
+        ]
+      }));
+
+      this.resultList = this.setView('#dashboard-lower-content', new Mango.HelpScreen());
+
+      this.mangoEditor = this.setView('#left-content', new Mango.MangoIndexEditorReact({
+        database: this.database
+      }));
+
+      this.apiUrl = function () {
+        return [mangoIndexCollection.urlRef(urlParams), FauxtonAPI.constants.DOC_URLS.GENERAL];
+      };
+    }
+  });
+
+  return {
+    MangoIndexEditorAndResults: MangoIndexEditorAndResults,
+    MangoIndexList: MangoIndexList
+  };
+});

--- a/app/addons/documents/routes.js
+++ b/app/addons/documents/routes.js
@@ -14,16 +14,19 @@ define([
   "addons/documents/views",
   "addons/documents/routes-documents",
   'addons/documents/routes-doc-editor',
-  'addons/documents/routes-index-editor'
+  'addons/documents/routes-index-editor',
+  'addons/documents/routes-mango'
 ],
 
-function (Documents, DocumentsRouteObject, docEditor, IndexEditorRouteObject) {
 
+function (Documents, DocumentsRouteObject, docEditor, IndexEditorRouteObject, Mango) {
   Documents.RouteObjects = [
     docEditor.DocEditorRouteObject,
     docEditor.NewDocEditorRouteObject,
     DocumentsRouteObject,
-    IndexEditorRouteObject
+    IndexEditorRouteObject,
+    Mango.MangoIndexList,
+    Mango.MangoIndexEditorAndResults
   ];
 
   return Documents;

--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -57,6 +57,10 @@ define([
       return this.id && this.id.match(/^_design\//) ? "design doc" : "doc";
     },
 
+    isDeletable: function () {
+      return true;
+    },
+
     isFromView: function () {
       return !this.id;
     },
@@ -213,6 +217,10 @@ define([
       if (!this.params.limit) {
         this.params.limit = this.perPageLimit;
       }
+    },
+
+    isEditable: function () {
+      return true;
     },
 
     urlRef: function (context, params) {

--- a/app/addons/documents/shared-routes.js
+++ b/app/addons/documents/shared-routes.js
@@ -43,6 +43,28 @@ define([
       });
     },
 
+    onSelectDatabase: function (dbName) {
+      this.cleanup();
+      this.initViews(dbName);
+
+      var url = FauxtonAPI.urls('allDocs', 'app',  app.utils.safeURLName(dbName), '');
+      FauxtonAPI.navigate(url, {
+        trigger: true
+      });
+
+      // we need to start listening again because cleanup() removed the listener, but in this case
+      // initialize() doesn't fire to re-set up the listener
+      this.listenToLookaheadTray();
+    },
+
+    listenToLookaheadTray: function () {
+      this.listenTo(FauxtonAPI.Events, 'lookaheadTray:update', this.onSelectDatabase);
+    },
+
+    getAllDatabases: function () {
+      return new Databases.List();  //getAllDatabases() can be overwritten instead of hard coded into initViews
+    },
+
     showQueryOptions: function (urlParams, ddoc, viewName) {
       var promise = this.designDocs.fetch({reset: true}),
       that = this,

--- a/app/addons/documents/shared-views.js
+++ b/app/addons/documents/shared-views.js
@@ -118,6 +118,11 @@ function (app, FauxtonAPI, Components, Documents, Databases) {
       this.designDocList = [];
 
       this.collection.each(function (design) {
+
+        if (design.get('doc').language === 'query') {
+          return;
+        }
+
         if (design.has('doc')) {
           design.collection = this.collection;
           var view = this.insertView(new Views.DdocSidenav({

--- a/app/addons/documents/tests/headerSpec.react.jsx
+++ b/app/addons/documents/tests/headerSpec.react.jsx
@@ -83,7 +83,7 @@ define([
 
       IndexResultsActions.newResultsList({
         collection: database.allDocs,
-        deleteable: false
+        isListDeletable: false
       });
 
 

--- a/app/addons/documents/tests/nightwatch/mangoIndex.js
+++ b/app/addons/documents/tests/nightwatch/mangoIndex.js
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+
+  'Creating new indexes with mango': function (client) {
+    /*jshint multistr: true */
+    var waitTime = 10000,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .populateDatabase(newDatabaseName)
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_index')
+      .waitForElementPresent('.watermark-logo', waitTime, false)
+      .assert.containsText('.watermark-logo', 'Mango')
+      .assert.containsText('.editor-description', 'is an easy way to find documents on predefined indexes')
+      .execute('\
+        var json = \'{\
+          "index": {\
+            "fields": ["ente_ente_mango"]\
+          },\
+          "name": "rocko-artischocko",\
+          "type" : "json"\
+        }\';\
+        var editor = ace.edit("query-field");\
+        editor.getSession().setValue(json);\
+      ')
+      .execute('$(".save")[0].scrollIntoView();')
+      .click('button.btn-success.save')
+
+      .waitForElementNotVisible('.global-notification', waitTime, false)
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_indexlist')
+      .waitForElementPresent('.prettyprint', waitTime, false)
+      .assert.containsText('#dashboard-lower-content', 'ente_ente_mango')
+    .end();
+  }
+};

--- a/app/addons/documents/tests/nightwatch/mangoIndexList.js
+++ b/app/addons/documents/tests/nightwatch/mangoIndexList.js
@@ -1,0 +1,29 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+
+  'Creating new indexes with mango': function (client) {
+    var waitTime = 10000,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .populateDatabase(newDatabaseName)
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_indexlist')
+      .waitForElementPresent('.prettyprint', waitTime, false)
+      .assert.containsText('.header-doc-id', '_all_docs')
+      .assert.containsText('#doc-list', 'ente_ente_mango_ananas')
+    .end();
+  }
+};

--- a/app/addons/documents/tests/resourcesSpec.js
+++ b/app/addons/documents/tests/resourcesSpec.js
@@ -71,21 +71,110 @@ define([
     });
   });
 
-  describe('AllDocs', function () {
+  describe('MangoIndex', function () {
+    var doc;
+
+    it('is deleteable', function () {
+      var index = {
+        ddoc: null,
+        name: '_all_docs',
+        type: 'json',
+        def: {fields: [{_id: 'asc'}]}
+      };
+      doc = new Models.MangoIndex(index, {});
+
+      assert.ok(doc.isDeletable());
+    });
+
+    it('special docs are not deleteable', function () {
+      var index = {
+        ddoc: null,
+        name: '_all_docs',
+        type: 'special',
+        def: {fields: [{_id: 'asc'}]}
+      };
+      doc = new Models.MangoIndex(index, {});
+
+      assert.notOk(doc.isDeletable());
+    });
+  });
+
+  describe('MangoIndexCollection', function () {
     var collection;
-    beforeEach(function () {
-      collection = new Models.AllDocs([{
-        _id:'myId1',
+
+    it('is not editable', function () {
+      collection = new Models.MangoIndexCollection([{
+        name: 'myId1',
         doc: 'num1'
       },
       {
-        _id:'myId2',
+        name: 'myId2',
         doc: 'num2'
       }], {
         database: {id: 'databaseId', safeID: function () { return this.id; }},
         params: {limit: 20}
       });
 
+      assert.notOk(collection.isEditable());
+    });
+  });
+
+
+  describe('IndexCollection', function () {
+    var collection;
+
+    it('design docs are editable', function () {
+      collection = new Models.IndexCollection([{
+        _id: 'myId1',
+        doc: 'num1'
+      },
+      {
+        _id: 'myId2',
+        doc: 'num2'
+      }], {
+        database: {id: 'databaseId', safeID: function () { return this.id; }},
+        params: {limit: 20},
+        design: '_design/foobar'
+      });
+
+      assert.ok(collection.isEditable());
+    });
+
+    it('reduced design docs are NOT editable', function () {
+      collection = new Models.IndexCollection([{
+        _id: 'myId1',
+        doc: 'num1'
+      },
+      {
+        _id: 'myId2',
+        doc: 'num2'
+      }], {
+        database: {id: 'databaseId', safeID: function () { return this.id; }},
+        params: {limit: 20, reduce: true},
+        design: '_design/foobar'
+      });
+
+      assert.notOk(collection.isEditable());
+    });
+  });
+
+  describe('AllDocs', function () {
+    var collection;
+
+    it('all-docs-list documents are always editable', function () {
+      collection = new Models.AllDocs([{
+        _id: 'myId1',
+        doc: 'num1'
+      },
+      {
+        _id: 'myId2',
+        doc: 'num2'
+      }], {
+        database: {id: 'databaseId', safeID: function () { return this.id; }},
+        params: {limit: 20}
+      });
+
+      assert.ok(collection.isEditable());
     });
   });
 

--- a/app/addons/documents/views-mango.js
+++ b/app/addons/documents/views-mango.js
@@ -1,0 +1,66 @@
+// Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  'api',
+  'addons/documents/mango/mango.components.react',
+  'addons/documents/mango/mango.actions',
+  'addons/documents/index-results/index-results.components.react'
+],
+
+function (FauxtonAPI, Mango, MangoActions, ViewResultList) {
+
+  var Views = {};
+
+
+  Views.HelpScreen = FauxtonAPI.View.extend({
+
+    afterRender: function () {
+      Mango.renderHelpScreen(this.el);
+    },
+
+    cleanup: function () {
+      Mango.removeHelpScreen(this.el);
+    }
+  });
+
+  Views.MangoIndexListReact = FauxtonAPI.View.extend({
+
+    afterRender: function () {
+      ViewResultList.renderViewResultList(this.el);
+    },
+
+    cleanup: function () {
+      ViewResultList.removeViewResultList(this.el);
+    }
+  });
+
+  Views.MangoIndexEditorReact = FauxtonAPI.View.extend({
+    initialize: function (options) {
+      this.database = options.database;
+    },
+
+    afterRender: function () {
+      MangoActions.setDatabase({
+        database: this.database
+      });
+
+      Mango.renderMangoIndexEditor(this.el);
+    },
+
+    cleanup: function () {
+      Mango.removeMangoIndexEditor(this.el);
+    }
+  });
+
+  return Views;
+});

--- a/i18n.json.default
+++ b/i18n.json.default
@@ -1,0 +1,8 @@
+{
+  "en_US": {
+    "mango-descripton": "Mango is an easy way to find documents on predefined indexes.",
+    "all-mango-indexes": "All Mango Indexes",
+    "new-mango-index": "New Mango Index",
+    "mango-help-title": "Mango"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "nano": "~5.12.0",
     "nightwatch": "~0.5.33",
     "react-tools": "^0.12.0",
+    "request": "^2.54.0",
     "send": "~0.1.1",
     "underscore": "~1.4.2",
     "url": "~0.7.9",

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -92,12 +92,11 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask('gen_initialize', 'Generate the app.js file', function () {
     var _ = grunt.util._,
-      settings = this.data,
-      template = "app/initialize.js.underscore",
-      dest = "app/initialize.js",
-      tmpl = _.template(grunt.file.read(template)),
-      app = {};
-
+        settings = this.data,
+        template = "app/initialize.js.underscore",
+        dest = "app/initialize.js",
+        tmpl = _.template(grunt.file.read(template)),
+        app = {};
 
     _.defaults(app, settings.app, {
       root: '/',

--- a/tasks/helper.js
+++ b/tasks/helper.js
@@ -28,6 +28,17 @@ exports.init = function (grunt) {
       }
     },
 
+    readI18nFile: function () {
+      if (fs.existsSync('i18n.json')) {
+        return grunt.file.readJSON('i18n.json');
+      }
+      if (fs.existsSync('i18n.json.default')) {
+        return grunt.file.readJSON('i18n.json.default');
+      }
+
+      throw new Error('i18n file missing');
+    },
+
     processAddons: function (callback) {
       this.readSettingsFile().deps.forEach(callback);
     },

--- a/test/nightwatch_tests/custom-commands/populateDatabase.js
+++ b/test/nightwatch_tests/custom-commands/populateDatabase.js
@@ -13,7 +13,8 @@
 var util = require('util'),
     events = require('events'),
     helpers = require('../helpers/helpers.js'),
-    async = require('async');
+    async = require('async'),
+    request = require('request');
 
 function PopulateDatabase () {
   events.EventEmitter.call(this);
@@ -56,7 +57,9 @@ PopulateDatabase.prototype.command = function (databaseName, count) {
 
         createKeyView(null, function () {
           createBrokenView(null, function () {
-            that.emit('complete');
+            createMangoIndex(null, function () {
+              that.emit('complete');
+            });
           });
         });
       });
@@ -97,6 +100,29 @@ PopulateDatabase.prototype.command = function (databaseName, count) {
       cb();
     });
   }
+
+  function createMangoIndex (err, cb) {
+    request({
+      uri: helpers.test_settings.db_url + '/' + databaseName + '/_index',
+      method: 'POST',
+      json: true,
+      body: {
+        index: {
+          fields: ['ente_ente_mango_ananas']
+        },
+        name: 'rocko-artischockbert',
+        type: 'json'
+      }
+    }, function (err, res, body) {
+      if (err) {
+        console.log('Error in nano populateDatabase Function: ' +
+          err.message);
+      }
+
+      cb && cb();
+    });
+  }
+
   return this;
 };
 


### PR DESCRIPTION
Part 1/2 for Mango:

Creation of Mango indexes and listing them. Disabled pagination
and bulk-deletion for now, see:

https://issues.apache.org/jira/browse/COUCHDB-2651
https://issues.apache.org/jira/browse/COUCHDB-2652

As you can't use the feature right now (querying is part 2/2)
the buttons to reach the features are hidden behind a feature flip.

Use the direct urls to access the features:

http://localhost:8000/#database/$YOUR_DATABASE/_index
http://localhost:8000/#database/$YOUR_DATABASE/_indexlist

or add `?beta=showquery` to your url, e.g.

http://localhost:8000/#database/$YOUR_DATABASE/_all_docs?beta=showquery

Additionally prepares the app for i18n.

COUCHDB-2627