### PR TITLE
Gruntfile fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,7 +125,9 @@ module.exports = function (grunt) {
     var i18n = JSON.stringify(helper.readI18nFile(), null, ' ');
 
     ['development', 'release', 'couchapp'].forEach(function (key) {
-      settings.template[key].app.i18n = i18n;
+      if (key in settings.template) {
+        settings.template[key].app.i18n = i18n;
+      }
     });
 
     return settings.template || defaultSettings;


### PR DESCRIPTION
A recent commit assumes the template always has a certain structure;
this just adds a check to only set i18n for elements that exist.