### PR TITLE
Catch all errors when failing to load doc

### DIFF
--- a/app/addons/documents/doc-editor/actions.js
+++ b/app/addons/documents/doc-editor/actions.js
@@ -39,10 +39,8 @@ function (app, FauxtonAPI, ActionTypes) {
         params.onLoaded();
       }
     }, function (xhr, reason, msg) {
-      if (xhr.status === 404) {
-        errorNotification('The document does not exist.');
-        FauxtonAPI.navigate(FauxtonAPI.urls('allDocs', 'app', params.database.id, ''));
-      }
+      errorNotification('The document does not exist.');
+      FauxtonAPI.navigate(FauxtonAPI.urls('allDocs', 'app', params.database.id, ''));
     });
   }
 


### PR DESCRIPTION
This makes the error handling for loading a doc a little more
generic. This actually caused an issue on the dash, not with
Fauxton - but good to change so that all errors are caught when
failing to load a document and the user's redirected back
to the database all docs page.