### PR TITLE
Remove reference to $.clearForm

### DIFF
--- a/app/addons/documents/tests/nightwatch/uploadAttachment.js
+++ b/app/addons/documents/tests/nightwatch/uploadAttachment.js
@@ -28,6 +28,7 @@ module.exports = {
       .setValue('input#_attachments', require('path').resolve(__dirname + '/uploadAttachment.js'))
       .clickWhenVisible('#upload-btn')
       .waitForElementVisible('#global-notification-id', waitTime, false)
+      .assert.attributeEquals('#_rev', 'value', '')
       .getText('#global-notification-id', function (result) {
         var data = result.value;
         this.verify.ok(data, 'Document saved successfully.');

--- a/app/addons/documents/views-doceditor.js
+++ b/app/addons/documents/views-doceditor.js
@@ -73,7 +73,8 @@ function (app, FauxtonAPI, Components, Documents, Databases, prettify) {
       FauxtonAPI.triggerRouteEvent('reRenderDoc');
       //slight delay to make this transistion a little more fluid and less jumpy
       setTimeout(function () {
-        $form.clearForm();
+        this.$('#_attachments').val('');
+        this.$('#_rev').val('');
         hideModal();
         $('.modal-backdrop').remove();
       }, 1000);


### PR DESCRIPTION
There's an error that appears after uploading a file. This is due
to the removal of a jQuery form lib. This PR removes the reference
to the unfound function and clears the form manually.