### PR TITLE
ESC key closes any open notification

### DIFF
--- a/app/addons/fauxton/base.js
+++ b/app/addons/fauxton/base.js
@@ -154,10 +154,26 @@ function (app, FauxtonAPI, Components, NavbarReactComponents, NavigationActions,
       this.removeWithAnimation();
     },
 
-    removeWithAnimation: function (event) {
+    removeWithAnimation: function () {
       this.$el.velocity('reverse', FauxtonAPI.constants.MISC.TRAY_TOGGLE_SPEED, function () {
         this.$el.remove();
+        this.removeCloseListener();
       }.bind(this));
+    },
+
+    addCloseListener: function () {
+      $(document).on('keydown.notificationClose', this.onKeyDown.bind(this));
+    },
+
+    onKeyDown: function (e) {
+      var code = e.keyCode || e.which;
+      if (code === 27) { // ESC key
+        this.removeWithAnimation();
+      }
+    },
+
+    removeCloseListener: function () {
+      $(document).off('keydown.notificationClose', this.removeWithAnimation);
     },
 
     delayedRemoval: function () {
@@ -174,6 +190,7 @@ function (app, FauxtonAPI, Components, NavbarReactComponents, NavigationActions,
       this.render().$el.appendTo(selector);
       this.$el.velocity('transition.slideDownIn', FauxtonAPI.constants.MISC.TRAY_TOGGLE_SPEED);
       this.delayedRemoval();
+      this.addCloseListener();
       return this;
     }
   });

--- a/app/addons/fauxton/tests/baseSpec.js
+++ b/app/addons/fauxton/tests/baseSpec.js
@@ -121,5 +121,21 @@ define([
       delete window.fauxton_xss_test2_escaped;
     });
 
+    it('should close notification when ESCAPE key used', function () {
+      var notification = FauxtonAPI.addNotification({
+        msg: 'Close me!',
+        selector: 'body'
+      });
+      var removeWithAnimationSpy = sinon.spy(notification, 'removeWithAnimation');
+
+      notification.render();
+
+      // manually trigger an ESCAPE key click
+      $(document).trigger($.Event("keydown", { keyCode: 27 }));
+
+      // confirm the remove method has now been called
+      assert.ok(removeWithAnimationSpy.calledOnce);
+    });
+
   });
 });


### PR DESCRIPTION
This PR just lets users use their keyboard to close notifications.
We discussed doing the same with mouse clicks and mouse overs, but
they were a bit more contentious so I figure we can add them later
if we want.