### PR TITLE
Convert headers to use flexbox

### DIFF
--- a/app/addons/activetasks/assets/less/activetasks.less
+++ b/app/addons/activetasks/assets/less/activetasks.less
@@ -90,7 +90,7 @@
   }
 
   #active-tasks-filter-tabs {
-    height: 100px;
+    height: 60px;
     background-color: #CBCBCB;
     padding-left: 20px;
     overflow: hidden;
@@ -103,7 +103,7 @@
 
     li {
       background-color: #eee;
-      margin-top: 65px;
+      margin-top: 25px;
       margin-left: 3px;
 
       &.active-tasks-checked {

--- a/app/addons/documents/assets/less/doc-editor.less
+++ b/app/addons/documents/assets/less/doc-editor.less
@@ -20,6 +20,11 @@
     padding-bottom: 0;
     top: 0;
   }
+
+  /* temporary wedge: can be removed at end of flexbox refactor */
+  #api-navbar {
+    float: right;
+  }
 }
 
 #editor-container {
@@ -39,11 +44,6 @@
     }
   }
 
-  .fixed-header {
-    height: 65px;
-    .box-shadow(none);
-  }
-
   #breadcrumbs {
     white-space: nowrap;
   }
@@ -56,6 +56,10 @@
     width: 100%;
     background-color: #f1f1f1;
     height: 61px;
+  }
+
+  &#dashboard > header {
+    .box-shadow(none);
   }
 
   #editor-container {

--- a/app/addons/fauxton/templates/api_bar.html
+++ b/app/addons/fauxton/templates/api_bar.html
@@ -12,11 +12,10 @@ License for the specific language governing permissions and limitations under
 the License.
 */ %>
 
-<a class="btn btn-primary pull-right api-url-btn">
+<a class="btn btn-primary api-url-btn">
   <i class="fonticon-link header-icon"></i>
   API URL
 </a>
-<div class="clearfix"></div>
 <div class="api-navbar tray">
     <div class="input-prepend input-append">
       <span class="add-on">

--- a/app/templates/layouts/doc_editor.html
+++ b/app/templates/layouts/doc_editor.html
@@ -13,8 +13,8 @@ the License.
 */%>
 
 <div id="dashboard" class="one-pane doc-editor-page">
-  <header class="fixed-header">
-    <div id="breadcrumbs"></div>
+  <header class="flex-layout flex-row">
+    <div id="breadcrumbs" class="flex-body"></div>
     <div id="api-navbar"></div>
   </header>
 

--- a/app/templates/layouts/one_pane.html
+++ b/app/templates/layouts/one_pane.html
@@ -11,12 +11,11 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
 */%>
-
 <div id="dashboard" class="one-pane">
-  <header class="fixed-header">
-    <div id="breadcrumbs"></div>
-    <div id="api-navbar"></div>
+  <header class="flex-layout flex-row">
+    <div id="breadcrumbs" class="flex-body"></div>
     <div id="right-header"></div>
+    <div id="api-navbar"></div>
   </header>
 
   <div class="content-area container-fluid">

--- a/app/templates/layouts/with_sidebar.html
+++ b/app/templates/layouts/with_sidebar.html
@@ -1,4 +1,4 @@
-<!--
+<%/*
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
@@ -10,9 +10,9 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
--->
-<div id="dashboard" class="container-fluid">
-  <header class="fixed-header">
+*/%>
+<div id="dashboard">
+  <header class="flex-layout flex-row">
     <div id="breadcrumbs"></div>
     <div id="api-navbar"></div>
   </header>

--- a/app/templates/layouts/with_tabs_sidebar.html
+++ b/app/templates/layouts/with_tabs_sidebar.html
@@ -12,25 +12,22 @@ License for the specific language governing permissions and limitations under
 the License.
 */%>
 
-<div id="dashboard" class="container-fluid with-sidebar">
+<div id="dashboard" class="with-sidebar">
+  <header class="flex-layout flex-row two-panel-header">
+    <div id="breadcrumbs" class="sidebar"></div>
+    <div class="right-header-wrapper flex-body">
+      <div id="react-headerbar"></div>
+      <div id="api-navbar"></div>
+      <div id="right-header"></div>
+    </div>
+  </header>
 
   <div class="with-sidebar tabs-with-sidebar content-area">
-    <div class="header-wrapper">
-      <div id="breadcrumbs" class="sidebar"></div>
-      <div class="right-header-wrapper">
-        <div id="react-headerbar"></div>
-        <div id="api-navbar"></div>
-        <div id="right-header"></div>
-      </div>
-    </div>
-
     <aside id="sidebar-content" class="scrollable"></aside>
-
-    <section id="dashboard-content" class="flex-layout flex-cols">
+    <section id="dashboard-content" class="flex-layout flex-col">
       <div id="dashboard-upper-content"></div>
       <div id="dashboard-lower-content" class="flex-body"></div>
       <div id="footer"></div>
     </section>
-
   </div>
 </div>

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -224,7 +224,7 @@ table.databases {
 
 #sidebar-content {
   position: absolute;
-  top: 60px;
+  top: 0;
   width: @sidebarWidth;
   left: 0;
   background-color: @secondarySidebar;
@@ -325,6 +325,10 @@ div.spinner {
 }
 
 #api-navbar {
+  /* prevents a slight shift on page load */
+  width: 108px;
+  overflow: hidden;
+
   > div:not(.hide) {
     border-left: 1px solid #ccc;
   }
@@ -398,7 +402,7 @@ div.spinner {
 
 .js-filter {
   ul {
-    margin-left: 0px;
+    margin-left: 0;
   }
   li {
     list-style-type: none;
@@ -406,22 +410,20 @@ div.spinner {
 }
 
 //---header--//
-.fixed-header{
-  height: @collapsedNavWidth;
+#dashboard > header {
+  height: 65px;
   background-color: @breadcrumbBG;
-  top: 0;
-  right: 0;
-  left: 0;
-  background-color: @breadcrumbBG;
-  position: absolute;
-
   .bottom-shadow-border();
-  z-index: 100;
 
-  /* these styles are for the new header*/
-  > div {
-    display:inline-block;
-    vertical-align: top;
+  /* this is necessary to allow the 6px box shadow overlap the panels below */
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
+body #dashboard .two-panel-header {
+  #breadcrumbs {
+    .flex(0 0 331px);
   }
 }
 
@@ -442,7 +444,7 @@ div.spinner {
 
 #breadcrumbs {
   height: @collapsedNavWidth;
-  float: left;
+
   /* these styles are for the new header*/
   .header-left{
     > div{
@@ -648,11 +650,9 @@ div.spinner {
 
 .header-right,
 #api-navbar {
-  float: right;
-  height: @collapsedNavWidth;
   > div {
     padding: 12px;
-    height: @collapsedNavWidth;
+    height: @collapsedNavWidth - 1;
   }
 }
 

--- a/assets/less/layouts.less
+++ b/assets/less/layouts.less
@@ -6,10 +6,10 @@
 body #dashboard .flex-layout {
   .display-flex();
 
-  &.flex-cols {
+  &.flex-col {
     .flex-direction(column);
   }
-  &.flex-rows {
+  &.flex-row {
     .flex-direction(row);
   }
 
@@ -20,9 +20,12 @@ body #dashboard .flex-layout {
   }
   /* end overrides */
 
-  /* always default all child elements as flex items */
+  /*
+  always default all child elements as flex items that neither shrink nor expand. Assumes all flex-layout containers
+  contain at least one .flex-body to indicate that's the one that expands
+  */
   &>* {
-    .flex(1);
+    .flex(0);
   }
 
   /* notice we don't set heights. Flex will expand to fill the content but no more */
@@ -40,7 +43,7 @@ body #dashboard .flex-layout {
 
 /* can be added to any element in a display:flex element that you want to act as the main body. It expands to the
    available space and shows a scrollbar */
-.flex-body {
+body #dashboard .flex-body {
   .flex(1);
   overflow: auto;
 }
@@ -52,3 +55,44 @@ body #dashboard .flex-layout {
   width: 100%;
   margin: 0 -20px;
 }
+
+/* this drops .fixed-header, which was a position:absolute'd element, and switches it and all children to use flexbox. */
+.one-pane > header {
+  width: 100%;
+
+  /* TODO move all style stuff out of this file. layouts.less should be entirely layout CSS, nothing else */
+  .bottom-shadow-border();
+
+  #breadcrumbs {
+    overflow: hidden;
+
+    /* overrides - can be removed later */
+    float: none;
+  }
+  #right-header {
+    /* TODO. How come .flex(0 0 inherit) is invalid? */
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: inherit;
+  }
+  #api-navbar {
+    .flex(0 0 108px);
+  }
+}
+
+
+/* temporary wedge. Can be replaced at end */
+.with-sidebar {
+  #breadcrumbs {
+    float: left;
+  }
+  #api-navbar {
+    float: right;
+  }
+}
+.right-header-wrapper {
+  #api-navbar {
+    float: right;
+  }
+}
+

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -326,15 +326,13 @@ with_tabs_sidebar.html
   top: @collapsedNavWidth;
   left: 0;
   background-color: @secondarySidebar;
+  margin-top: 6px;
   > div.inner {
     display: block;
   }
-  margin-top: 6px;
-
   .nav-list:last-child {
     margin-bottom: 30px;
   }
-
 }
 
 .scrollable {
@@ -415,9 +413,7 @@ with_tabs_sidebar.html
 #dashboard-content {
 
   & > div {
-    padding-left: 15px;
-    padding-right: 15px;
-    padding-top: 20px;
+    padding: @panelPadding;
   }
 
   &.row-fluid {
@@ -533,7 +529,7 @@ with_tabs_sidebar.html
 
 .with-sidebar.content-area {
   position: absolute;
-  top: 0;
+  top: 65px;
   bottom: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
This removes the old .fixed-header class on the header/div
element in the templates and cleans up the CSS a bit to use
flexbox to layout the subelements.

N.B. In fixing this I also tweaked the active tasks header
to reduce the height a little (it was affected at one point)