### PR TITLE
Add a check to confirm test exists

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -364,6 +364,7 @@ module.exports = function (grunt) {
       }
     },
     gen_initialize: templateSettings,
+    checkTestExists: templateSettings,
 
     mkcouchdb: couch_config,
     rmcouchdb: couch_config,
@@ -540,7 +541,7 @@ module.exports = function (grunt) {
    */
   // clean out previous build artifacts and lint
   grunt.registerTask('lint', ['clean', 'jshint']);
-  grunt.registerTask('test', ['clean:release', 'dependencies', 'jsx', 'jshint', 'shell:stylecheck', 'gen_initialize:development', 'test_inline']);
+  grunt.registerTask('test', ['checkTestExists', 'clean:release', 'dependencies', 'jsx', 'jshint', 'shell:stylecheck', 'gen_initialize:development', 'test_inline']);
 
   // lighter weight test task for use inside dev/watch
   grunt.registerTask('test_inline', ['mochaSetup', 'jst', 'concat:test_config_js', 'shell:phantomjs']);

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -107,6 +107,16 @@ module.exports = function (grunt) {
     grunt.file.write(dest, tmpl(app));
   });
 
+  // quick sanity check to run immediately when the user specifies a specific mocha test to run, like
+  //     `grunt test --file=./my/test.js`
+  // This dies immediately if the file doesn't exist and notifies the user.
+  grunt.registerMultiTask('checkTestExists', 'Confirms that if a specific mocha test exists', function () {
+    var fileSrc = grunt.option('file');
+    if (fileSrc && !fs.existsSync(fileSrc)) {
+      grunt.fail.fatal('Mocha test file not found: ' + fileSrc);
+    }
+  });
+
   grunt.registerMultiTask('mochaSetup', 'Generate a config.js and runner.html for tests', function () {
     var data = this.data,
         configInfo,


### PR DESCRIPTION
A pet peeve with running a single mocha test on the command line,
like `grunt file --file=./a/b/c.js` is that (a) it spends several
seconds compiling, copying etc. then (b) just ends. It doesn't
notify you that the file doesn't exist, you just have to infer it
or spend a few minutes being confused.

This little PR adds a test that runs up front: if the file you
entered doesn't exist, it lets you know about it and stops the
process immediately.