### PR TITLE
Databases component tweak

### DIFF
--- a/app/addons/databases/stores.js
+++ b/app/addons/databases/stores.js
@@ -20,7 +20,7 @@ define([
   var DatabasesStore = FauxtonAPI.Store.extend({
 
     initialize: function () {
-      this._collection = {};
+      this._collection = new Backbone.Collection();
       this._loading = false;
       this._promptVisible = false;
     },

--- a/app/load_addons.js.underscore
+++ b/app/load_addons.js.underscore
@@ -16,7 +16,7 @@
  * THIS IS A GENERATED FILE. DO NOT EDIT.
  */
 define([
-  <%= '"' + deps.join('","') + '"' %>
+  <%= '"' + deps.join('",\n"') + '"' %>
 ],
 function () {
   var LoadAddons = {

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -116,6 +116,12 @@ module.exports = function (grunt) {
     var fileSrc = grunt.option('file') || data.files.src;
     var testFiles =  grunt.file.expand(fileSrc);
 
+    // filter out any tests that aren't found in the /app/ folder. For scripts that are extending Fauxton, we still
+    // know that all addons will have been copied into /app. This prevent tests being ran twice
+    testFiles = _.filter(testFiles, function (filePath) {
+      return /\/app\//.test(filePath);
+    });
+
     var configTemplate = _.template(grunt.file.read(configTemplateSrc));
     // a bit of a nasty hack to read our current config.js and get the info so we can change it
     // for our testing setup


### PR DESCRIPTION
This line causes problems when using the component within
other components - not something that currently occurs on Fauxton.
I tried contriving a test but couldn't find an easy way to break
it so decided to forego the test. As you can see, all
the current Fauxton tests work fine.

All it does is change the collection default to an actual Backbone
collection rather than an object.