### PR TITLE
Cloudant Query page link fix

### DIFF
--- a/app/addons/documents/mango/mango.components.react.jsx
+++ b/app/addons/documents/mango/mango.components.react.jsx
@@ -126,7 +126,7 @@ function (app, FauxtonAPI, React, Stores, Actions,
     },
 
     render: function () {
-      var url = FauxtonAPI.urls('allDocs', 'app', this.props.dbName, '');
+      var url = '#/' + FauxtonAPI.urls('allDocs', 'app', this.props.dbName, '');
 
       return (
         <div className="editor-wrapper span5 scrollable">


### PR DESCRIPTION
Small link fix for the database name on the Cloudant Query page.
It was failing to link properly to the All Docs page.

There's no test because it works fine for test environments: the
link fails when Fauxton or a wrapper is ran under a separate
location, like whatever.html#/database/mydb/_all_docs

