### PR TITLE
Docs now fully collapse to single line

### DIFF
--- a/app/addons/components/react-components.react.jsx
+++ b/app/addons/components/react-components.react.jsx
@@ -249,6 +249,16 @@ function (app, FauxtonAPI, React, Components, beautifyHelper) {
       this.props.onDoubleClick(this.props.docIdentifier, this.props.doc, e);
     },
 
+    getDocContent: function () {
+      if (!_.isEmpty(this.props.docContent)) {
+        return (
+          <div className="doc-data">
+            <pre className="prettyprint">{this.props.docContent}</pre>
+          </div>
+        );
+      }
+    },
+
     render: function () {
       return (
         <div data-id={this.props.docIdentifier} onDoubleClick={this.onDoubleClick} className="doc-row">
@@ -266,9 +276,7 @@ function (app, FauxtonAPI, React, Components, beautifyHelper) {
               {this.getUrlFragment()}
               <div className="doc-item-extension-icons pull-right">{this.getExtensionIcons()}</div>
             </header>
-            <div className="doc-data">
-              <pre className="prettyprint">{this.props.docContent}</pre>
-            </div>
+            {this.getDocContent()}
           </div>
           <div className="clearfix"></div>
         </div>

--- a/app/addons/components/tests/docSpec.react.jsx
+++ b/app/addons/components/tests/docSpec.react.jsx
@@ -98,6 +98,22 @@ define([
       assert.notOk($(el.getDOMNode()).find('input[type="checkbox"]').length);
       assert.ok($(el.getDOMNode()).find('.checkbox-dummy').length);
     });
+
+    it('contains a doc-data element when there\'s doc content', function () {
+      el = TestUtils.renderIntoDocument(
+        <ReactComponents.Document isDeletable={true} checked={true} docIdentifier="foo" docContent='{ "content": true }' />,
+        container
+      );
+      assert.equal(1, $(el.getDOMNode()).find('.doc-data').length);
+    });
+
+    it('doesn\'t contain a doc-data element when there\'s no doc content', function () {
+      el = TestUtils.renderIntoDocument(
+        <ReactComponents.Document isDeletable={true} checked={true} docIdentifier="foo" docContent='' />,
+        container
+      );
+      assert.equal(0, $(el.getDOMNode()).find('.doc-data').length);
+    });
   });
 
 });

--- a/app/addons/documents/index-results/index-results.components.react.jsx
+++ b/app/addons/documents/index-results/index-results.components.react.jsx
@@ -150,7 +150,6 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents) {
 
       if (this.state.hasResults) {
         view = <ResultsScreen
-          isCollapsed={this.isCollapsed}
           isSelected={this.isSelected}
           isEditable={this.state.isEditable}
           isListDeletable={this.state.isListDeletable}

--- a/app/addons/documents/index-results/stores.js
+++ b/app/addons/documents/index-results/stores.js
@@ -80,15 +80,7 @@ function (FauxtonAPI, ActionTypes, HeaderActionTypes, Documents) {
 
     getDocContent: function (originalDoc) {
       var doc = originalDoc.toJSON();
-
-      if (this.isCollapsed(doc._id)) {
-        doc = {
-          _id: _.isUndefined(doc._id),
-          _rev: doc._rev
-        };
-      }
-
-      return JSON.stringify(doc, null, "  ");
+      return (this.isCollapsed(doc._id)) ? '' : JSON.stringify(doc, null, ' ');
     },
 
     getDocId: function (doc) {
@@ -112,7 +104,7 @@ function (FauxtonAPI, ActionTypes, HeaderActionTypes, Documents) {
           keylabel: doc.isFromView() ? 'key' : 'id',
           url: doc.isFromView() ? doc.url('app') : doc.url('web-index'),
           isDeletable: this.isDeletable(doc),
-          isEditable: this.isEditable(doc),
+          isEditable: this.isEditable(doc)
         };
       }, this);
     },

--- a/app/addons/documents/index-results/tests/index-results.storesSpec.js
+++ b/app/addons/documents/index-results/tests/index-results.storesSpec.js
@@ -169,7 +169,7 @@ define([
       assert.equal(JSON.parse(result).value, 'one');
     });
 
-    it('returns collapsed doc if collapsed', function () {
+    it('returns no doc content if collapsed', function () {
       store._collection = new Documents.AllDocs([{_id: 'testId1', 'value': 'one'}] , {
         params: {},
         database: {
@@ -181,7 +181,7 @@ define([
       store._collapsedDocs = {'testId1': true};
       var result = store.getDocContent(doc);
 
-      assert.ok(_.isUndefined(JSON.parse(result).value));
+      assert.equal('', result);
     });
 
   });


### PR DESCRIPTION
This reduces selected documents to a single line containing
only the ID, rather than show a subset of the doc with an ID
and rev.

Closes COUCHDB-2548