### PR TITLE
Move sidebar click handler to section header

### DIFF
--- a/app/addons/documents/sidebar/sidebar.react.jsx
+++ b/app/addons/documents/sidebar/sidebar.react.jsx
@@ -215,14 +215,14 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, DocumentViews) {
       var designDocName = this.props.designDocName;
       var linkId = "nav-design-function-" + designDocName + this.props.selector;
       return (
-        <li id={linkId} onClick={this.toggle}>
-          <a className={toggleClassNames} data-toggle="collapse">
+        <li id={linkId}>
+          <a className={toggleClassNames} data-toggle="collapse" onClick={this.toggle}>
             <div className="fonticon-play"></div>
             <span className={icon + " fonticon"}></span>
             {title}
-            </a>
-            <ul className={toggleBodyClassNames}>
-              {this.createItems()}
+          </a>
+          <ul className={toggleBodyClassNames}>
+            {this.createItems()}
           </ul>
         </li>
       );

--- a/app/addons/documents/tests/nightwatch/editDocumentsFromView.js
+++ b/app/addons/documents/tests/nightwatch/editDocumentsFromView.js
@@ -15,7 +15,6 @@ module.exports = {
     var waitTime = client.globals.maxWaitTime,
         newDatabaseName = client.globals.testDatabaseName,
         newDocumentName = '_design/abc',
-        baseUrl = client.globals.test_settings.launch_url,
         ddocContents = {
           "views": {
             "evens": {
@@ -28,13 +27,13 @@ module.exports = {
 
     client
       .loginToGUI()
-      .createDocument(newDocumentName, newDatabaseName, ddocContents )
+      .createDocument(newDocumentName, newDatabaseName, ddocContents)
       .populateDatabase(newDatabaseName)
 
       //navigate to 'evens' view (declared above), then click on first document's pencil icon
       .clickWhenVisible('#dashboard-content a[href="#/database/' + newDatabaseName + '/_all_docs"]')
       .clickWhenVisible('#nav-header-abc')
-      .clickWhenVisible('#nav-design-function-abcviews')
+      .clickWhenVisible('#nav-design-function-abcviews a')
       .clickWhenVisible('#abc_evens')
       .clickWhenVisible('a[href="#/database/fauxton-selenium-tests/document_10"]')
 

--- a/app/addons/documents/tests/nightwatch/previousButton.js
+++ b/app/addons/documents/tests/nightwatch/previousButton.js
@@ -21,7 +21,7 @@ module.exports = {
       .loginToGUI()
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_changes')
       .clickWhenVisible('#nav-header-keyview')
-      .clickWhenVisible('#nav-design-function-keyviewviews')
+      .clickWhenVisible('#nav-design-function-keyviewviews a')
       .clickWhenVisible('#keyview_keyview')
       .clickWhenVisible('.breadcrumb-back-link .fonticon-left-open')
       .waitForElementPresent('.js-changes-view', waitTime)

--- a/app/addons/documents/tests/nightwatch/viewCreate.js
+++ b/app/addons/documents/tests/nightwatch/viewCreate.js
@@ -116,8 +116,10 @@ module.exports = {
       //go back to all docs
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
       .clickWhenVisible('#nav-header-testdesigndoc', waitTime, false)
-      .clickWhenVisible('#nav-design-function-testdesigndocviews', waitTime, false)
+      .clickWhenVisible('#nav-design-function-testdesigndocviews a', waitTime, false)
+      .execute('$("#testdesigndoc_test-new-view")[0].scrollIntoView();')
       .clickWhenVisible('#testdesigndoc_test-new-view', waitTime, false)
+      .execute('$(".save")[0].scrollIntoView();')
       .waitForElementPresent('.prettyprint', waitTime, false)
       .waitForElementNotPresent('.loading-lines', waitTime, false)
       .assert.containsText('.prettyprint', 'enteente')


### PR DESCRIPTION
The toggle event was placed one node too high on the Index
section in the sidebar, which resulted in the section being
expanded/contracted when a subelement is clicked, rather than
just the parent.