### PR TITLE
Update two_pane template to use flexbox

### DIFF
--- a/app/addons/documents/assets/less/view-editor.less
+++ b/app/addons/documents/assets/less/view-editor.less
@@ -215,16 +215,5 @@ body .view-query-save .control-group {
 
     // generate .spanX
     .spanX (@gridColumns);
-
   }
-
-  /* legacy. Once all layouts are ported to flexbox this can be dropped */
-  footer.pagination-footer {
-    z-index: 10;
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-  }
-
 }

--- a/app/addons/documents/mango/mango.components.react.jsx
+++ b/app/addons/documents/mango/mango.components.react.jsx
@@ -129,7 +129,7 @@ function (app, FauxtonAPI, React, Stores, Actions,
       var url = '#/' + FauxtonAPI.urls('allDocs', 'app', this.props.dbName, '');
 
       return (
-        <div className="editor-wrapper span5 scrollable">
+        <div className="editor-wrapper">
           <PaddedBorderedBox>
             <div
               dangerouslySetInnerHTML={{__html: this.props.description}}

--- a/app/templates/layouts/two_pane.html
+++ b/app/templates/layouts/two_pane.html
@@ -11,30 +11,22 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
 */%>
-<div id="dashboard" class="two-pane">
-  <div class="row-fluid">
-    <div class="header-wrapper">
-      <div id="breadcrumbs" class="span5"></div>
-      <div class="right-header-wrapper span7">
-        <div id="react-headerbar"></div>
-        <div id="api-navbar"></div>
-        <div id="right-header"></div>
-      </div>
+<div id="dashboard" class="two-pane flex-layout flex-col">
+
+  <div class="header-wrapper flex-layout flex-row">
+    <div id="breadcrumbs"></div>
+    <div class="right-header-wrapper">
+      <div id="react-headerbar"></div>
+      <div id="api-navbar"></div>
+      <div id="right-header"></div>
     </div>
   </div>
-  <div class="row-fluid content-area">
-    <div id="left-content" class="span5">
 
-    </div>
-    <div id="right-content" class="span7">
-      <section id="dashboard-content" class="list">
-        <div class="scrollable">
-          <div class="inner">
-            <div id="dashboard-lower-content"></div>
-          </div>
-        </div>
-        <div id="footer"></div>
-      </section>
+  <div id="two-pane-content" class="flex-layout flex-row flex-body">
+    <div id="left-content" class="flex-body"></div>
+    <div id="right-content" class="flex-body flex-layout flex-col">
+      <div id="dashboard-lower-content" class="flex-body"></div>
+      <div id="footer"></div>
     </div>
   </div>
 </div>

--- a/assets/less/layouts.less
+++ b/assets/less/layouts.less
@@ -3,7 +3,7 @@
 
 
 /* new flex layout for templates. "body #dashboard" needed for specificity: will remove at end */
-body #dashboard .flex-layout {
+body #dashboard .flex-layout, body #dashboard.flex-layout {
   .display-flex();
 
   &.flex-col {
@@ -13,7 +13,7 @@ body #dashboard .flex-layout {
     .flex-direction(row);
   }
 
-  /* overrides */
+  /* FLEXBOX REFACTOR: temporary overrides */
   padding: 0;
   &>div {
     padding: 0;
@@ -81,7 +81,6 @@ body #dashboard .flex-body {
   }
 }
 
-
 /* temporary wedge. Can be replaced at end */
 .with-sidebar {
   #breadcrumbs {
@@ -97,3 +96,38 @@ body #dashboard .flex-body {
   }
 }
 
+/** FLEXBOX REFACTOR: "body #dashboard" can be removed at end. Specificity needed right now */
+body #dashboard.two-pane {
+  height: 100%;
+
+  /* this will be renamed & reused once all templates use flexbox */
+  #two-pane-content {
+    .display-flex();
+    .flex-direction(row);
+  }
+  .right-header-wrapper {
+    .flex(1);
+  }
+  #left-content {
+    .flex(0 0 440px);
+  }
+  #footer {
+    .flex(0 0 50px)
+  }
+
+  /* overrides a weird default */
+  .editor-wrapper form {
+    padding-bottom: 0;
+  }
+
+  /* temporary. header-wrapper will be converted to flexbox everywhere */
+  .header-wrapper {
+    .flex(0 0 65px);
+    position: inherit;
+
+    #breadcrumbs {
+      .flex(0 0 440px);
+      overflow: hidden;
+    }
+  }
+}

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -510,8 +510,6 @@ with_tabs_sidebar.html
   }
 
   #right-content {
-    position: relative;
-    height: 100%;
     .view {
       padding: 0 20px 40px;
     }


### PR DESCRIPTION
This updates the CSS for two_pane to remove the old
layout CSS and use flexbox.

Impact:
- Cloudant Query page