### PR TITLE
Change all scrollbars to show up only if content is clipped

### DIFF
--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -234,7 +234,7 @@ table.databases {
 
 #dashboard-content .scrollable {
   height: auto;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   width: 100%;
   position: absolute;

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -40,7 +40,7 @@
 
 @media screen and (max-height: 600px) {
   #primary-navbar {
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 }
 
@@ -329,7 +329,7 @@ with_tabs_sidebar.html
 
 .scrollable {
   height: auto;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   width: 100%;
   position: absolute;


### PR DESCRIPTION
overflow: scroll, shows a scrollbar regardless if the content needs
scrolling,
overflow:auto only shows a scrollbar when the content is clipped and
the scrollbar is needed