### PR TITLE
Fix for switchDatabase.js test

### DIFF
--- a/app/addons/databases/tests/nightwatch/switchDatabase.js
+++ b/app/addons/databases/tests/nightwatch/switchDatabase.js
@@ -21,9 +21,9 @@ module.exports = {
 
       // wait for the DB name typeahead field to appear in the header
       .waitForElementPresent('#jump-to-db .search-autocomplete', waitTime, false)
+      .waitForElementPresent('#dashboard-content table.databases', waitTime, false)
       .setValue('#jump-to-db .search-autocomplete', [newDatabaseName, client.Keys.ENTER])
       .waitForElementPresent('.index-pagination', waitTime, false)
-
       // now check we've redirected and the URL ends with /_all_docs
       .url(function (result) {
         var endsWithAllDocs = /all_docs$/.test(result.value);


### PR DESCRIPTION
This is a patch for a buggy test.

It slows down the test to wait for the body of the databases
table to have been loaded before redirecting. That ensures that
the databases have actually been loaded, so the jumptodb option
has a data source loaded. Formerly it would *probably* work. 