### PR TITLE
Add callback for when Tray closed by clicking off it

### DIFF
--- a/app/addons/fauxton/components.react.jsx
+++ b/app/addons/fauxton/components.react.jsx
@@ -14,7 +14,10 @@ define([
   'app',
   'api',
   'react',
-  'plugins/zeroclipboard/ZeroClipboard'
+  'plugins/zeroclipboard/ZeroClipboard',
+
+  // needed to run the test individually. Don't remove
+  'velocity.ui'
 ],
 
 function (app, FauxtonAPI, React, ZeroClipboard) {
@@ -120,6 +123,16 @@ function (app, FauxtonAPI, React, ZeroClipboard) {
   var _NextTrayInternalId = 0;
   var Tray = React.createClass({
 
+    propTypes: {
+      onAutoHide: React.PropTypes.func
+    },
+
+    getDefaultProps: function () {
+      return {
+        onAutoHide: function () { }
+      };
+    },
+
     getInitialState: function () {
       return {
         show: false,
@@ -148,6 +161,7 @@ function (app, FauxtonAPI, React, ZeroClipboard) {
         var tgt = $(e.target);
         if (this.state.show && tgt.closest('.tray').length === 0) {
           this.hide();
+          this.props.onAutoHide();
         }
       }.bind(this));
     },

--- a/app/addons/fauxton/tests/componentsSpec.react.jsx
+++ b/app/addons/fauxton/tests/componentsSpec.react.jsx
@@ -19,19 +19,26 @@ define([
   var assert = utils.assert;
   var TestUtils = React.addons.TestUtils;
 
+
   describe('Tray', function () {
 
-    var container, trayEl, done;
+    var container, trayEl, oldToggleSpeed;
 
     beforeEach(function () {
       container = document.createElement('div');
+
       // when we want to control the diff, we have to render directly
       trayEl = React.render(<Views.Tray className="traytest" />, container);
-      done = sinon.spy();
+
+      oldToggleSpeed = FauxtonAPI.constants.MISC.TRAY_TOGGLE_SPEED;
+
+      // makes velocity toggle immediately
+      FauxtonAPI.constants.MISC.TRAY_TOGGLE_SPEED = 0;
     });
 
     afterEach(function () {
       React.unmountComponentAtNode(container);
+      FauxtonAPI.constants.MISC.TRAY_TOGGLE_SPEED = oldToggleSpeed;
     });
 
     it('renders trayid and custom classes', function () {
@@ -74,6 +81,38 @@ define([
           assert.equal('none', trayEl.getDOMNode().style.display);
         });
       });
+    });
+
+    it('calls props.onAutoHide when closing tray by clicking outside of it', function () {
+      var container = document.createElement('div');
+      var onClose = function () { };
+      var spy = sinon.spy();
+
+      var wrapper = React.createClass({
+
+        runTest: function () {
+          var trayEl = this.refs.tray;
+          var externalEl = this.refs.externalElement;
+          trayEl.show(function () {
+            TestUtils.Simulate.click(externalEl.getDOMNode());
+            assert.ok(spy.calledOnce);
+          });
+        },
+
+        render: function () {
+          return (
+            <div>
+              <p ref="externalElement">Click me!</p>
+              <Views.Tray ref="tray" onAutoHide={onClose} />
+            </div>
+          );
+        }
+      });
+
+      var reactEl = React.render(React.createElement(wrapper), container);
+      reactEl.runTest();
+
+      React.unmountComponentAtNode(container);
     });
 
   });


### PR DESCRIPTION
The Tray component has custom callbacks for explicit hide/show
methods, but not when the Tray is closed by clicking outside of
it. This is useful when using a Tray within another component
and the visiblity status is stored in a store. We need to track
the auto close event to update the store.