### PR TITLE
getEditor() method added to <CodeEditor />

### DIFF
--- a/app/addons/components/react-components.react.jsx
+++ b/app/addons/components/react-components.react.jsx
@@ -381,6 +381,10 @@ function (app, FauxtonAPI, React, Components, ace, beautifyHelper) {
       return this.editor.getValue();
     },
 
+    getEditor: function () {
+      return this;
+    },
+
     render: function () {
       return (
         <div ref="ace" className="js-editor" id={this.props.id}></div>

--- a/app/addons/components/tests/codeEditorSpec.react.jsx
+++ b/app/addons/components/tests/codeEditorSpec.react.jsx
@@ -96,5 +96,17 @@ define([
       });
     });
 
+    describe('getEditor', function () {
+      beforeEach(function () {
+        codeEditorEl = TestUtils.renderIntoDocument(
+          <ReactComponents.CodeEditor defaultCode={code} />,
+          container
+        );
+      });
+      it('returns a reference to get access to the editor', function () {
+        assert.ok(codeEditorEl.getEditor());
+      });
+    });
+
   });
 });


### PR DESCRIPTION
This exposes the editor for reference elsewhere.