### PR TITLE
Remove old, incorrect classes

### DIFF
--- a/app/addons/documents/index-editor/components.react.jsx
+++ b/app/addons/documents/index-editor/components.react.jsx
@@ -434,7 +434,7 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, ReactComponents) 
   var EditorController = React.createClass({
     render: function () {
       return (
-        <div className="editor-wrapper span5 scrollable">
+        <div className="editor-wrapper">
           <Editor />
         </div>
       );

--- a/app/addons/documents/mango/mango.components.react.jsx
+++ b/app/addons/documents/mango/mango.components.react.jsx
@@ -74,7 +74,7 @@ function (app, FauxtonAPI, React, Stores, Actions,
       var loadLines;
       if (this.state.isLoading) {
         return (
-          <div className="editor-wrapper span5 scrollable">
+          <div className="editor-wrapper">
             <ReactComponents.LoadLines />
           </div>
         );


### PR DESCRIPTION
Apologies @robertkowalski you were quite right on an earlier ticket:
these classes should have been removed; I didn't see the problem
in Fauxton.

To confirm: check the Edit View page layout looks normal.