### PR TITLE
Url fix

### DIFF
--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -75,7 +75,7 @@ function (app, FauxtonAPI, Documents) {
     },
 
     app: function (database, doc) {
-      return '/database/' + database + '/' + doc;
+      return '/database/' + database + '/' + encodeURI(doc);
     },
 
     apiurl: function (database, doc) {

--- a/app/addons/documents/helpers.js
+++ b/app/addons/documents/helpers.js
@@ -16,7 +16,7 @@ define([
 
   var Helpers = {};
 
-  Helpers.getPreviousPage = function (database, wasCloned) {
+  Helpers.getPreviousPageForDoc = function (database, wasCloned) {
     var previousPage = database.url('index'), // default to the current database's all_docs page
         lastPages = FauxtonAPI.router.lastPages;
 
@@ -33,6 +33,9 @@ define([
     return previousPage;
   };
 
+  Helpers.getPreviousPage = function (database) {
+    return database.url('index');
+  };
 
   // sequence info is an array in couchdb2 with two indexes. On couch 1.x, it's just a string / number
   Helpers.getSeqNum = function (val) {

--- a/app/addons/documents/routes-doc-editor.js
+++ b/app/addons/documents/routes-doc-editor.js
@@ -49,7 +49,7 @@ function (app, FauxtonAPI, Helpers, Documents, DocEditor, Databases) {
     },
 
     crumbs: function () {
-      var previousPage = Helpers.getPreviousPage(this.database, this.wasCloned);
+      var previousPage = Helpers.getPreviousPageForDoc(this.database, this.wasCloned);
 
       return [
         { type: 'back', link: previousPage },
@@ -72,7 +72,7 @@ function (app, FauxtonAPI, Helpers, Documents, DocEditor, Databases) {
       this.docView = this.setView('#dashboard-content', new DocEditor.CodeEditor({
         model: this.doc,
         database: this.database,
-        previousPage: Helpers.getPreviousPage(this.database)
+        previousPage: Helpers.getPreviousPageForDoc(this.database)
       }));
     },
 
@@ -126,7 +126,7 @@ function (app, FauxtonAPI, Helpers, Documents, DocEditor, Databases) {
     },
 
     crumbs: function () {
-      var previousPage = Helpers.getPreviousPage(this.database);
+      var previousPage = Helpers.getPreviousPageForDoc(this.database);
       return [
         { type: 'back', link: previousPage },
         { name: 'New Document', link: '#' }

--- a/app/addons/documents/tests/routeSpec.js
+++ b/app/addons/documents/tests/routeSpec.js
@@ -11,12 +11,14 @@
 // the License.
 
 define([
+        'api',
+        'addons/documents/base',
         'addons/documents/routes',
         'addons/documents/header/header.actions',
         'addons/documents/index-results/actions',
 
         'testUtils'
-], function (Documents, HeaderActions, IndexResultsActions, testUtils) {
+], function (FauxtonAPI, Base, Documents, HeaderActions, IndexResultsActions, testUtils) {
   var assert = testUtils.assert;
   var DocumentRoute = Documents.RouteObjects[2];
 
@@ -47,6 +49,16 @@ define([
 
       routeObj.findUsingIndex();
       assert.ok(spy.calledOnce);
+    });
+
+  });
+
+  describe('Fauxton Urls', function () {
+
+    it('document app encodes document id', function () {
+      var id = "\foo";
+      var url = FauxtonAPI.urls('document', 'app', 'fake-db', id);
+      assert.deepEqual("/database/fake-db/%0Coo", url);
     });
 
   });


### PR DESCRIPTION
THis is a fix for [COUCHDB-2717](https://issues.apache.org/jira/browse/COUCHDB-2717). It also sets the back button for all views and indexes to _all_docs instead of trying to keep a history. 