### PR TITLE
test: remove confirmdialog

### DIFF
--- a/app/addons/cors/tests/componentsSpec.react.jsx
+++ b/app/addons/cors/tests/componentsSpec.react.jsx
@@ -172,9 +172,11 @@ define([
       });
 
       it('should confirm on delete', function () {
-        var spy = sinon.spy(window, 'confirm');
+        var stub = sinon.stub(window, 'confirm');
+        stub.returns(true);
+
         TestUtils.Simulate.click($(originTableEl.getDOMNode()).find('.fonticon-trash')[0]);
-        assert.ok(spy.calledOnce);
+        assert.ok(stub.calledOnce);
       });
 
       it('should deleteOrigin on confirm true', function () {


### PR DESCRIPTION
when running the testsuite in the browser tests were stopped unti
confirming with `OK`