### PR TITLE
Prevent overlapping of Ace highlighted row and trays

### DIFF
--- a/app/addons/documents/assets/less/doc-editor.less
+++ b/app/addons/documents/assets/less/doc-editor.less
@@ -59,6 +59,7 @@
   }
 
   &#dashboard > header {
+    z-index: 2;
     .box-shadow(none);
   }
 


### PR DESCRIPTION
On the full page doc editor, if you have the cursor on the first
row and click on API URL to see the tray, the tray gets overlapped
slightly by the highlighted row.