### PR TITLE
Fix for right panel not being scrollable

### DIFF
--- a/app/templates/layouts/with_sidebar.html
+++ b/app/templates/layouts/with_sidebar.html
@@ -19,6 +19,6 @@ the License.
 
   <div class="with-sidebar content-area">
     <div id="sidebar-content"></div>
-    <div id="dashboard-content" class="list window-resizeable"></div>
+    <div id="dashboard-content" class="scrollable list"></div>
   </div>
 </div>

--- a/app/templates/layouts/with_tabs_sidebar.html
+++ b/app/templates/layouts/with_tabs_sidebar.html
@@ -26,7 +26,7 @@ the License.
 
     <aside id="sidebar-content" class="scrollable"></aside>
 
-    <section id="dashboard-content" class="list scrollable">
+    <section id="dashboard-content" class="list">
       <div class="scrollable">
         <div class="inner">
           <div id="dashboard-upper-content"></div>

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -414,6 +414,7 @@ with_tabs_sidebar.html
     /*remove gutter without rewriting variable*/
     margin-left: 0px;
   }
+
   .with-sidebar & {
     border-left: 1px solid @grayLight;
     .left-shadow-border();
@@ -422,7 +423,6 @@ with_tabs_sidebar.html
     bottom: 0px;
     top: @collapsedNavWidth;
     position: fixed;
-    overflow: hidden;
     left: @sidebarWidth+@navWidth;
     right: 0;
     .box-sizing(border-box);
@@ -430,6 +430,10 @@ with_tabs_sidebar.html
       left: @sidebarWidth+@collapsedNavWidth;
     }
   }
+  .with-tabs-sidebar & {
+    overflow: hidden;
+  }
+
   > div.inner {
     display: block;
   }


### PR DESCRIPTION
Certain two-panel pages like the Create Admin page had overflow
hidden so content would get cut off an unreachable for smaller
browser widths. This patches it to only apply the overflow for pages
that need it (e.g. the doc list).