### PR TITLE
Clears the databases store after a test

### DIFF
--- a/app/addons/databases/tests/componentsSpec.react.jsx
+++ b/app/addons/databases/tests/componentsSpec.react.jsx
@@ -283,6 +283,8 @@ define([
       assert.equal(links.length, 6, 'extra column shows up');
 
       FauxtonAPI.unRegisterExtension('DatabaseTable:databaseRow');
+
+      Stores.databasesStore.reset();
     });
 
   });


### PR DESCRIPTION
This test can cause problems because the store isn't cleared out.
Explicitly resets the store.