### PR TITLE
Fix for Safari not recognizing autofill on login form

### DIFF
--- a/app/addons/auth/test/auth.componentsSpec.react.jsx
+++ b/app/addons/auth/test/auth.componentsSpec.react.jsx
@@ -26,22 +26,43 @@ define([
   describe('Auth -- Components', function () {
 
     describe('LoginForm', function () {
-      var container, loginForm;
+      var container, loginForm, stub;
 
       beforeEach(function () {
+        stub = sinon.stub(Actions, 'login');
         container = document.createElement('div');
-        loginForm = TestUtils.renderIntoDocument(<Components.LoginForm />, container);
       });
 
       afterEach(function () {
         React.unmountComponentAtNode(container);
+        createAdminSidebarStore.reset();
+        Actions.login.restore();
       });
 
       it('should trigger login event when form submitted', function () {
-        var spy = sinon.spy(Actions, 'login');
+        loginForm = TestUtils.renderIntoDocument(<Components.LoginForm />, container);
         TestUtils.Simulate.submit($(loginForm.getDOMNode()).find('#login')[0]);
-        assert.ok(spy.calledOnce);
+        assert.ok(stub.calledOnce);
       });
+
+      it('in case of nothing in state, should pass actual values to Actions.login()', function () {
+        var username = 'bob';
+        var password = 'smith';
+
+        loginForm = TestUtils.renderIntoDocument(
+          <Components.LoginForm
+            testBlankUsername={username}
+            testBlankPassword={password}
+          />, container);
+
+        TestUtils.Simulate.submit($(loginForm.getDOMNode()).find('#login')[0]);
+        assert.ok(stub.calledOnce);
+
+        // confirm Actions.login() received the values that weren't in the DOM
+        assert.equal(stub.args[0][0], username);
+        assert.equal(stub.args[0][1], password);
+      });
+
     });
 
     describe('ChangePasswordForm', function () {


### PR DESCRIPTION
Safari doesn't trigger change events for form field autofills,
so the state of the login component doesn't updated, triggering
the rather irritating "you didn't fill in all the fields" error
when visually you sure did.

Since existing polyfill options don't work (see ticket), this fix
explicitly checks for the condition of a mismatch of
username-password form values and component state. It's a little
inelegant, but justifiable I think.

Closes COUCHDB-2829