### PR TITLE
Fauxton csrf fixes

### DIFF
--- a/app/addons/databases/tests/nightwatch/createsDatabase.js
+++ b/app/addons/databases/tests/nightwatch/createsDatabase.js
@@ -45,7 +45,7 @@ module.exports = {
       .setValue('#js-new-database-name', [newDatabaseName])
       .clickWhenVisible('#js-create-database', waitTime, false)
       .checkForDatabaseCreated(newDatabaseName, waitTime)
-      .url(baseUrl + '/_all_dbs')
+      .url(baseUrl + '/#/_all_dbs')
       .waitForElementVisible('html', waitTime, false)
       .getText('html', function (result) {
         var data = result.value,

--- a/app/addons/databases/tests/nightwatch/csrf.js
+++ b/app/addons/databases/tests/nightwatch/csrf.js
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+var newDatabaseName = 'fauxton-selenium-tests-db-create';
+var helpers = require('../../../../../test/nightwatch_tests/helpers/helpers.js');
+module.exports = {
+
+  before: function (client, done) {
+    var nano = helpers.getNanoInstance();
+    nano.db.destroy(newDatabaseName, function (err, body, header) {
+      done();
+    });
+  },
+
+  after: function (client, done) {
+    var nano = helpers.getNanoInstance();
+    nano.db.destroy(newDatabaseName, function (err, body, header) {
+      done();
+    });
+  },
+
+  'Creates a Database' : function (client) {
+    var waitTime = client.globals.maxWaitTime,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .checkForDatabaseDeleted(newDatabaseName, waitTime)
+      .url(baseUrl)
+
+      // ensure the page has fully loaded
+      .waitForElementPresent('.databases.table', waitTime, false)
+      .waitForElementPresent('#add-new-database', waitTime, false)
+      .clickWhenVisible('#add-new-database', waitTime, false)
+      .waitForElementVisible('#js-new-database-name', waitTime, false)
+      .setValue('#js-new-database-name', [newDatabaseName])
+      .clickWhenVisible('#js-create-database', waitTime, false)
+      .checkForDatabaseCreated(newDatabaseName, waitTime)
+      .url(baseUrl + '/_all_dbs')
+      .waitForElementVisible('html', waitTime, false)
+      .getText('html', function (result) {
+        var data = result.value,
+            createdDatabaseIsPresent = data.indexOf('mismatch');
+
+        this.verify.ok(createdDatabaseIsPresent !== -1,
+          'CSRF token mismatch');
+      })
+    .end();
+  }
+};

--- a/app/addons/documents/tests/nightwatch/createsDocument.js
+++ b/app/addons/documents/tests/nightwatch/createsDocument.js
@@ -34,7 +34,7 @@ module.exports = {
       ')
       .clickWhenVisible('#doc-editor-actions-panel .save-doc')
       .checkForDocumentCreated(newDocumentName)
-      .url(baseUrl + '/' + newDatabaseName + '/_all_docs')
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
       .waitForElementPresent('body', waitTime, false)
       .getText('body', function (result) {
         var data = result.value,

--- a/app/app.js
+++ b/app/app.js
@@ -63,32 +63,25 @@ function (app, $, _, Backbone, Bootstrap, Helpers, Utils, FauxtonAPI, Couchdb) {
   // Localize or create a new JavaScript Template object
   var JST = window.JST = window.JST || {};
 
-  var parseCookies = function (cookies) {
-    if (!cookies) {
-      return {};
+  $(document).on('ajaxSend', function (elm, xhr, s) {
+
+    function parseCookies (cookies) {
+      if (!cookies) {
+        return {};
+      }
+
+      return _.reduce(cookies.split(';'), function (list, cookie) {
+        var parts = cookie.split('=');
+        list[parts.shift().trim()] = decodeURI(parts.join('='));
+        return list;
+      }, {});
     }
-    return _.reduce(cookies.split(';'), function (list, cookie) {
-      var parts = cookie.split('=');
-      list[parts.shift().trim()] = decodeURI(parts.join('='));
-      return list;
-    }, {});
-  };
 
-  $._ajax = $.ajax;
-
-  $.ajax = function (settings) {
     var cookies = parseCookies(document.cookie);
     var csrf = cookies['CouchDB-CSRF'] ? cookies['CouchDB-CSRF'] : 'true';
-    var origBeforeSend = settings.beforeSend;
-    var newBeforeSend = function (xhr, o) {
-      if (origBeforeSend) {
-        origBeforeSend(xhr, o);
-      }
-      xhr.setRequestHeader('X-CouchDB-CSRF', csrf);
-    };
-    settings.beforeSend = newBeforeSend;
-    return $._ajax(settings);
-  };
+
+    xhr.setRequestHeader('X-CouchDB-CSRF', csrf);
+  });
 
   // Configure LayoutManager with Backbone Boilerplate defaults
   FauxtonAPI.Layout.configure({

--- a/app/core/tests/csrfSpec.js
+++ b/app/core/tests/csrfSpec.js
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+define([
+  'app',
+  'api',
+  'testUtils'
+], function (app, FauxtonAPI, testUtils) {
+  var assert = testUtils.assert;
+
+  describe('csrf tokens', function () {
+    var xhr, request;
+    beforeEach(function () {
+      xhr = sinon.useFakeXMLHttpRequest();
+      xhr.onCreate = function (xhr) {
+        request = xhr;
+      };
+    });
+
+    afterEach(function () {
+      testUtils.restore(xhr);
+    });
+
+    it('asks for a CSRF token', function (done) {
+      $.ajax({
+        type: 'GET',
+        url: 'http://example.com'
+      }).done(function () {
+        assert.equal(request.requestHeaders['X-CouchDB-CSRF'], 'true');
+        done();
+      });
+      request.respond(200, {
+        'Content-Type': 'application/json'
+      }, '[{ "id": 12, "comment": "Hey there" }]');
+    });
+
+  });
+});


### PR DESCRIPTION
Main patch is:

```
   csrf: fix tests

    when fauxton requests session token & csrf token it handles them
    as additional data it sends to each ajax request.

    the testsuite tries to open 5984:/_alldocs and friends in several
    places right after running the test. as the csrf cookie is sent
    via ajax, a plain GET will result in a CSRF error
```

Other patches:

- add test coverage
- don't monkey patch ajax, use an event handler "hook"