### PR TITLE
Moving with_sidebar template to flexbox

### DIFF
--- a/app/addons/auth/assets/less/auth.less
+++ b/app/addons/auth/assets/less/auth.less
@@ -18,16 +18,14 @@
 
 .sidenav header {
   padding-left: 24px;
-
   h3 {
-    margin: 8px 0px 4px;
+    margin: 8px 0 4px;
   }
 }
 
-.auth-page {
+#dashboard-content .auth-page {
   padding: 20px;
-
   h3 {
-    margin-top: 0px;
+    margin-top: 0;
   }
 }

--- a/app/addons/components/assets/less/header-togglebutton.less
+++ b/app/addons/components/assets/less/header-togglebutton.less
@@ -62,6 +62,7 @@ button.header-control-box:focus {
 button.control-toggle-alternative-header {
   float: left;
   border-right: 1px solid @btnBorder;
+  border-left: none;
 }
 
 button.control-toggle-alternative-header.js-headerbar-togglebutton-selected {

--- a/app/templates/layouts/one_pane.html
+++ b/app/templates/layouts/one_pane.html
@@ -12,11 +12,13 @@ License for the specific language governing permissions and limitations under
 the License.
 */%>
 <div id="dashboard" class="one-pane">
-  <header class="flex-layout flex-row">
-    <div id="breadcrumbs" class="flex-body"></div>
-    <div id="right-header"></div>
-    <div id="api-navbar"></div>
-    <div id="notification-center-btn"></div>
+  <header>
+    <div class="flex-layout flex-row">
+      <div id="breadcrumbs" class="flex-body"></div>
+      <div id="right-header"></div>
+      <div id="api-navbar"></div>
+      <div id="notification-center-btn"></div>
+    </div>
   </header>
 
   <div class="content-area container-fluid">

--- a/app/templates/layouts/with_sidebar.html
+++ b/app/templates/layouts/with_sidebar.html
@@ -11,15 +11,17 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
 */%>
-<div id="dashboard">
+<div id="dashboard" class="template-with-sidebar flex-layout flex-col">
   <header class="flex-layout flex-row">
-    <div id="breadcrumbs" class="flex-body"></div>
-    <div id="api-navbar"></div>
-    <div id="notification-center-btn"></div>
+    <div class="flex-layout flex-row">
+      <div id="breadcrumbs" class="flex-body"></div>
+      <div id="api-navbar" class="flex-fill"></div>
+      <div id="notification-center-btn" class="flex-fill"></div>
+    </div>
   </header>
 
-  <div class="with-sidebar content-area">
+  <div class="template-content flex-body flex-layout flex-row">
     <div id="sidebar-content"></div>
-    <div id="dashboard-content" class="scrollable list"></div>
+    <div id="dashboard-content" class="flex-body"></div>
   </div>
 </div>

--- a/app/templates/layouts/with_tabs_sidebar.html
+++ b/app/templates/layouts/with_tabs_sidebar.html
@@ -13,14 +13,15 @@ the License.
 */%>
 
 <div id="dashboard" class="with-sidebar">
-
-  <header class="flex-layout flex-row two-panel-header">
-    <div id="breadcrumbs" class="sidebar"></div>
-    <div class="header-right-panel flex-layout flex-row flex-body">
-      <div id="react-headerbar" class="flex-body"></div>
-      <div id="right-header" class="flex-body"></div>
-      <div id="api-navbar"></div>
-      <div id="notification-center-btn"></div>
+  <header class="two-panel-header">
+    <div class="flex-layout flex-row">
+      <div id="breadcrumbs" class="sidebar"></div>
+      <div class="right-header-wrapper flex-layout flex-row flex-body">
+        <div id="react-headerbar" class="flex-body"></div>
+        <div id="right-header" class="flex-fill"></div>
+        <div id="api-navbar" class="flex-fill"></div>
+        <div id="notification-center-btn" class="flex-fill"></div>
+      </div>
     </div>
   </header>
 

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -223,17 +223,6 @@ table.databases {
   }
 }
 
-#sidebar-content {
-  position: absolute;
-  top: 0;
-  width: @sidebarWidth;
-  left: 0;
-  background-color: @secondarySidebar;
-  > div.inner {
-    display: block;
-  }
-}
-
 #dashboard-content .scrollable {
   height: auto;
   overflow-y: auto;
@@ -250,8 +239,6 @@ table.databases {
 /*ONE PANEL TEMPLATE ONLY STYLES  AKA _all_dbs */
 
 .result-tools{
-  border-bottom: 1px solid #999999;
-  padding: 5px 0;
   border-bottom: 1px solid #999999;
   padding: 10px 0;
   float: left;
@@ -390,14 +377,18 @@ div.spinner {
 
 //---header--//
 #dashboard > header {
-  height: 65px;
   background-color: @breadcrumbBG;
-  .bottom-shadow-border();
+  height: 64px;
 
-  /* this is necessary to allow the 6px box shadow overlap the panels below */
-  position: absolute;
-  width: 100%;
-  z-index: 1;
+  /* the position absolute is necessary to allow the 6px box shadow overlap the panels below. The parent <header>
+   ensures the flexbox height is respected */
+  &>div {
+    height: 65px;
+    .bottom-shadow-border();
+    position: absolute;
+    width: 100%;
+    z-index: 1;
+  }
 }
 
 body #dashboard .two-panel-header {
@@ -417,8 +408,12 @@ body #dashboard .two-panel-header {
 }
 
 
+body #dashboard .flex-body#breadcrumbs {
+  overflow: hidden;
+}
+
 #breadcrumbs {
-  height: @collapsedNavWidth;
+  height: 64px;
 
   /* these styles are for the new header*/
   .header-left{

--- a/assets/less/layouts.less
+++ b/assets/less/layouts.less
@@ -55,6 +55,11 @@ body #dashboard .flex-body, body #notification-center .flex-body {
   }
 }
 
+/* tells an element to be as large as the content. This will replace the hardcoded ones */
+body #dashboard .flex-fill {
+  .flex(0 0 auto);
+}
+
 /* used on the databases page. To be removed once moved to flexbox */
 .one-pane #footer {
   position: absolute;
@@ -66,7 +71,15 @@ body #dashboard .flex-body, body #notification-center .flex-body {
 /* this drops .fixed-header, which was a position:absolute'd element, and switches it and all children to use flexbox. */
 .one-pane > header {
   width: 100%;
-  .bottom-shadow-border();
+
+//  .bottom-shadow-border();
+
+  #breadcrumbs {
+    overflow: hidden;
+
+    /* overrides - can be removed later */
+    float: none;
+  }
 
   #right-header {
     -ms-flex-preferred-size: auto;
@@ -75,8 +88,8 @@ body #dashboard .flex-body, body #notification-center .flex-body {
     flex-shrink: 0;
     flex-basis: inherit;
   }
-  #breadcrumbs {
-    overflow: hidden;
+  #api-navbar {
+    .flex(0 0 auto);
   }
 }
 
@@ -146,8 +159,32 @@ body #dashboard.two-pane {
     position: inherit;
 
     #breadcrumbs {
+      height: 64px;
       .flex(0 0 440px);
       overflow: hidden;
     }
   }
+}
+
+body #dashboard.template-with-sidebar {
+  header {
+    .flex(0 0 65px);
+  }
+  #sidebar-content {
+    .flex(0 0 330px);
+    overflow: auto;
+    overflow-x: hidden;
+  }
+  .template-content {
+    overflow: hidden;
+  }
+  #dashboard-content {
+    border-left: 1px solid @grayLight;
+    .left-shadow-border();
+  }
+}
+
+/* tmp. Will be removed at end of flexbox refactor */
+aside#sidebar-content {
+  top: 64px;
 }

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -291,6 +291,7 @@ with_tabs_sidebar.html
 #dashboard {
   position: relative;
   left: @navWidth;
+  padding-left: 0;
   background-color: @sidebarBG;
   height: 100%;
   width: 100%;
@@ -322,9 +323,6 @@ with_tabs_sidebar.html
 
 #sidebar-content {
   width: @sidebarWidth;
-  position: absolute;
-  top: @collapsedNavWidth;
-  left: 0;
   background-color: @secondarySidebar;
   margin-top: 6px;
   > div.inner {
@@ -522,12 +520,4 @@ with_tabs_sidebar.html
       display: none;
     }
   }
-}
-
-.with-sidebar.content-area {
-  position: absolute;
-  top: 65px;
-  bottom: 0;
-  left: 0;
-  right: 0;
 }


### PR DESCRIPTION
This ticket updates the `with_sidebar.html` template which is used on
the account page (cluster of one) only right now, but it also touches on
other pages as well to clean up a little CSS, so a cursory look over the 
UI is probably a good idea.

After this one's merged, I'll tackle the `with_tabs_sidebar.html` template
which should allow me to remove a lot of old CSS!