### PR TITLE
JS validation added for Add Database

### DIFF
--- a/app/addons/databases/actions.js
+++ b/app/addons/databases/actions.js
@@ -65,9 +65,9 @@ function (app, FauxtonAPI, Stores, ActionTypes, Resources) {
     },
 
     createNewDatabase: function (databaseName) {
-      if (_.isNull(databaseName) || databaseName.trim().length === 0) {
+      if (_.isNull(databaseName) || databaseName.trim().length === 0 || !this.isValidDatabaseName(databaseName)) {
         FauxtonAPI.addNotification({
-          msg: 'Please enter a valid database name',
+          msg: 'Please enter a valid database name. The database must start with a letter and can only contain lowercase letters (a-z), digits (0-9) and the following characters _, $, (, ), +, -, and /.',
           type: 'error',
           clear: true
         });
@@ -118,6 +118,10 @@ function (app, FauxtonAPI, Stores, ActionTypes, Resources) {
           type: 'error'
         });
       }
+    },
+
+    isValidDatabaseName: function (databaseName) {
+      return (/^[a-z][a-z0-9_\$\(\)\+\/-]*$/).test(databaseName);
     }
   };
 });

--- a/app/addons/databases/tests/actionsSpec.js
+++ b/app/addons/databases/tests/actionsSpec.js
@@ -246,6 +246,40 @@ define([
 
     });
 
+    describe('isValidDatabaseName', function () {
+      it("accepts valid database names", function () {
+        [
+          "one",
+          "one$",
+          "one/",
+          "o-n-e",
+          "o_n_e",
+          "o+n+e",
+          "one(or-two)"
+        ].forEach(function (item) {
+          assert.equal(Actions.isValidDatabaseName(item), true);
+        });
+      });
+
+      it("rejects invalid database names", function () {
+        [
+          "ONE",
+          "_one",
+          "-blah",
+          "one%",
+          "one*",
+          "one@",
+          "one#",
+          "one^",
+          "one~",
+          "one two",
+          " one"
+        ].forEach(function (item) {
+          assert.equal(Actions.isValidDatabaseName(item), false, "item: " + item);
+        });
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
Right now we rely on the server to validate the database name
that the user enters and return the error message if it's invalid.
That works in most cases, except when the db name contains a # or
? char. This PR just adds a simple one-liner regexp as suggested
in the CouchDB docs to validate it on the client first.