### PR TITLE
Improve db page error handling

### DIFF
--- a/app/addons/databases/assets/less/databases.less
+++ b/app/addons/databases/assets/less/databases.less
@@ -62,3 +62,8 @@
 #database-pagination {
   float: right;
 }
+
+.database-load-fail {
+  color: #999999;
+  height: 49px;
+}

--- a/app/addons/databases/components.react.jsx
+++ b/app/addons/databases/components.react.jsx
@@ -107,6 +107,10 @@ define([
 
   var DatabaseRow = React.createClass({
 
+    propTypes: {
+      row: React.PropTypes.object
+    },
+
     renderGraveyard: function (row) {
       if (row.status.isGraveYard()) {
         return (
@@ -127,8 +131,19 @@ define([
     render: function () {
       var row = this.props.row;
       var name = row.get("name");
+
+      // if the row status failed to load, inform the user
+      if (!row.status.loadSuccess) {
+        return (
+          <tr>
+            <td>{name}</td>
+            <td colSpan="4" className="database-load-fail">This database failed to load.</td>
+          </tr>
+        );
+      }
       var encoded = app.utils.safeURLName(name);
       var size = Helpers.formatSize(row.status.dataSize());
+
       return (
         <tr>
           <td>

--- a/app/addons/databases/resources.js
+++ b/app/addons/databases/resources.js
@@ -123,6 +123,7 @@ function (app, FauxtonAPI, Documents) {
 
     initialize: function (options) {
       this.database = options.database;
+      this.loadSuccess = false;
     },
 
     numDocs: function () {
@@ -158,6 +159,11 @@ function (app, FauxtonAPI, Documents) {
       } else {
         return 0;
       }
+    },
+
+    parse: function (resp) {
+      this.loadSuccess = true;
+      return resp;
     },
 
     // a sure-fire way to know when the DB size info is actually available; dataSize() may return 0 before or after

--- a/app/addons/databases/tests/componentsSpec.react.jsx
+++ b/app/addons/databases/tests/componentsSpec.react.jsx
@@ -40,6 +40,7 @@ define([
               }
             },
             "status": {
+              "loadSuccess": true,
               "dataSize": function () {
                 return 2 * 1024 * 1024;
               },
@@ -63,6 +64,7 @@ define([
               }
             },
             "status": {
+              "loadSuccess": true,
               "dataSize": function () {
                 return 1024;
               },
@@ -270,6 +272,7 @@ define([
 
       var row = new Backbone.Model({ name: 'db name' });
       row.status = {
+        loadSuccess: true,
         dataSize: function () { return 0; },
         numDocs: function () { return 0; },
         updateSeq: function () { return 0; },
@@ -285,6 +288,35 @@ define([
       FauxtonAPI.unRegisterExtension('DatabaseTable:databaseRow');
 
       Stores.databasesStore.reset();
+    });
+
+    it('shows error message if row marked as failed to load', function () {
+      var row = new Backbone.Model({ name: 'db name' });
+      row.status = {
+        loadSuccess: false,
+        dataSize: function () { return 0; },
+        numDocs: function () { return 0; },
+        updateSeq: function () { return 0; },
+        isGraveYard: function () { return false; }
+      };
+
+      var databaseRow = TestUtils.renderIntoDocument(<Views.DatabaseTable body={[row]} />, container);
+      assert.equal($(databaseRow.getDOMNode()).find('.database-load-fail').length, 1);
+    });
+
+    it('shows no error if row marked as loaded', function () {
+      var row = new Backbone.Model({ name: 'db name' });
+      row.status = {
+        loadSuccess: true,
+        dataSize: function () { return 0; },
+        numDocs: function () { return 0; },
+        updateSeq: function () { return 0; },
+        isGraveYard: function () { return false; }
+      };
+
+      var databaseRow = TestUtils.renderIntoDocument(<Views.DatabaseTable body={[row]} />, container);
+
+      assert.equal($(databaseRow.getDOMNode()).find('.database-load-fail').length, 0);
     });
 
   });


### PR DESCRIPTION
This PR fixes an old bug with the databases page where if one
database query fails, the remaining responses that haven't been
returned don't get populated and the database table has a lot
of incomplete rows.

Now the individual failed database rows don't affect the others and
show a "This database failed to load" message to make it clear to
the user.

_______________

How to test:
- The https://issues.apache.org/jira/browse/COUCHDB-2243 ticket includes some instructions. For my part, I had Fiddler installed, so I just overwrote the `_all_dbs` request to return an array of valid database names, plus a made-up one in the middle.

_______________

Closes COUCHDB-2243

<img width="1226" alt="screen shot 2015-10-05 at 8 13 43 pm" src="https://cloud.githubusercontent.com/assets/512116/10299597/b9c4d36a-6ba0-11e5-89c2-267d6eda163f.png">
