### PR TITLE
hasDataSize() method added to Databases.Status

### DIFF
--- a/app/addons/databases/resources.js
+++ b/app/addons/databases/resources.js
@@ -158,6 +158,12 @@ function (app, FauxtonAPI, Documents) {
       } else {
         return 0;
       }
+    },
+
+    // a sure-fire way to know when the DB size info is actually available; dataSize() may return 0 before or after
+    // the data has been loaded
+    hasDataSize: function () {
+      return this.get('other') || this.get('data_size') || this.get('disk_size');
     }
   });
 


### PR DESCRIPTION
Just a helper function because dataSize() didn't provide enough info.