### PR TITLE
Fix for relative link handling issue in test environment

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -34,8 +34,8 @@ function (app, FauxtonAPI, LoadAddons) {
     // Get the absolute anchor href.
     var href = { prop: $(this).prop("href"), attr: $(this).attr("href") };
 
-    // Get the absolute root.
-    var root = location.protocol + "//" + location.host + app.root;
+    // Get the absolute root
+    var root = location.protocol + "//" + location.host;
 
     // Ensure the root is part of the anchor href, meaning it's relative
     if (href.prop && href.prop.slice(0, root.length) === root) {


### PR DESCRIPTION
Hey @garren, @robertkowalski, can I get extra eyes on this ticket? It's a tiny change but potentially big impact. It's complicated, so pardon the long explanation.

________________

There's an issue with our current beta where clicking on a View
name in the new React sidebar doesn't redirect the user to that
view, but just shrinks the view section.

Michelle got a fix in place in this PR: https://github.com/apache/couchdb-fauxton/pull/463. It works
fine, but I didn't want to have to cancel events any time this
occurs.

After some digging, we found that this issue only occurs on
environments like `dashboard.xxx/dashboard.html` like in a 
wrapper, where it's targeting a subfolder for the build target. It 
works fine anywhere it's not in a sub-folder, like for local 
development or a production server.

The issue is that the modified line of code in this PR was
determining whether a link should be handled via the backbone
router by comparing the base of the URL plus the build's target
assets subfolder (like `dashboard.xxx/dashboard.assets`) folder.
That  was too aggressive a check for beta environments because 
no link linked to the assets folder.

So remarkably, the if-statement never passes for any link on 
environments running in subfolders. The links still worked 
because the router independently listened to the  hash changes 
and handled the routing. The only difference was that the event 
wasn’t canceled, which caused the issue described  above.

I think the change made in this PR is safe. The purpose of the
line is to determine "relative" links (or rather links within
Fauxton), so I just made it a little more generic by comparing
the `http://whatever:port/` part, and not
`http://whatever:port/subfolder/` part.

Michelle mentioned there have been other instances where we
seem to need to cancel events like this. This should solve that.

Hope this is clear.