### PR TITLE
Allow customization of View loading spinners

### DIFF
--- a/app/addons/documents/views-doceditor.js
+++ b/app/addons/documents/views-doceditor.js
@@ -209,8 +209,10 @@ function (app, FauxtonAPI, Components, Documents, Databases, prettify) {
       'click a.js-back': 'onClickGoBack',
       'click .code-region': 'focusOnLastLine'
     },
-
-    disableLoader: true,
+    loaderStyles: {
+      color: '#ffffff',
+      opacity: 0.15
+    },
 
     initialize: function (options) {
       this.database = options.database;

--- a/app/addons/fauxton/components.js
+++ b/app/addons/fauxton/components.js
@@ -990,7 +990,7 @@ function (app, FauxtonAPI, ace, spin, ZeroClipboard) {
     removeRouteObjectSpinner();
 
     if (!view.disableLoader) {
-      var opts = {
+      var opts = _.extend({
         lines: 16, // The number of lines to draw
         length: 8, // The length of each line
         width: 4, // The line thickness
@@ -999,7 +999,7 @@ function (app, FauxtonAPI, ace, spin, ZeroClipboard) {
         speed: 1, // Rounds per second
         trail: 10, // Afterglow percentage
         shadow: false // Whether to render a shadow
-      };
+      }, view.loaderStyles);
 
       var viewSpinner = new Spinner(opts).spin();
       $('<div class="spinner"></div>')


### PR DESCRIPTION
By default, the core Fauxton code inserts a spinner for each view
while it's loading. This can be removed via the `disableLoader` param
but not customized. This PR lets you define an optional
`loaderStyles` property on your view to override the styles. The
use-case here is to provide a light-coloured loader on the dark-
background Doc Editor page.

I investigated using the new React spinner, but ran into problems
targeting views that weren't loaded yet in the page load lifecycle.
This seemed like a very elegant solution that tapped into what we 
already had.