### PR TITLE
Grunt test task reordered

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -486,7 +486,8 @@ module.exports = function (grunt) {
    */
   // clean out previous build artifacts and lint
   grunt.registerTask('lint', ['clean', 'jshint']);
-  grunt.registerTask('test', ['jsx', 'lint', 'shell:stylecheck', 'dependencies', 'gen_initialize:development', 'test_inline']);
+  grunt.registerTask('test', ['clean:release', 'dependencies', 'jsx', 'jshint', 'shell:stylecheck', 'gen_initialize:development', 'test_inline']);
+
   // lighter weight test task for use inside dev/watch
   grunt.registerTask('test_inline', ['mochaSetup', 'jst', 'concat:test_config_js', 'mocha_phantomjs']);
   // Fetch dependencies (from git or local dir), lint them and make load_addons


### PR DESCRIPTION
Small change to only run the JSX step after the clean and
dependencies steps. This ensures that any external addons being
included also get any .jsx tests compiled and ran. Up to now
any of those tests weren't being ran, when ran via this command.