### PR TITLE
Prevent overlap of text and arrows in styled-select

### DIFF
--- a/app/addons/components/assets/less/styled-select.less
+++ b/app/addons/components/assets/less/styled-select.less
@@ -24,10 +24,10 @@
   appearance: none;
   background-color: #e6e6e6;
   border: 1px solid #b3b3b3;
-  height: 45px;
   width: 200px;
   text-indent: 4px;
   height: 46px;
+  padding-right: 35px;
 }
 
 .styled-select select:-moz-focusring {


### PR DESCRIPTION
Super minor thing. If an option in a styled select box
(.styled-select) is quite long, it will overlap the down arrow
overlay which looks kind of bad. Unfortunately browsers are
limited in that you can't put an ellipsis, so this just adds
padding instead to cut off the text, which still looks a lot
better.