### PR TITLE
Fix for header on full page doc editor

### DIFF
--- a/app/addons/documents/assets/less/doc-editor.less
+++ b/app/addons/documents/assets/less/doc-editor.less
@@ -55,7 +55,9 @@
 
   &#dashboard > header {
     z-index: 2;
-    .box-shadow(none);
+    > div {
+      .box-shadow(none);
+    }
   }
 
   #editor-container {

--- a/app/addons/documents/tests/nightwatch/createsDocument.js
+++ b/app/addons/documents/tests/nightwatch/createsDocument.js
@@ -28,6 +28,10 @@ module.exports = {
       .verify.urlEquals(baseUrl + '/#/database/' + newDatabaseName + '/new')
       .waitForElementPresent('.ace_layer.ace_cursor-layer.ace_hidden-cursors', waitTime, false)
 
+      // confirm the header elements are showing up
+      .waitForElementVisible('.js-lastelement', waitTime, true)
+      .waitForElementVisible('#api-navbar', waitTime, true)
+
       //.pause(1000) // looks like auto-focus happens during the next execute() line, so this slows it down
       .execute('\
         var editor = ace.edit("doc-editor");\

--- a/app/templates/layouts/doc_editor.html
+++ b/app/templates/layouts/doc_editor.html
@@ -13,10 +13,12 @@ the License.
 */%>
 
 <div id="dashboard" class="one-pane doc-editor-page">
-  <header class="flex-layout flex-row">
-    <div id="breadcrumbs" class="flex-body"></div>
-    <div id="api-navbar"></div>
-    <div id="notification-center-btn"></div>
+  <header>
+    <div class="flex-layout flex-row">
+      <div id="breadcrumbs" class="flex-body"></div>
+      <div id="api-navbar"></div>
+      <div id="notification-center-btn"></div>
+    </div>
   </header>
 
   <div id="dashboard-content"></div>


### PR DESCRIPTION
Drat, missed this one. This fixes a layout issue on the full
page doc editor header. Test included to confirm the breadcrumb
and API URL are always visible.