### PR TITLE
Increase timeout for NW tests

### DIFF
--- a/test/nightwatch_tests/custom-commands/checkForDatabaseCreated.js
+++ b/test/nightwatch_tests/custom-commands/checkForDatabaseCreated.js
@@ -26,7 +26,7 @@ CheckForDatabaseCreated.prototype.command = function (databaseName, timeout) {
   var couchUrl = helpers.test_settings.db_url;
 
   if (!timeout) {
-    timeout = 10000;
+    timeout = helpers.maxWaitTime;
   }
 
   var timeOutId = setTimeout(function () {

--- a/test/nightwatch_tests/custom-commands/checkForDatabaseDeleted.js
+++ b/test/nightwatch_tests/custom-commands/checkForDatabaseDeleted.js
@@ -26,7 +26,7 @@ CheckForDatabaseDeleted.prototype.command = function (databaseName, timeout) {
   var couchUrl = helpers.test_settings.db_url;
 
   if (!timeout) {
-    timeout = 10000;
+    timeout = helpers.maxWaitTime;
   }
 
   var timeOutId = setTimeout(function () {

--- a/test/nightwatch_tests/custom-commands/checkForDocumentCreated.js
+++ b/test/nightwatch_tests/custom-commands/checkForDocumentCreated.js
@@ -27,7 +27,7 @@ CheckForDocumentCreated.prototype.command = function (doc, timeout) {
       db = helpers.testDatabaseName;
 
   if (!timeout) {
-    timeout = 10000;
+    timeout = helpers.maxWaitTime;
   }
 
   var timeOutId = setTimeout(function () {

--- a/test/nightwatch_tests/custom-commands/checkForStringNotPresent.js
+++ b/test/nightwatch_tests/custom-commands/checkForStringNotPresent.js
@@ -27,7 +27,7 @@ CheckForStringNotPresent.prototype.command = function (path, string, timeout) {
       db = helpers.testDatabaseName;
 
   if (!timeout) {
-    timeout = 10000;
+    timeout = helpers.maxWaitTime;
   }
 
   var timeOutId = setTimeout(function () {

--- a/test/nightwatch_tests/custom-commands/checkForStringPresent.js
+++ b/test/nightwatch_tests/custom-commands/checkForStringPresent.js
@@ -27,7 +27,7 @@ CheckForStringPresent.prototype.command = function (path, string, timeout) {
       db = helpers.testDatabaseName;
 
   if (!timeout) {
-    timeout = 10000;
+    timeout = helpers.maxWaitTime;
   }
 
   var timeOutId = setTimeout(function () {

--- a/test/nightwatch_tests/custom-commands/clickWhenVisible.js
+++ b/test/nightwatch_tests/custom-commands/clickWhenVisible.js
@@ -10,10 +10,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+var helpers = require('../helpers/helpers.js');
+
 exports.command = function (element, waitTime) {
 
   if (waitTime === undefined) {
-    waitTime = 10000;
+    waitTime = helpers.maxWaitTime;
   }
 
   this

--- a/test/nightwatch_tests/custom-commands/closeNotification.js
+++ b/test/nightwatch_tests/custom-commands/closeNotification.js
@@ -10,13 +10,14 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+var helpers = require('../helpers/helpers.js');
+
 exports.command = function () {
-  var waitTime = 8000,
-      client = this,
+  var client = this,
       dismissSelector = '#global-notifications .js-dismiss';
 
   client
-    .waitForElementPresent(dismissSelector, waitTime, false)
+    .waitForElementPresent(dismissSelector, helpers.maxWaitTime, false)
     .click(dismissSelector);
 
   return this;


### PR DESCRIPTION
The max timeout time for several of the NW custom commands was
set to 10 seconds. Recently NW tests have been failing a good deal
more (esp on the dash) and all appear to be due to timeouts.

This PR changes it to use the default timeout time (30 seconds). I
think this is wise in any event, since ANY effort to increase the
robustness of the tests is needed. Plus it won't slow anything
down - just make it more likely to identify legitimately failing tests.