### PR TITLE
Update Fauxton docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,17 @@
-Contributing to Fauxton
-=======================
+# Contributing to Fauxton
 
-CouchDB is an Apache project, which is why we keep all our issues in Jira.  You can find or submit issues for Fauxton [here](https://issues.apache.org/jira/issues/?jql=project%20%3D%20COUCHDB%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20Fauxton%20ORDER%20BY%20priority%20DESC).
+CouchDB is an Apache project, which is why we keep all our issues in Jira.  You can find or submit issues for Fauxton 
+[here](https://issues.apache.org/jira/issues/?jql=project%20%3D%20COUCHDB%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20Fauxton%20ORDER%20BY%20priority%20DESC).
 
-We try to keep all tickets up to date with Skill level for you to have an idea of the level of effort or comfortability with the framework you'd need to complete the task.
+We try to keep all tickets up to date with Skill level for you to have an idea of the level of effort or comfort 
+with the framework you'd need to complete the task.
 
 The [Readme file](https://github.com/apache/couchdb-fauxton/blob/master/readme.md) has information about how to get the project running.
 
-##Guide to Contributions
-We follow our coding-styleguide to make it easier for everyone to write, read and review code: [https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md](https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md)
+## Guide to Contributions
+
+We follow our coding-styleguide to make it easier for everyone to write, read and review code: 
+[https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md](https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md)
 
 To start working on a specific ticket, create a branch with the Jira ID # followed by a traincase description of the issue.
 
@@ -16,13 +19,15 @@ To start working on a specific ticket, create a branch with the Jira ID # follow
 
 If there is no Jira ticket for the issue you have, you don't have to create one.
 
-Please describe the issue, how it happens and how you fixed it in the commit message. Before you submit the Pull-Request, please run our testsuite and make sure that it passes:
+Please describe the issue, how it happens and how you fixed it in the commit message. Before you submit the Pull 
+Request, please run our testsuite and make sure that it passes:
 
 ```
 grunt test
 ```
 
-You can also open `couchdb-fauxton/test/runner.html` in a browser. Click on the headlines of the testcases to just run a specific test that fails - it should be faster than running the whole testsuite every time.
+You can also open `couchdb-fauxton/test/runner.html` in a browser. Click on the headlines of the testcases to just run 
+a specific test that fails - it should be faster than running the whole testsuite every time.
 
 Commit messages should follow the following style:
 
@@ -36,10 +41,14 @@ issue
 Closes COUCHDB-XXXX (if there is a Jira ticket)
 ```
 
-When you're ready for a review, submit a Pull Request. We regularly check the PR list for Fauxton and should get back to you with a code review.  If no one has responded to you yet, you can find us on IRC in #couchdb-dev.  Ping **Garren**, **robertkowalski** or **Deathbear**, though anyone in the room should be able to help you.
+When you're ready for a review, submit a Pull Request. We regularly check the PR list for Fauxton and should get back 
+to you with a code review.  If no one has responded to you yet, you can find us on IRC in #couchdb-dev.  
+Ping **Garren**, **robertkowalski** or **michellep** though anyone in the room should be able to help you.
 
 ## Get in Touch
-We appreciate constructive feedback from people who use CouchDB, so don't be shy. We know there are bugs and we know there is room for improvement.
+
+We appreciate constructive feedback from people who use CouchDB, so don't be shy. We know there are bugs and we know 
+there is room for improvement.
 
 ʕ´•ᴥ•`ʔ Thanks!
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
-Fauxton
-=======
+# Fauxton
+
 
 Fauxton is the new Web UI for CouchDB. To get it running in development on your machine. Follow the steps below.
 
@@ -12,24 +12,19 @@ You can use the latest release of Fauxton via npm:
 
 See `fauxton --help` for extra options.
 
-## CouchDB is Required
 
-Install couchdb from docs here: http://couchdb.readthedocs.org/en/latest/install/index.html
+## Setting up Fauxton
 
-## Setup Fauxton
+Please note that a recent installation of [node.js](http://nodejs.org/) and npm is required.
 
-A recent of [node.js](http://nodejs.org/) and npm is required.
+1. make sure you have CouchDB installed. Instructions on how to install it can be  
+[found here](http://couchdb.readthedocs.org/en/latest/install/index.html)
+2. fork this repo: `https://github.com/apache/couchdb-fauxton.git` and make sure you have a cloned local copy
+3. add upstream to the main git repo: `git remote add git-repo https://github.com/apache/couchdb-fauxton.git`
+4. add upstream to the private apache repo: `git remote add upstream http://git-wip-us.apache.org/repos/asf/couchdb-fauxton.git`
+5. go to your cloned copy of the repo (usually `couchdb-fauxton`) and type `npm install` to download all dependencies
+7. install the `grunt-cli` (grunt command line interface) 
 
-### Fork this Repo
-
-1. Fork this repo: https://github.com/apache/couchdb-fauxton.git
-2. add upstream to the main git repo: `git remote add git-repo https://github.com/apache/couchdb-fauxton.git`
-3. add upstream to the private apache repo: `git remote add upstream http://git-wip-us.apache.org/repos/asf/couchdb-fauxton.git`
-4. `cd couchdb-fauxton`
-5. `npm install`
-
-
-### Install the grunt-cli
 In case you don't have the Grunt command line interface installed, run the following command:
 
     npm install -g grunt-cli
@@ -39,88 +34,30 @@ If you run into a permissions problem, run that last command as an administrator
     sudo npm install -g grunt-cli
 
 
-### NOTE: Before you run Fauxton, don't forget to start CouchDB!
+## Running Fauxton
 
-### Dev Server
-Using the dev server is the easiest way to use Fauxton, specially when
-developing for it. Copy or symlink the `settings.json.default` file if you'd like to see the `styletests` addon).
+**NOTE: Before you run Fauxton, don't forget to start CouchDB!**
 
-And then...
+
+### The Dev Server
+
+Using the dev server is the easiest way to use Fauxton, especially when developing for it. In the cloned repo folder,
+type:
 
     grunt dev
 
-You should be able to access Fauxton on `http://localhost:8000`
+Wait until you see the "Fauxton" ascii art on your command line, then you should be able to access Fauxton at
+`http://localhost:8000`
 
-### Styleguide
-We follow our coding-styleguide to make it easier for everyone to write, read and review code: [https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md](https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md)
 
-### Prepare Fauxton Release
-Follow the "Fauxton Setup" section, edit settings.json variable root where the document will live,
-e.g. "/_utils/" then:
+### Preparing a Fauxton Release
+
+Follow the "Setting up Fauxton" section above, then edit the `settings.json` variable root where the document will live, 
+e.g. `/_utils/`. Then type:
 
     grunt couchdb
 
 This will install the latest version of Fauxton into `/share/www/`
-
-### Running Tests
-
-You can run the tests either via the command line or your browser.
-
-Command line:
-
-    grunt test
-
-Browser: make sure the dev server is running, and enter the path (not URL) to your `runner.html` file in your browser.
-
-    file://path/to/couchdb-fauxton/test/runner.html
-
-Refreshing the URL will re-run the tests via PhantomJS and in the browser.
-
-#### Nightwatch Functional Browser Tests
-
-There is a bit of setup involved before you are able to run the Nightwatch tests.
-
-In your CouchDB admin accounts, add a user:  
-
-> user: tester  
-password: testerpass  
-
-Then on the command line:  
-
-    npm install
-
-Start fauxton with
-
-    grunt dev
-
-And to run the tests (in another terminal tab):
-
-    grunt nightwatch
-
-##### Omitting nightwatch tests
-
-If you need to omit particular tests from running you can add a `testBlacklist` option to the nightwatch section of
-your settings.json file. That defines an object of the following form:
-
-```javascript
-// ...
-"nightwatch": {
-  // ...
-  "testBlacklist": {
-    "documents": ["*"],
-    "databases": [
-      "checkDatabaseTooltip.js",
-      "createsDatabase.js"
-    ]
-  }
-}
-// ...
-
-```
-
-The properties (`documents`, `databases`) map to a particular addon folder name (see `app/addons`). The values
-should be an array of tests that you don't want to run. `*` will flag all tests from being ran, otherwise you
-just enter the names of the files to omit.
 
 
 ### To Deploy Fauxton
@@ -129,17 +66,29 @@ To deploy to your local [CouchDB instance](http://localhost:5984/fauxton/_design
 
     grunt couchapp_deploy
 
-## (Optional) To avoid a npm global install
+
+### (Optional) To avoid a npm global install
     # Development mode, non minified files
     npm run couchdebug
 
     # Or fully compiled install
     npm run couchdb
 
-## Understanding the Fauxton Code Layout
 
-Interested in writing learning more? Give [this file](code-layout.md) a read over for a little more information about 
-how Fauxton's organized. 
 
-Want to get involved? Check out [Jira](https://issues.apache.org/jira/browse/COUCHDB/component/12320406) for a list
-of items to do.
+## More information 
+
+Check out the following pages for a lot more information about Fauxton:
+
+- [The Fauxton Code Layout](https://github.com/apache/couchdb-fauxton/blob/master/code-layout.md)
+- [Style Guide](https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md)
+- [Testing Fauxton](https://github.com/apache/couchdb-fauxton/blob/master/tests.md)
+- [Writing Addons](https://github.com/apache/couchdb-fauxton/blob/master/writing_addons.md)
+- [Extensions](https://github.com/apache/couchdb-fauxton/blob/master/extensions.md)
+- [How to contribute](https://github.com/apache/couchdb-fauxton/blob/master/CONTRIBUTING.md)
+
+
+------
+
+
+-- The Fauxton Team

--- a/tests.md
+++ b/tests.md
@@ -1,0 +1,67 @@
+# Tests
+
+Fauxton has both test coverage through unit and selenium tests, built on 
+[Mocha](https://mochajs.org/) and [Nightwatch](http://nightwatchjs.org/) respectively.
+
+
+## Unit Tests
+
+You can run the Mocha unit tests via the command line or your browser.
+
+Command line:
+
+    grunt test
+
+Browser: make sure the dev server is running, and enter the path (not URL) to your `runner.html` file in your browser.
+
+    file://path/to/couchdb-fauxton/test/runner.html
+
+Refreshing the URL will re-run the tests via PhantomJS and in the browser.
+
+
+## Selenium tests
+
+There is a bit of setup involved before you are able to run the Nightwatch selenium tests.
+
+First, in your CouchDB admin accounts, add a user:
+
+> user: tester  
+password: testerpass  
+
+Then on the command line:  
+
+    npm install
+
+Start Fauxton with
+
+    grunt dev
+
+And to run the tests (in another terminal tab):
+
+    grunt nightwatch
+
+
+### Omitting Nightwatch tests
+
+If you need to omit particular tests from running you can add a `testBlacklist` option to the nightwatch section of
+your settings.json file. That defines an object of the following form:
+
+```javascript
+// ...
+"nightwatch": {
+  // ...
+  "testBlacklist": {
+    "documents": ["*"],
+    "databases": [
+      "checkDatabaseTooltip.js",
+      "createsDatabase.js"
+    ]
+  }
+}
+// ...
+
+```
+
+The properties (`documents`, `databases`) map to a particular addon folder name (see `app/addons`). The values
+should be an array of tests that you don't want to run. `*` will flag all tests from being ran, otherwise you
+just enter the names of the files to omit.


### PR DESCRIPTION
The current readme is kind of all over the map and a little hard to 
follow. This updates it to focus on what new arrivals are most likely 
to be interested in: setup and deployment info. Other information 
(primarily developer) is now found in a link section at the end 
for further reading. See:
https://github.com/benkeen/couchdb-fauxton/blob/update-docs/readme.md
