### PR TITLE
Includes the second ace theme for bundling

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -319,6 +319,7 @@ module.exports = function (grunt) {
           {src: "assets/js/libs/ace/worker-json.js", dest: "dist/release/js/ace/worker-json.js"},
           {src: "assets/js/libs/ace/mode-json.js", dest: "dist/release/js/ace/mode-json.js"},
           {src: "assets/js/libs/ace/theme-idle_fingers.js", dest: "dist/release/js/ace/theme-idle_fingers.js"},
+          {src: "assets/js/libs/ace/theme-dawn.js", dest: "dist/release/js/ace/theme-dawn.js"},
           {src: "assets/js/libs/ace/mode-javascript.js", dest: "dist/release/js/ace/mode-javascript.js"},
           {src: "assets/js/libs/ace/worker-javascript.js", dest: "dist/release/js/ace/worker-javascript.js"},
         ]


### PR DESCRIPTION
This just updates the gruntfile to include the new Ace theme
used for the Zen editor. It wasn't working in bundled (prod)
environments because the file needed to be explictly included.