### PR TITLE
Grunt mocha test file existence check

### DIFF
--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -112,7 +112,9 @@ module.exports = function (grunt) {
   // This dies immediately if the file doesn't exist and notifies the user.
   grunt.registerMultiTask('checkTestExists', 'Confirms that if a specific mocha test exists', function () {
     var fileSrc = grunt.option('file');
-    if (fileSrc && !fs.existsSync(fileSrc)) {
+
+    // the + 'x' check checks for jsx files that haven't been compiled yet
+    if (fileSrc && !fs.existsSync(fileSrc) && !fs.existsSync(fileSrc + 'x')) {
       grunt.fail.fatal('Mocha test file not found: ' + fileSrc);
     }
   });


### PR DESCRIPTION
This is a small tweak to a recent commit that does an up-front
check to confirm the mocha test exists. It had failed to check
the condition where the user was trying to run a .js mocha test
for a .jsx file that hadn't yet been compiled. This expands on the
existence check for a .jsx version of the file.