### PR TITLE
Database link fix on Add/Edit View page

### DIFF
--- a/app/addons/documents/index-editor/components.react.jsx
+++ b/app/addons/documents/index-editor/components.react.jsx
@@ -375,7 +375,7 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, ReactComponents) 
         );
       }
 
-      var url = FauxtonAPI.urls('allDocs', 'app', this.state.database.id, '');
+      var url = '#/' + FauxtonAPI.urls('allDocs', 'app', this.state.database.id, '');
 
       return (
         <div className="define-view">


### PR DESCRIPTION
This is the same issue as d072d9ffad7fc57c3cbb548c879950cd164cf1c6 just on a 
different page.

There's no test because it works fine for test environments: the
link fails when Fauxton or a wrapper is ran under a separate
location, like whatever.html#/database/mydb/_all_docs