### PR TITLE
Workaround for React oddity

### DIFF
--- a/app/addons/databases/components.react.jsx
+++ b/app/addons/databases/components.react.jsx
@@ -70,8 +70,12 @@ define([
 
     getExtensionColumns: function () {
       var cols = FauxtonAPI.getExtensions('DatabaseTable:head');
-      return _.map(cols, function (Item, index) {
-        return <Item key={index} />;
+
+      // regrettable, but necessary. This hack gets around a current React bug where you can't return an empty node
+      // within a table tr: https://github.com/glittershark/reactable/issues/133
+      return _.filter(cols, function (Item, index) {
+        var item = React.renderToStaticMarkup(<Item />);
+        return (item === '<noscript></noscript>') ? null : <Item key={index} />;
       });
     },
 
@@ -118,8 +122,11 @@ define([
 
     getExtensionColumns: function (row) {
       var cols = FauxtonAPI.getExtensions('DatabaseTable:databaseRow');
-      return _.map(cols, function (Item, index) {
-        return <Item row={row} key={index} />;
+
+      // see comment above reg. https://github.com/glittershark/reactable/issues/133
+      return _.filter(cols, function (Item, index) {
+        var item = React.renderToStaticMarkup(<Item row={row} />);
+        return (item === '<noscript></noscript>') ? null : <Item row={row} key={index} />;
       });
     },
 


### PR DESCRIPTION
React does some odd stuff with the DOM like inserting `<noscript>`
tags to keep track of rendering info. In this instance it was
optionally inserting the noscript into a `<tr>`, which threw an error 
because it was invalid markup.

This is a workaround to detect the scenario until the issue is
resolved.