### PR TITLE
make code for getting safe doc ids reusable

### DIFF
--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -54,7 +54,7 @@ define([
     },
 
     docType: function () {
-      return this.id && this.id.match(/^_design\//) ? "design doc" : "doc";
+      return app.utils.getDocTypeFromId(this.id);
     },
 
     isDeletable: function () {
@@ -155,17 +155,8 @@ define([
       return this;
     },
 
-    // Need this to work around backbone router thinking _design/foo
-    // is a separate route. Alternatively, maybe these should be
-    // treated separately. For instance, we could default into the
-    // json editor for docs, or into a ddoc specific page.
     safeID: function () {
-      if (this.isDdoc()) {
-        var ddoc = this.id.replace(/^_design\//, "");
-        return "_design/" + app.utils.safeURLName(ddoc);
-      }else {
-        return app.utils.safeURLName(this.id);
-      }
+      return app.utils.getSafeIdForDoc(this.id);
     },
 
     destroy: function () {

--- a/app/core/tests/utilsSpec.js
+++ b/app/core/tests/utilsSpec.js
@@ -18,6 +18,37 @@ define([
 
   describe('Utils', function () {
 
+    describe('getDocTypeFromId', function () {
+
+      it('returns doc if id not given', function () {
+        var res = utils.getDocTypeFromId();
+        assert.equal(res, 'doc');
+      });
+
+      it('returns design doc for design docs', function () {
+        var res = utils.getDocTypeFromId('_design/foobar');
+        assert.equal(res, 'design doc');
+      });
+
+      it('returns doc for all others', function () {
+        var res = utils.getDocTypeFromId('blerg');
+        assert.equal(res, 'doc');
+      });
+    });
+
+    describe('getSafeIdForDoc', function () {
+
+      it('keeps _design/ intact', function () {
+        var res = utils.getSafeIdForDoc('_design/foo/do');
+        assert.equal(res, '_design/foo%2Fdo');
+      });
+
+      it('encodes all other', function () {
+        var res = utils.getSafeIdForDoc('_redesign/foobar');
+        assert.equal(res, '_redesign%2Ffoobar');
+      });
+    });
+
     describe('localStorage', function () {
 
       it('Should get undefined when getting a non-existent key', function () {

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -98,6 +98,27 @@ function ($, _) {
       return (checkforBad !== null) ? encodeURIComponent(name) : name;
     },
 
+    getDocTypeFromId: function (id) {
+      if (id && /^_design\//.test(id)) {
+        return 'design doc';
+      }
+
+      return 'doc';
+    },
+
+    // Need this to work around backbone router thinking _design/foo
+    // is a separate route. Alternatively, maybe these should be
+    // treated separately. For instance, we could default into the
+    // json editor for docs, or into a ddoc specific page.
+    getSafeIdForDoc: function (id) {
+      if (utils.getDocTypeFromId(id) === 'design doc') {
+        var ddoc = id.replace(/^_design\//, '');
+        return '_design/' + utils.safeURLName(ddoc);
+      }
+
+      return utils.safeURLName(id);
+    },
+
     // a pair of simple local storage wrapper functions. These ward against problems getting or
     // setting (e.g. local storage full) and allow you to get/set complex data structures
     localStorageSet: function (key, value) {


### PR DESCRIPTION
this puts the tools for getting a safe id for a doc into a shared
location.

part of https://github.com/apache/couchdb-fauxton/pull/543 which needs further design work but i need the safe-id functionality in other places now