### PR TITLE
sidebar: fix collapsible for special chars

### DIFF
--- a/app/addons/documents/shared-views.js
+++ b/app/addons/documents/shared-views.js
@@ -17,7 +17,8 @@ define([
        "addons/fauxton/components",
 
        "addons/documents/resources",
-       "addons/databases/resources"
+       "addons/databases/resources",
+       "css.escape"
 ],
 
 function (app, FauxtonAPI, Components, Documents, Databases) {
@@ -168,9 +169,14 @@ function (app, FauxtonAPI, Components, Documents, Databases) {
       "click .js-collapse-toggle": "toggleArrow"
     },
 
-    toggleArrow:  function (e) {
-      this.$(e.currentTarget).toggleClass("down");
+    toggleArrow: function (e) {
+      var escapedId = window.CSS.escape(e.currentTarget.id),
+          $toggleElement = this.$('#' + escapedId).next();
+
+      this.$('#' + escapedId).toggleClass('down');
+      $toggleElement.collapse('toggle');
     },
+
     buildIndexList: function (designDocs, info) {
       var design = this.model.id.replace(/^_design\//, "");
       var databaseId = this.model.database.id;
@@ -188,13 +194,14 @@ function (app, FauxtonAPI, Components, Documents, Databases) {
 
     serialize: function () {
       var ddocName = this.model.id.replace(/^_design\//, ""),
+          escapedId = window.CSS.escape(ddocName),
           docSafe = app.utils.safeURLName(ddocName),
           databaseName = this.collection.database.safeID();
 
       return {
         designDocMetaUrl: FauxtonAPI.urls('designDocs', 'app', databaseName, docSafe),
         designDoc: ddocName,
-        ddoc_clean: docSafe,
+        escapedId: escapedId
       };
     },
 

--- a/app/addons/documents/templates/design_doc_menu.html
+++ b/app/addons/documents/templates/design_doc_menu.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,19 +10,19 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
+*/%>
 <li class="nav-header">
 
-<div class="js-collapse-toggle accordion-header" data-toggle="collapse" data-target="#<%- ddoc_clean %>" id="nav-header-<%- ddoc_clean %>" >
+<div class="js-collapse-toggle accordion-header" id="nav-header-<%- escapedId %>" >
   <div class="accordion-list-item">
     <div class="fonticon-play"></div>
     <p class="design-doc-name"><span title="_design/<%- designDoc%>">_design/<%- designDoc%></span></p>
   </div>
   <div class="new-button add-dropdown"></div>
 </div>
-<ul class="accordion-body collapse" id="<%- ddoc_clean %>">
+<ul class="accordion-body collapse <%- escapedId %>" id="<%- escapedId %>">
   <li>
-  <a id="<%- ddoc_clean %>_metadata" href="#/<%- designDocMetaUrl %>" class="toggle-view accordion-header">
+  <a id="<%- escapedId %>_metadata" href="#/<%- designDocMetaUrl %>" class="toggle-view accordion-header">
     <span class="fonticon-sidenav-info fonticon"></span>
     Design Doc Metadata
   </a>

--- a/app/addons/documents/tests/nightwatch/checkSidebarBehavior.js
+++ b/app/addons/documents/tests/nightwatch/checkSidebarBehavior.js
@@ -1,0 +1,35 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+
+  'Checks if design docs that have a dot symbol in the id show up in the UI': function (client) {
+    var waitTime = 10000,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .createDocument('_design/ddoc_normal', newDatabaseName)
+      .createDocument('_design/ddoc.with.specialcharacters', newDatabaseName)
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .waitForElementPresent('.nav-list', waitTime, false)
+      .assert.hidden('a[href="#/database/' + newDatabaseName + '/_design/ddoc_normal/_info"]')
+      .assert.hidden('a[href="#/database/' + newDatabaseName + '/_design/ddoc.with.specialcharacters/_info"]')
+
+      .clickWhenVisible('#nav-header-ddoc_normal')
+      .assert.visible('a[href="#/database/' + newDatabaseName + '/_design/ddoc_normal/_info"]')
+      .clickWhenVisible('[title="_design/ddoc.with.specialcharacters"]')
+      .assert.visible('a[href="#/database/' + newDatabaseName + '/_design/ddoc.with.specialcharacters/_info"]')
+    .end();
+  }
+};

--- a/app/addons/documents/tests/nightwatch/viewCreate.js
+++ b/app/addons/documents/tests/nightwatch/viewCreate.js
@@ -63,7 +63,7 @@ var tests = {
     var waitTime = client.globals.maxWaitTime;
     /*jshint multistr: true */
 
-    openDifferentDropdownsAndClick(client, '[data-target="#testdesigndoc"]')
+    openDifferentDropdownsAndClick(client, '#nav-header-testdesigndoc')
       .clearValue('#index-name')
       .setValue('#index-name', 'test-new-view')
       .execute('\
@@ -77,7 +77,7 @@ var tests = {
       })
       //go back to all docs
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
-      .clickWhenVisible('[data-target="#testdesigndoc"]', waitTime, false)
+      .clickWhenVisible('#nav-header-testdesigndoc', waitTime, false)
       .clickWhenVisible('[data-target="#testdesigndocviews"]', waitTime, false)
       .clickWhenVisible('#testdesigndoc_testnewview', waitTime, false)
       .waitForElementPresent('.prettyprint', waitTime, false)

--- a/app/config.js
+++ b/app/config.js
@@ -36,6 +36,7 @@ require.config({
     react: "../assets/js/libs/react",
     flux: "../assets/js/libs/flux",
     "es5-shim": "../assets/js/libs/es5-shim",
+    "css.escape": "../assets/js/libs/css.escape",
     moment: '../assets/js/libs/moment'
   },
 

--- a/assets/js/libs/css.escape.js
+++ b/assets/js/libs/css.escape.js
@@ -1,0 +1,84 @@
+/*! https://mths.be/cssescape v0.2.1 by @mathias | MIT license */
+;(function(root) {
+
+	if (!root.CSS) {
+		root.CSS = {};
+	}
+
+	var CSS = root.CSS;
+
+	var InvalidCharacterError = function(message) {
+		this.message = message;
+	};
+	InvalidCharacterError.prototype = new Error;
+	InvalidCharacterError.prototype.name = 'InvalidCharacterError';
+
+	if (!CSS.escape) {
+		// http://dev.w3.org/csswg/cssom/#serialize-an-identifier
+		CSS.escape = function(value) {
+			var string = String(value);
+			var length = string.length;
+			var index = -1;
+			var codeUnit;
+			var result = '';
+			var firstCodeUnit = string.charCodeAt(0);
+			while (++index < length) {
+				codeUnit = string.charCodeAt(index);
+				// Note: there’s no need to special-case astral symbols, surrogate
+				// pairs, or lone surrogates.
+
+				// If the character is NULL (U+0000), then throw an
+				// `InvalidCharacterError` exception and terminate these steps.
+				if (codeUnit == 0x0000) {
+					throw new InvalidCharacterError(
+						'Invalid character: the input contains U+0000.'
+					);
+				}
+
+				if (
+					// If the character is in the range [\1-\1F] (U+0001 to U+001F) or is
+					// U+007F, […]
+					(codeUnit >= 0x0001 && codeUnit <= 0x001F) || codeUnit == 0x007F ||
+					// If the character is the first character and is in the range [0-9]
+					// (U+0030 to U+0039), […]
+					(index == 0 && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+					// If the character is the second character and is in the range [0-9]
+					// (U+0030 to U+0039) and the first character is a `-` (U+002D), […]
+					(
+						index == 1 &&
+						codeUnit >= 0x0030 && codeUnit <= 0x0039 &&
+						firstCodeUnit == 0x002D
+					)
+				) {
+					// http://dev.w3.org/csswg/cssom/#escape-a-character-as-code-point
+					result += '\\' + codeUnit.toString(16) + ' ';
+					continue;
+				}
+
+				// If the character is not handled by one of the above rules and is
+				// greater than or equal to U+0080, is `-` (U+002D) or `_` (U+005F), or
+				// is in one of the ranges [0-9] (U+0030 to U+0039), [A-Z] (U+0041 to
+				// U+005A), or [a-z] (U+0061 to U+007A), […]
+				if (
+					codeUnit >= 0x0080 ||
+					codeUnit == 0x002D ||
+					codeUnit == 0x005F ||
+					codeUnit >= 0x0030 && codeUnit <= 0x0039 ||
+					codeUnit >= 0x0041 && codeUnit <= 0x005A ||
+					codeUnit >= 0x0061 && codeUnit <= 0x007A
+				) {
+					// the character itself
+					result += string.charAt(index);
+					continue;
+				}
+
+				// Otherwise, the escaped character.
+				// http://dev.w3.org/csswg/cssom/#escape-a-character
+				result += '\\' + string.charAt(index);
+
+			}
+			return result;
+		};
+	}
+
+}(typeof global != 'undefined' ? global : this));


### PR DESCRIPTION
fix collapsible for design docs with special chars in their name,
like `_design////design//foo` or `_design/bar.foo.bar`

internally sizzle works with `querySelectorAll` which needs
escaping for special chars in css selectors.

based on a patch from Michelle Phung <michellephung@gmail.com>