### PR TITLE
Open up require's config.js file to be extended

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -370,7 +370,8 @@ module.exports = function (grunt) {
           src: initHelper.watchFiles(['[Ss]pec.js'], ['./app/addons/**/*[Ss]pec.js', './app/addons/**/*[Ss]pec.react.js', './app/core/**/*[Ss]pec.js', './app/**/*[Ss]pec.js'])
         },
         template: 'test/test.config.underscore',
-        config: './app/config.js'
+        config: './app/config-source.js',
+        templateSettings: templateSettings
       }
     },
 

--- a/app/config-source.js
+++ b/app/config-source.js
@@ -1,0 +1,68 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+var requireConfig = {
+
+  // initialize the application with the main application file
+  deps: ['main'],
+
+  paths: {
+
+    // JavaScript folders
+    libs: '../assets/js/libs',
+    plugins: '../assets/js/plugins',
+
+    // Libraries
+    jquery: '../assets/js/libs/jquery',
+    lodash: '../assets/js/libs/lodash',
+    backbone: '../assets/js/libs/backbone',
+    'backbone.layoutmanager': '../assets/js/plugins/backbone.layoutmanager',
+    bootstrap: '../assets/js/libs/bootstrap',
+    spin: '../assets/js/libs/spin.min',
+    d3: '../assets/js/libs/d3',
+    ace: '../assets/js/libs/ace',
+    'cloudant.pagingcollection': '../assets/js/plugins/cloudant.pagingcollection',
+    velocity: '../assets/js/plugins/velocity',
+    'velocity.ui': '../assets/js/plugins/velocity.ui',
+    react: '../assets/js/libs/react',
+    flux: '../assets/js/libs/flux',
+    'es5-shim': '../assets/js/libs/es5-shim',
+    'css.escape': '../assets/js/libs/css.escape',
+    moment: '../assets/js/libs/moment'
+  },
+
+  baseUrl: '/',
+
+  map: {
+    '*': {
+      'underscore': 'lodash',
+      'api': 'core/api'
+    }
+  },
+
+  shim: {
+    backbone: {
+      deps: ['lodash', 'jquery'],
+      exports: 'Backbone'
+    },
+    bootstrap: {
+      deps: ['jquery'],
+      exports: 'Bootstrap'
+    },
+    'plugins/prettify': [],
+    'plugins/beautify': [],
+    'plugins/jquery.form': ['jquery'],
+    velocity: ['jquery'],
+    'velocity.ui': ['velocity']
+  }
+};
+

--- a/app/config.js
+++ b/app/config.js
@@ -10,65 +10,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// Set the require.js configuration for your application.
-require.config({
-
-  // Initialize the application with the main application file.
-  deps: ["main"],
-
-  paths: {
-    // JavaScript folders.
-    libs: "../assets/js/libs",
-    plugins: "../assets/js/plugins",
-
-    // Libraries.
-    jquery: "../assets/js/libs/jquery",
-    lodash: "../assets/js/libs/lodash",
-    backbone: "../assets/js/libs/backbone",
-    "backbone.layoutmanager": "../assets/js/plugins/backbone.layoutmanager",
-    bootstrap: "../assets/js/libs/bootstrap",
-    spin: "../assets/js/libs/spin.min",
-    d3: "../assets/js/libs/d3",
-    "ace":"../assets/js/libs/ace",
-    "cloudant.pagingcollection": "../assets/js/plugins/cloudant.pagingcollection",
-    "velocity": "../assets/js/plugins/velocity",
-    "velocity.ui": "../assets/js/plugins/velocity.ui",
-    react: "../assets/js/libs/react",
-    flux: "../assets/js/libs/flux",
-    "es5-shim": "../assets/js/libs/es5-shim",
-    "css.escape": "../assets/js/libs/css.escape",
-    moment: '../assets/js/libs/moment'
-  },
-
-  baseUrl: '/',
-
-  map: {
-    "*": {
-      'underscore': 'lodash',
-      'api':'core/api'
-    }
-  },
-
-  shim: {
-    // Backbone library depends on lodash and jQuery.
-    backbone: {
-      deps: ["lodash", "jquery"],
-      exports: "Backbone"
-    },
-
-    bootstrap: {
-      deps: ["jquery"],
-      exports: "Bootstrap"
-    },
-
-    "plugins/prettify": [],
-    "plugins/beautify": [],
-
-    "plugins/jquery.form": ["jquery"],
-
-    "velocity": ["jquery"],
-
-    "velocity.ui": ["velocity"]
-  }
-});
+/* global requireConfig */
+require.config(requireConfig);
 

--- a/assets/index.underscore
+++ b/assets/index.underscore
@@ -42,6 +42,8 @@
   </div>
 
   <!-- Application source. -->
+  <script src="/app/config-source.js"></script>
   <script data-main="/config" src="<%= requirejs %>"></script>
+
 </body>
 </html>

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -12,7 +12,13 @@
 
 module.exports = function (grunt) {
   var _ = grunt.util._,
-      fs = require('fs');
+      fs = require('fs'),
+      vm = require('vm');
+
+  var includeInScope = function (path) {
+    var code = fs.readFileSync(path);
+    vm.runInThisContext(code, path);
+  }.bind(this);
 
   grunt.registerMultiTask('template', 'generates an html file from a specified template', function () {
     var data = this.data,
@@ -109,7 +115,6 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask('mochaSetup', 'Generate a config.js and runner.html for tests', function () {
     var data = this.data,
-        configInfo,
         _ = grunt.util._,
         configTemplateSrc = data.template;
 
@@ -117,22 +122,23 @@ module.exports = function (grunt) {
     var testFiles =  grunt.file.expand(fileSrc);
 
     var configTemplate = _.template(grunt.file.read(configTemplateSrc));
-    // a bit of a nasty hack to read our current config.js and get the info so we can change it
-    // for our testing setup
-    var require = {
-      config: function (args) {
-        configInfo = args;
-        configInfo.paths['chai'] = '../test/mocha/chai';
-        configInfo.paths['sinon-chai'] = '../test/mocha/sinon-chai';
-        configInfo.paths['testUtils'] = '../test/mocha/testUtils';
-        configInfo.baseUrl = '../app';
-        delete configInfo.deps;
-      }
-    };
 
-    eval(grunt.file.read(data.config) + '');
+    // include the config file source. That contains a requireConfig var that's included in this scope
+    includeInScope(data.config);
 
-    grunt.file.write('./test/test.config.js', configTemplate({configInfo: configInfo, testFiles: testFiles}));
+    // if the settings file specifies a file that extends Require's config.js file, include it as well
+    if (data.templateSettings.development.variables && data.templateSettings.development.variables.config_extend_file) {
+      includeInScope(data.templateSettings.development.variables.config_extend_file);
+    }
+
+    // now apply whatever additional requireJS config changes we need
+    requireConfig.paths['chai'] = '../test/mocha/chai';
+    requireConfig.paths['sinon-chai'] = '../test/mocha/sinon-chai';
+    requireConfig.paths['testUtils'] = '../test/mocha/testUtils';
+    requireConfig.baseUrl = '../app';
+    delete requireConfig.deps;
+
+    grunt.file.write('./test/test.config.js', configTemplate({ configInfo: requireConfig, testFiles: testFiles }));
   });
 
 


### PR DESCRIPTION
This PR separates the content of the /app/config.js file into
a different file so scripts that extend Fauxton can choose to
load it first, then add/override whatever additional settings
it needs.

One nice thing is that it removes a hack for the mocha code 
which had to work around the fact that the config data 
was innaccessible in require.config();

Note: this PR doesn't include a test because there's nothing really
that can be tested. If it didn't work, everything would break 
immediately.

Closes COUCHDB-2678