### PR TITLE
Delete doc msg tweaks

### DIFF
--- a/app/addons/documents/index-results/actions.js
+++ b/app/addons/documents/index-results/actions.js
@@ -117,9 +117,15 @@ function (app, FauxtonAPI, ActionTypes, Stores, HeaderStores, HeaderActions, Doc
 
     deleteSelected: function () {
       var itemsLength = indexResultsStore.getSelectedItemsLength();
-      var msg = "Are you sure you want to delete these " + itemsLength + " docs?";
+      var msg = (itemsLength === 1) ? 'Are you sure you want to delete this doc?' :
+        'Are you sure you want to delete these ' + itemsLength + ' docs?';
 
-      if (itemsLength === 0 || !window.confirm(msg)) {
+      if (itemsLength === 0) {
+        window.alert('Please select the document rows you want to delete.');
+        return false;
+      }
+
+      if (!window.confirm(msg)) {
         return false;
       }
 


### PR DESCRIPTION
Two small changes:
- the alert message has correct English when there's a single row
selected
- when nothing is selected, it alerts the user to let them know
they need to select one or more rows