### PR TITLE
Prevent duplicate mocha tests running

### DIFF
--- a/app/load_addons.js.underscore
+++ b/app/load_addons.js.underscore
@@ -16,7 +16,7 @@
  * THIS IS A GENERATED FILE. DO NOT EDIT.
  */
 define([
-  <%= '"' + deps.join('","') + '"' %>
+  <%= '"' + deps.join('",\n"') + '"' %>
 ],
 function () {
   var LoadAddons = {

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -116,6 +116,12 @@ module.exports = function (grunt) {
     var fileSrc = grunt.option('file') || data.files.src;
     var testFiles =  grunt.file.expand(fileSrc);
 
+    // filter out any tests that aren't found in the /app/ folder. For scripts that are extending Fauxton, we still
+    // know that all addons will have been copied into /app. This prevent tests being ran twice
+    testFiles = _.filter(testFiles, function (filePath) {
+      return /\/app\//.test(filePath);
+    });
+
     var configTemplate = _.template(grunt.file.read(configTemplateSrc));
     // a bit of a nasty hack to read our current config.js and get the info so we can change it
     // for our testing setup


### PR DESCRIPTION
When running mocha for environments where Fauxton has been
extended, e.g. the Cloudant dashboard, tests unique to that other
environment get run twice because the original tests are included
once from the original folder and once from where they've been
copied - in the Fauxton /app folder. Since we know that the files
would need to be copied over to the /app folder for inclusion
in Fauxton, this PR removes the extra tests from the original
source.