### PR TITLE
Allow custom buttons to be added to the Doc Editor page

### DIFF
--- a/app/addons/documents/doc-editor/components.react.jsx
+++ b/app/addons/documents/doc-editor/components.react.jsx
@@ -155,6 +155,13 @@ define([
       this.refs.docEditor.clearChanges();
     },
 
+    getExtensionIcons: function () {
+      var extensions = FauxtonAPI.getExtensions('DocEditor:icons');
+      return _.map(extensions, function (Extension, i) {
+        return (<Extension doc={this.state.doc} key={i} />);
+      }, this);
+    },
+
     getButtonRow: function () {
       if (this.props.isNewDoc) {
         return false;
@@ -162,7 +169,7 @@ define([
       return (
         <div>
           <AttachmentsPanelButton doc={this.state.doc} isLoading={this.state.isLoading} />
-          <div className="doc-editor-extension-icons"></div>
+          <div className="doc-editor-extension-icons">{this.getExtensionIcons()}</div>
           <PanelButton title="Upload Attachment" iconClass="icon-circle-arrow-up" onClick={Actions.showUploadModal} />
           <PanelButton title="Clone Document" iconClass="icon-repeat" onClick={Actions.showCloneDocModal} />
           <PanelButton title="Delete" iconClass="icon-trash" onClick={Actions.showDeleteDocModal} />

--- a/app/addons/documents/doc-editor/tests/doc-editor.componentsSpec.react.jsx
+++ b/app/addons/documents/doc-editor/tests/doc-editor.componentsSpec.react.jsx
@@ -184,4 +184,23 @@ define([
     });
   });
 
+
+  describe("Custom Extension Buttons", function () {
+    it('supports buttons', function () {
+      var CustomButton = React.createClass({
+        render: function () {
+          return (
+            <button>Oh no she di'n't!</button>
+          );
+        }
+      });
+      FauxtonAPI.registerExtension('DocEditor:icons', CustomButton);
+
+      var container = document.createElement('div');
+      var el = TestUtils.renderIntoDocument(<Components.DocEditorController database={database} />, container);
+      assert.isTrue(/Oh\sno\sshe\sdi'n't!/.test(el.getDOMNode().outerHTML));
+      React.unmountComponentAtNode(container);
+    });
+  });
+
 });


### PR DESCRIPTION
This feature was accidentally removed in the recent full page doc
editor refactor. This ticket adds the option back in to allow
other code to add arbitrary buttons on the doc editor page.