### PR TITLE
[WIP] changing sleep time + order of travis steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
 before_script:
   - ./node_modules/grunt-cli/bin/grunt dev &
-  - sleep 50
+  - sleep 40
   - ./node_modules/grunt-cli/bin/grunt test
 script:
   - ./node_modules/grunt-cli/bin/grunt nightwatch

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - ./node_modules/grunt-cli/bin/grunt dev &
   - sleep 40
   - ./node_modules/grunt-cli/bin/grunt test
-  - ./node_modules/grunt-cli/bin/grunt devDebug
+  - ./node_modules/grunt-cli/bin/grunt debugDev
 script:
   - ./node_modules/grunt-cli/bin/grunt nightwatch
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
 before_script:
   - ./node_modules/grunt-cli/bin/grunt dev &
-  - sleep 40
+  - sleep 180
   - ./node_modules/grunt-cli/bin/grunt test
   - ./node_modules/grunt-cli/bin/grunt debugDev
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_script:
   - ./node_modules/grunt-cli/bin/grunt dev &
   - sleep 40
   - ./node_modules/grunt-cli/bin/grunt test
+  - ./node_modules/grunt-cli/bin/grunt devDebug
 script:
   - ./node_modules/grunt-cli/bin/grunt nightwatch
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,8 @@ before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1400x900x16"
 
 before_script:
-  - ./node_modules/grunt-cli/bin/grunt dev &
-  - sleep 180
   - ./node_modules/grunt-cli/bin/grunt test
-  - ./node_modules/grunt-cli/bin/grunt debugDev
+  - ./node_modules/grunt-cli/bin/grunt dev &
 script:
   - ./node_modules/grunt-cli/bin/grunt nightwatch
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1400x900x16"
 
 before_script:
-  - ./node_modules/grunt-cli/bin/grunt test
   - ./node_modules/grunt-cli/bin/grunt dev &
-  - sleep 25
+  - sleep 50
+  - ./node_modules/grunt-cli/bin/grunt test
 script:
   - ./node_modules/grunt-cli/bin/grunt nightwatch
 notifications:

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-TEST13
+TEST14
 
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-BLAH1
+TEST6
 
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-TEST9
+TEST10
 
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,5 +1,7 @@
 # Style Guide
 
+BLAH1
+
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),
 [Google JS style guide](https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml), and from

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-TEST7
+TEST8
 
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-TEST12
+TEST13
 
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-TEST8
+TEST9
 
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-TEST10
+TEST11
 
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-TEST11
+TEST12
 
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),

--- a/styleguide.md
+++ b/styleguide.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-TEST6
+TEST7
 
 This document attempts to codify the JavaScript, HTML and CSS style rules for Fauxton. This has been patched together from
 a few sources, including [Pootle's style guide](http://pootle.readthedocs.org/en/latest/developers/styleguide.html),


### PR DESCRIPTION
There's a problem with the travis config in that sometimes the mocha tests fail, e.g. 
https://travis-ci.org/apache/couchdb-fauxton/builds/62419139
https://travis-ci.org/apache/couchdb-fauxton/builds/62403433

I can reproduce this locally when Fauxton isn't running when mocha is started. This PR is trying out some different configurations like increasing the sleep time and changing the order to ensure tests run after the server has been started.