### PR TITLE
Explicitly create DB in NW tests

### DIFF
--- a/app/addons/databases/tests/nightwatch/deletesDatabase.js
+++ b/app/addons/databases/tests/nightwatch/deletesDatabase.js
@@ -17,6 +17,7 @@ module.exports = {
         baseUrl = client.globals.test_settings.launch_url;
 
     client
+      .createDatabase(newDatabaseName)
       .loginToGUI()
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
       .waitForElementPresent('#header-dropdown-menu a.dropdown-toggle.icon.fonticon-cog', waitTime, false)

--- a/app/addons/documents/tests/nightwatch/createsDocument.js
+++ b/app/addons/documents/tests/nightwatch/createsDocument.js
@@ -19,6 +19,7 @@ module.exports = {
         baseUrl = client.globals.test_settings.launch_url;
 
     client
+      .createDatabase(newDatabaseName)
       .loginToGUI()
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
       .clickWhenVisible('#new-all-docs-button a')


### PR DESCRIPTION
This shouldn't be required, but we noticed that sometimes the
NW beforeEach() doesn't appear to create the database before the
test starts running.