### PR TITLE
Databases component fix

### DIFF
--- a/app/addons/databases/stores.js
+++ b/app/addons/databases/stores.js
@@ -20,7 +20,11 @@ define([
   var DatabasesStore = FauxtonAPI.Store.extend({
 
     initialize: function () {
-      this._collection = {};
+      this.reset();
+    },
+
+    reset: function () {
+      this._collection = new Backbone.Collection();
       this._loading = false;
       this._promptVisible = false;
     },

--- a/app/addons/databases/tests/componentsSpec.react.jsx
+++ b/app/addons/databases/tests/componentsSpec.react.jsx
@@ -204,6 +204,9 @@ define([
       // because of the need to override typeahead, this just does a spy on the componentDidUpdate method to ensure
       // it gets called
       assert.ok(spy.calledOnce);
+
+      // reset the store for future use
+      Stores.databasesStore.reset();
     });
   });
 

--- a/app/load_addons.js.underscore
+++ b/app/load_addons.js.underscore
@@ -16,7 +16,7 @@
  * THIS IS A GENERATED FILE. DO NOT EDIT.
  */
 define([
-  <%= '"' + deps.join('","') + '"' %>
+  <%= '"' + deps.join('",\n"') + '"' %>
 ],
 function () {
   var LoadAddons = {

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -116,6 +116,12 @@ module.exports = function (grunt) {
     var fileSrc = grunt.option('file') || data.files.src;
     var testFiles =  grunt.file.expand(fileSrc);
 
+    // filter out any tests that aren't found in the /app/ folder. For scripts that are extending Fauxton, we still
+    // know that all addons will have been copied into /app. This prevent tests being ran twice
+    testFiles = _.filter(testFiles, function (filePath) {
+      return /\/app\//.test(filePath);
+    });
+
     var configTemplate = _.template(grunt.file.read(configTemplateSrc));
     // a bit of a nasty hack to read our current config.js and get the info so we can change it
     // for our testing setup


### PR DESCRIPTION
This fixes a small problem with the mocha test for the databases
component. Because it didn't reset the store it would sometimes
interfere with other mocha tests running. Only seen with the dash.