### PR TITLE
Zen Mode option for small Ace Editor fields

### DIFF
--- a/app/addons/components/assets/less/code-editor.less
+++ b/app/addons/components/assets/less/code-editor.less
@@ -1,0 +1,81 @@
+.zen-editor-icon {
+  float: right;
+  font-size: 13px;
+  margin-top: 3px;
+}
+
+.full-page-editor-modal-wrapper {
+  position: fixed;
+  padding: 110px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  width: 100%;
+  z-index: 1025;
+
+  &.zen-theme-dark {
+    background-color: #323232;
+  }
+  &.zen-theme-light {
+    background-color: #ffffff;
+  }
+
+  .ace_editor {
+    height: 100%;
+    font-size: 15px;
+    line-height: 25px;
+    background-color: inherit;
+
+    .ace_gutter, .ace_gutter-active-line {
+      background-color: inherit;
+    }
+  }
+}
+
+.zen-theme-light {
+  .zen-mode-controls {
+    color: #999999;
+  }
+}
+
+.zen-mode-controls {
+  position: absolute;
+  right: 30px;
+  top: 30px;
+  font-size: 20px;
+  color: white;
+
+  .zen-mode-controls-wrapper {
+    position: relative;
+    float: left;
+  }
+
+  .tooltips {
+    position: relative;
+    float: left;
+  }
+
+  ul {
+    float: right;
+    list-style-type: none;
+  }
+
+  .tooltip {
+    margin-right: 20px;
+    min-width: 140px;
+  }
+
+  span {
+    cursor: pointer;
+    width: 23px;
+    height: 23px;
+    margin: 10px;
+    display: inline-block;
+  }
+}
+
+html body .ace_editor .ace_marker-layer .ace_selection {
+  background-color: rgba(29, 151, 215, 0.5);
+}

--- a/app/addons/components/assets/less/components.less
+++ b/app/addons/components/assets/less/components.less
@@ -16,3 +16,4 @@
 @import "styled-select.less";
 @import "docs.less";
 @import "loading-lines.less";
+@import "code-editor.less";

--- a/app/addons/components/tests/codeEditorSpec.js
+++ b/app/addons/components/tests/codeEditorSpec.js
@@ -12,6 +12,7 @@
 define([
   'api',
   'addons/components/react-components.react',
+
   'testUtils',
   'react'
 ], function (FauxtonAPI, ReactComponents, utils, React) {
@@ -28,7 +29,7 @@ define([
       spy = sinon.spy();
       container = document.createElement('div');
       codeEditorEl = TestUtils.renderIntoDocument(
-        <ReactComponents.CodeEditor code={code} change={spy} />,
+        React.createElement(ReactComponents.CodeEditor, {code: code, change: spy}),
         container
       );
     });
@@ -64,7 +65,7 @@ define([
 
       beforeEach(function () {
         codeEditorEl = TestUtils.renderIntoDocument(
-          <ReactComponents.CodeEditor code={code} isFullPageEditor={false}  setHeightWithJS={true}/>,
+          React.createElement(ReactComponents.CodeEditor, {code: code, isFullPageEditor: false, setHeightWithJS: true}),
           container
         );
 
@@ -84,7 +85,7 @@ define([
 
       beforeEach(function () {
         codeEditorEl = TestUtils.renderIntoDocument(
-          <ReactComponents.CodeEditor code={code}/>,
+          React.createElement(ReactComponents.CodeEditor, {code: code}),
           container
         );
 
@@ -100,7 +101,7 @@ define([
 
       it('sets new code', function () {
         codeEditorEl = TestUtils.renderIntoDocument(
-          <ReactComponents.CodeEditor code={code}/>,
+          React.createElement(ReactComponents.CodeEditor, {code: code}),
           container
         );
 
@@ -114,7 +115,7 @@ define([
 
       it('only shows editor when showEditorOnly=true', function () {
         codeEditorEl = TestUtils.renderIntoDocument(
-          <ReactComponents.CodeEditor code={code} showEditorOnly={true} />,
+          React.createElement(ReactComponents.CodeEditor, {code: code, showEditorOnly: true}),
           container
         );
         assert.notOk($(codeEditorEl.getDOMNode()).hasClass('control-group'));
@@ -122,40 +123,12 @@ define([
 
       it('shows everything by default', function () {
         var codeEditorEl = TestUtils.renderIntoDocument(
-          <ReactComponents.CodeEditor code={code} />,
+          React.createElement(ReactComponents.CodeEditor, {code: code}),
           container
         );
         assert.ok($(codeEditorEl.getDOMNode()).hasClass('control-group'));
       });
 
-    });
-
-    describe('Zen Mode', function () {
-      it('shows zen mode by default', function () {
-        var container = document.createElement('div');
-        var codeEditorEl = TestUtils.renderIntoDocument(
-          <ReactComponents.CodeEditor code={code} change={spy} docs="http://link.com" />,
-          container
-        );
-        assert.equal($(codeEditorEl.getDOMNode()).find('.zen-editor-icon').length, 1);
-      });
-
-      it('omits zen mode if explicitly turned off', function () {
-        var container = document.createElement('div');
-        var codeEditorEl = TestUtils.renderIntoDocument(
-          <ReactComponents.CodeEditor code={code} change={spy} docs="http://link.com" allowZenMode={false} />,
-          container
-        );
-        assert.equal($(codeEditorEl.getDOMNode()).find('.zen-editor-icon').length, 0);
-      });
-
-      it('updates parent editor after changing content in zen mode', function () {
-        var container = document.createElement('div');
-        var codeEditorEl = TestUtils.renderIntoDocument(
-          <ReactComponents.CodeEditor code={code} change={spy} docs="http://link.com" />,
-          container
-        );
-      });
     });
   });
 });

--- a/app/addons/components/tests/zenModeSpec.react.jsx
+++ b/app/addons/components/tests/zenModeSpec.react.jsx
@@ -1,0 +1,58 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+define([
+  'api',
+  'addons/components/react-components.react',
+  'testUtils',
+  'react'
+], function (FauxtonAPI, ReactComponents, utils, React) {
+
+  var assert = utils.assert;
+  var TestUtils = React.addons.TestUtils;
+  var code = 'function (doc) {\n  emit(doc._id, 1);\n}';
+
+  describe('Zen Mode', function () {
+    var container, el, spy;
+
+    beforeEach(function () {
+      spy = sinon.spy();
+      container = document.createElement('div');
+      el = TestUtils.renderIntoDocument(
+        <ReactComponents.ZenModeOverlay defaultCode={code} onExit={spy} />,
+        container
+      );
+    });
+
+    afterEach(function () {
+      React.unmountComponentAtNode(container);
+    });
+
+    describe('Toggle theme', function () {
+      it('defaults to dark theme', function () {
+        assert.ok($(el.getDOMNode()).hasClass('zen-theme-dark'));
+      });
+
+      it('switch to light theme on click', function () {
+        TestUtils.Simulate.click($(el.getDOMNode()).find('.js-toggle-theme')[0]);
+        assert.ok($(el.getDOMNode()).hasClass('zen-theme-light'));
+      });
+    });
+
+    describe('Closing zen mode', function () {
+      it('defaults to dark theme', function () {
+        TestUtils.Simulate.click($(el.getDOMNode()).find('.js-exit-zen-mode')[0]);
+        assert.ok(spy.calledOnce);
+      });
+    });
+
+  });
+});

--- a/app/addons/documents/assets/less/view-editor.less
+++ b/app/addons/documents/assets/less/view-editor.less
@@ -13,8 +13,6 @@
 @import "../../../../../assets/less/variables.less";
 
 .editor-wrapper {
-
-
   .define-view {
     padding-bottom: 70px;
   }
@@ -26,6 +24,7 @@
   }
   label {
     font-size: 16px;
+    margin-right: 0px;
   }
   .bordered-box {
     border-bottom: 1px solid #ccc;


### PR DESCRIPTION
This adds a zen-mode option to small Ace Editor fields to allow a lot more real estate for entering code. See screenshots:

Icon:
![screen shot 2015-06-08 at 12 40 04 pm](https://cloud.githubusercontent.com/assets/512116/8043468/3f5ae2ae-0ddb-11e5-950e-f53b0cbb940f.png)

Dark zen-mode (default):
![screen shot 2015-06-08 at 12 40 26 pm](https://cloud.githubusercontent.com/assets/512116/8043478/4f688c32-0ddb-11e5-86ab-4802856d67db.png)

Light zen-mode: 
![screen shot 2015-06-08 at 12 40 35 pm](https://cloud.githubusercontent.com/assets/512116/8043487/5708f030-0ddb-11e5-9eba-63fa59bb8e27.png)

The choice of theme (dark/light) is remembered in local storage.