### PR TITLE
Fix for error caused by newlines in View search -> keys field

### DIFF
--- a/app/addons/documents/queryoptions/stores.js
+++ b/app/addons/documents/queryoptions/stores.js
@@ -211,7 +211,7 @@ function (app, FauxtonAPI, ActionTypes) {
           params.end_key = betweenKeys.endkey;
         }
       } else if (this._showByKeys) {
-        params.keys = this._byKeys;
+        params.keys = this._byKeys.replace(/\r?\n/g, '');
       }
 
       if (this._updateSeq) {

--- a/app/addons/documents/tests/nightwatch/viewQueryOptions.js
+++ b/app/addons/documents/tests/nightwatch/viewQueryOptions.js
@@ -30,5 +30,26 @@ module.exports = {
       .assert.elementNotPresent('#right-content [data-id="document_0"]')
       .assert.elementPresent('#right-content [data-id="document_1"]')
     .end();
+  },
+
+  'Edit view: Queryoptions works querying index with newlines in key field': function (client) {
+    /*jshint multistr: true */
+    var waitTime = client.globals.maxWaitTime,
+      newDatabaseName = client.globals.testDatabaseName,
+      baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .populateDatabase(newDatabaseName, 3)
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_design/keyview/_view/keyview')
+      .clickWhenVisible('#toggle-query', waitTime, false)
+      .clickWhenVisible('#byKeys', waitTime, false)
+      .setValue('#keys-input', '["document_1",\n"document_2"]')
+      .clickWhenVisible('#query-options .btn-success')
+      .waitForElementNotPresent('#right-content [data-id="document_0"]', waitTime, false)
+      .assert.elementNotPresent('#right-content [data-id="document_0"]')
+      .assert.elementPresent('#right-content [data-id="document_1"]')
+      .end();
   }
+
 };


### PR DESCRIPTION
Curious, very specific bug. When doing a search on a View and entering
a value for the Keys field that contains a newline between two values,
the encoding of the URL gets all messed up and you see a
"missing_named_view" error get thrown within the UI. This ticket simply
strips out newlines in that field.

How to reproduce:
- create a new view
- click on the "Query Options" section and click on Keys to expand
that section. Enter:

["one",
"two"]

Note the newline after the "one" line.
- submit the form.

Result: JS errors and the error notification.