### PR TITLE
Small fix for Permissions page and tests

### DIFF
--- a/app/addons/permissions/components.react.jsx
+++ b/app/addons/permissions/components.react.jsx
@@ -65,7 +65,6 @@ function (app, FauxtonAPI, React, Components, Stores, Actions) {
       if (!_.isEmpty(value)) {
         return false;
       }
-
       FauxtonAPI.addNotification({
         msg: 'Cannot add an empty value for ' + type + '.',
         type: 'warning'
@@ -76,7 +75,7 @@ function (app, FauxtonAPI, React, Components, Stores, Actions) {
 
     addNames: function (e) {
       e.preventDefault();
-      if (this.isEmptyValue(this.state.newRole, 'names')) {
+      if (this.isEmptyValue(this.state.newName, 'names')) {
         return;
       }
       this.props.addItem({

--- a/app/addons/permissions/tests/componentsSpec.react.jsx
+++ b/app/addons/permissions/tests/componentsSpec.react.jsx
@@ -85,8 +85,14 @@ define([
         });
 
         it('adds user on submit', function () {
-          var dom = $(el.getDOMNode()).find('.permission-item-form')[0];
-          TestUtils.Simulate.submit(dom);
+          var input = $(el.getDOMNode()).find('input')[0];
+          TestUtils.Simulate.change(input, {
+            target: {
+              value: 'newusername'
+            }
+          });
+          var form = $(el.getDOMNode()).find('.permission-item-form')[0];
+          TestUtils.Simulate.submit(form);
 
           var options = addSpy.args[0][0];
           assert.ok(addSpy.calledOnce);
@@ -95,8 +101,14 @@ define([
         });
 
         it('adds role on submit', function () {
-          var dom = $(el.getDOMNode()).find('.permission-item-form')[1];
-          TestUtils.Simulate.submit(dom);
+          var input = $(el.getDOMNode()).find('input')[1];
+          TestUtils.Simulate.change(input, {
+            target: {
+              value: 'newrole'
+            }
+          });
+          var form = $(el.getDOMNode()).find('.permission-item-form')[1];
+          TestUtils.Simulate.submit(form);
 
           var options = addSpy.args[0][0];
           assert.ok(addSpy.calledOnce);


### PR DESCRIPTION
The mocha tests were failing (correctly!) due to extra check to
prevent adding blank entries.