### PR TITLE
Minor extension check

### DIFF
--- a/app/addons/documents/mango/mango.helper.js
+++ b/app/addons/documents/mango/mango.helper.js
@@ -29,8 +29,11 @@ define([
     }, []);
 
     if (!nameArray.length) {
-      indexes = FauxtonAPI.getExtensions('mango:additionalIndexes')[0];
-      nameArray = indexes.createHeader(doc);
+      indexes = FauxtonAPI.getExtensions('mango:additionalIndexes');
+
+      if (!_.isUndefined(indexes) && indexes.length > 0) {
+        nameArray = indexes[0].createHeader(doc);
+      }
     }
 
     return nameArray.join(', ');


### PR DESCRIPTION
Small thing. If the 'mango:additionalIndexes' extension isn't
defined it throws a JS error and causes the page not to load.
This just adds a check.