### PR TITLE
Fix for logout link showing up twice in footer

### DIFF
--- a/app/addons/auth/base.js
+++ b/app/addons/auth/base.js
@@ -29,7 +29,7 @@ function (app, FauxtonAPI, Auth) {
       title: "Login",
       href: "#login",
       icon: "fonticon-user",
-      bottomNav: true,
+      bottomNav: true
     });
 
     Auth.session.on('change', function () {
@@ -42,7 +42,7 @@ function (app, FauxtonAPI, Auth) {
           title: "Admin Party!",
           href: "#createAdmin",
           icon: "fonticon-user",
-          bottomNav: true,
+          bottomNav: true
         };
       } else if (session.isLoggedIn()) {
         link = {
@@ -50,8 +50,11 @@ function (app, FauxtonAPI, Auth) {
           title: session.user().name,
           href: "#changePassword",
           icon: "fonticon-user",
-          bottomNav: true,
+          bottomNav: true
         };
+
+        // ensure the footer link is removed before adding it
+        FauxtonAPI.removeHeaderLink({id: "logout", footerNav: true});
 
         FauxtonAPI.addHeaderLink({
           id: 'logout',

--- a/app/addons/auth/base.js
+++ b/app/addons/auth/base.js
@@ -11,9 +11,9 @@
 // the License.
 
 define([
-  "app",
-  "api",
-  "addons/auth/routes"
+  'app',
+  'api',
+  'addons/auth/routes'
 ],
 
 function (app, FauxtonAPI, Auth) {
@@ -25,10 +25,10 @@ function (app, FauxtonAPI, Auth) {
   Auth.initialize = function () {
 
     FauxtonAPI.addHeaderLink({
-      id: "auth",
-      title: "Login",
-      href: "#login",
-      icon: "fonticon-user",
+      id: 'auth',
+      title: 'Login',
+      href: '#login',
+      icon: 'fonticon-user',
       bottomNav: true
     });
 
@@ -38,44 +38,42 @@ function (app, FauxtonAPI, Auth) {
 
       if (session.isAdminParty()) {
         link = {
-          id: "auth",
-          title: "Admin Party!",
-          href: "#createAdmin",
-          icon: "fonticon-user",
+          id: 'auth',
+          title: 'Admin Party!',
+          href: '#createAdmin',
+          icon: 'fonticon-user',
           bottomNav: true
         };
       } else if (session.isLoggedIn()) {
         link = {
-          id: "auth",
+          id: 'auth',
           title: session.user().name,
-          href: "#changePassword",
-          icon: "fonticon-user",
+          href: '#changePassword',
+          icon: 'fonticon-user',
           bottomNav: true
         };
 
         // ensure the footer link is removed before adding it
-        FauxtonAPI.removeHeaderLink({id: "logout", footerNav: true});
-
+        FauxtonAPI.removeHeaderLink({ id: 'logout', footerNav: true });
         FauxtonAPI.addHeaderLink({
           id: 'logout',
           footerNav: true,
-          href: "#logout",
-          title: "Logout",
-          icon: "",
+          href: '#logout',
+          title: 'Logout',
+          icon: '',
           className: 'logout'
         });
       } else {
         link = {
-          id: "auth",
+          id: 'auth',
           title: 'Login',
-          href: "#login",
-          icon: "fonticon-user",
-          bottomNav: true,
+          href: '#login',
+          icon: 'fonticon-user',
+          bottomNav: true
         };
-        FauxtonAPI.removeHeaderLink({id: "logout", footerNav: true});
+        FauxtonAPI.removeHeaderLink({ id: 'logout', footerNav: true });
       }
       FauxtonAPI.updateHeaderLink(link);
-
     });
 
     Auth.session.fetchUser().then(function () {
@@ -86,10 +84,10 @@ function (app, FauxtonAPI, Auth) {
       var deferred = $.Deferred();
 
       if (session.isAdminParty()) {
-        session.trigger("authenticated");
+        session.trigger('authenticated');
         deferred.resolve();
       } else if (session.matchesRoles(roles)) {
-        session.trigger("authenticated");
+        session.trigger('authenticated');
         deferred.resolve();
       } else {
         deferred.reject();
@@ -105,7 +103,7 @@ function (app, FauxtonAPI, Auth) {
       if (pattern.test(url)) {
         url = url.replace('login?urlback=', '');
       }
-      FauxtonAPI.navigate('/login?urlback=' + url, {replace: true});
+      FauxtonAPI.navigate('/login?urlback=' + url, { replace: true });
     };
 
     FauxtonAPI.auth.registerAuth(auth);

--- a/app/addons/fauxton/navigation/stores.js
+++ b/app/addons/fauxton/navigation/stores.js
@@ -171,13 +171,14 @@ function (app, FauxtonAPI, ActionTypes) {
 
     dispatch: function (action) {
       switch (action.type) {
-
         case ActionTypes.ADD_NAVBAR_LINK:
           this.addLink(action.link);
         break;
+
         case ActionTypes.TOGGLE_NAVBAR_MENU:
           this.toggleMenu();
         break;
+
         case ActionTypes.UPDATE_NAVBAR_LINK:
           this.updateLink(action.link);
         break;

--- a/app/addons/fauxton/navigation/tests/componentsSpec.react.jsx
+++ b/app/addons/fauxton/navigation/tests/componentsSpec.react.jsx
@@ -13,9 +13,11 @@ define([
   'api',
   'addons/fauxton/navigation/components.react',
   'addons/fauxton/navigation/actions',
+  'core/auth',
+  'addons/auth/base',
   'testUtils',
   "react"
-], function (FauxtonAPI, Views, Actions, utils, React) {
+], function (FauxtonAPI, Views, Actions, Auth, BaseAuth, utils, React) {
 
   var assert = utils.assert;
   var TestUtils = React.addons.TestUtils;
@@ -40,6 +42,33 @@ define([
         assert.ok(toggleMenu.calledOnce);
       });
 
+    });
+
+    it('logout link only ever appears once', function () {
+      FauxtonAPI.auth = new Auth();
+      sinon.stub(FauxtonAPI.session, 'isLoggedIn').returns(true);
+      sinon.stub(FauxtonAPI.session, 'isAdminParty').returns(false);
+      sinon.stub(FauxtonAPI.session, 'user').returns({ name: 'test-user' });
+      BaseAuth.initialize();
+
+      var container = document.createElement('div');
+      var el = TestUtils.renderIntoDocument(<Views.NavBar />, container);
+
+      FauxtonAPI.session.trigger('change');
+
+      // confirm the logout link is present
+      var matches = React.findDOMNode(el).outerHTML.match(/Logout/);
+      assert.equal(matches.length, 1);
+
+      // now confirm there's still only a single logout link after publishing multiple
+      FauxtonAPI.session.trigger('change');
+      FauxtonAPI.session.trigger('change');
+      matches = React.findDOMNode(el).outerHTML.match(/Logout/);
+      assert.equal(matches.length, 1);
+
+      FauxtonAPI.session.isLoggedIn.restore();
+      FauxtonAPI.session.user.restore();
+      FauxtonAPI.session.isAdminParty.restore();
     });
 
     describe('CSRF info', function () {


### PR DESCRIPTION
An old bug is the Logout link in the footer showing up twice. It's
a little difficult to reproduce consistently, but I've found this
works the best (Mac, chrome):
1. open dev tools (it slows down browser performance),
2. Login to Fauxton, notice the single "logout" link in footer.
3. click on the browser URL bar and click <enter>
4. Repeat the above until you see two "logout" links in the footer.

What's happening is that when you see two logout links, 
the change event on Auth.session is firing twice, each of which 
adds a new footer link.

This fix just ensures the link is removed prior to adding it.