### PR TITLE
Take out one layer of encoding

### DIFF
--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -75,7 +75,7 @@ function (app, FauxtonAPI, Documents) {
     },
 
     app: function (database, doc) {
-      return '/database/' + database + '/' + encodeURI(doc);
+      return '/database/' + database + '/' + doc;
     },
 
     apiurl: function (database, doc) {

--- a/app/addons/documents/tests/routeSpec.js
+++ b/app/addons/documents/tests/routeSpec.js
@@ -53,13 +53,15 @@ define([
 
   });
 
-  describe('Fauxton Urls', function () {
+  //    until there is consensus on how to encode json responses
+  //    https://issues.apache.org/jira/browse/COUCHDB-2748
+  //    taking out this test for https://github.com/apache/couchdb-fauxton/pull/489
 
-    it('document app encodes document id', function () {
-      var id = "\foo";
-      var url = FauxtonAPI.urls('document', 'app', 'fake-db', id);
-      assert.deepEqual("/database/fake-db/%0Coo", url);
-    });
-
-  });
+  //describe('Fauxton Urls', function () {
+    // it('document app encodes document id', function () {
+    //   var id = "\foo";
+    //   var url = FauxtonAPI.urls('document', 'app', 'fake-db', id);
+    //   assert.deepEqual("/database/fake-db/%0Coo", url);
+    // });
+  //});
 });


### PR DESCRIPTION
There is some encoding issues going on.  :/

This is related to [original reason for the change: COUCHDB-2717] (https://issues.apache.org/jira/browse/COUCHDB-2717), and possibly related to [DBCore Issue:COUCHDB-2748 ](https://issues.apache.org/jira/browse/COUCHDB-2748)

We're double encoding the url, in app/addons/documents/base.js, (file edited in this PR).

I am able to save a document with the name:
![screen shot 2015-08-03 at 3 33 04 pm](https://cloud.githubusercontent.com/assets/836039/9045938/59ffdd8a-39f5-11e5-8edb-bdd7cb8d2d85.png)
but when I click on it: i am rerouted back to all docs, because: 
GET http://localhost:8000/aaa/__hello-world%253A%2520colonspace__ 404 (Not Found)

So it SHOULD go to:

GET http://localhost:8000/aaa/__hello-world%3A%20colonspace__

(notice the extra '25' before the %3A=(colon) and %20=(space), and that %25=(percent sign))

Research
- A bit of explaining as to what that `%2520` is :

- The common space character is encoded as` %20` as you noted yourself. The` %` character is encoded as `%25`.

- The way you get `%2520` is when your url already has a`%20` in it, and gets urlencoded again, which transforms the `%20` to `%2520`.

[Source: SO](http://stackoverflow.com/questions/16084935/a-html-space-is-showing-as-2520-instead-of-20)

I'm not sure about the < back button behavior with when editing/looking at a view document, and if we still need to encode the url for that fix.

@garrensmith could you take a look at this? for  [COUCHDB-2717] (https://issues.apache.org/jira/browse/COUCHDB-2717) I couldn't reproduce, and i remember you mentioned you fixed the < back button navigation after this fix, so we might not need to encode here. 



