### PR TITLE
Pass data to API Bar via actions

### DIFF
--- a/app/addons/components/actions.js
+++ b/app/addons/components/actions.js
@@ -1,0 +1,45 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  'api',
+  'addons/components/actiontypes'
+],
+function (FauxtonAPI, ActionTypes) {
+
+  function showAPIBar () {
+    FauxtonAPI.dispatch({ type: ActionTypes.SHOW_API_BAR });
+  }
+
+  function hideAPIBar () {
+    FauxtonAPI.dispatch({ type: ActionTypes.HIDE_API_BAR });
+  }
+
+  // general usage for setting multiple params at once. If a param isn't passed, it's not overridden
+  function updateAPIBar (params) {
+    FauxtonAPI.dispatch({
+      type: ActionTypes.UPDATE_API_BAR,
+      options: {
+        visible: params.visible,
+        endpoint: params.endpoint,
+        docURL: params.docURL
+      }
+    });
+  }
+
+  return {
+    showAPIBar: showAPIBar,
+    hideAPIBar: hideAPIBar,
+    updateAPIBar: updateAPIBar
+  };
+
+});

--- a/app/addons/components/actiontypes.js
+++ b/app/addons/components/actiontypes.js
@@ -1,0 +1,21 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([],  function () {
+
+  return {
+    SHOW_API_BAR: 'SHOW_API_BAR',
+    HIDE_API_BAR: 'HIDE_API_BAR',
+    UPDATE_API_BAR: 'UPDATE_API_BAR'
+  };
+
+});

--- a/app/addons/components/stores.js
+++ b/app/addons/components/stores.js
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  'api',
+  'app',
+  'addons/components/actiontypes'
+],
+
+function (FauxtonAPI, app, ActionTypes) {
+  var Stores = {};
+
+
+  Stores.ComponentStore = FauxtonAPI.Store.extend({
+    initialize: function () {
+      this.reset();
+    },
+
+    reset: function () {
+      this._apiBarVisible = true;
+      this._endpoint = '';
+      this._docURL = FauxtonAPI.constants.DOC_URLS.GENERAL;
+    },
+
+    isAPIBarVisible: function () {
+      return this._apiBarVisible;
+    },
+
+    updateAPIBar: function (settings) {
+      if (!_.isUndefined(settings.visible)) {
+        this._apiBarVisible = settings.visible;
+      }
+      if (!_.isUndefined(settings.endpoint)) {
+        this._endpoint = settings.endpoint;
+      }
+      if (!_.isUndefined(settings.docURL)) {
+        this._docURL = settings.docURL;
+      }
+    },
+
+    getEndpoint: function () {
+      return this._endpoint;
+    },
+
+    getDocURL: function () {
+      return this._docURL;
+    },
+
+    dispatch: function (action) {
+      switch (action.type) {
+        case ActionTypes.SHOW_API_BAR:
+          this._apiBarVisible = true;
+          this.triggerChange();
+        break;
+
+        case ActionTypes.HIDE_API_BAR:
+          this._apiBarVisible = false;
+          this.triggerChange();
+        break;
+
+        case ActionTypes.UPDATE_API_BAR:
+          this.updateAPIBar(action.options);
+          this.triggerChange();
+        break;
+
+        default:
+        return;
+          // do nothing
+      }
+    }
+  });
+
+  Stores.componentStore = new Stores.ComponentStore();
+  Stores.componentStore.dispatchToken = FauxtonAPI.dispatcher.register(Stores.componentStore.dispatch);
+
+  return Stores;
+
+});

--- a/app/addons/components/tests/apiBarControllerSpec.react.jsx
+++ b/app/addons/components/tests/apiBarControllerSpec.react.jsx
@@ -1,0 +1,134 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+define([
+  'api',
+  'addons/components/actions',
+  'addons/components/stores',
+  'addons/components/react-components.react',
+  'testUtils',
+  'react'
+], function (FauxtonAPI, Actions, Stores, ReactComponents, utils, React) {
+
+  var assert = utils.assert;
+  var TestUtils = React.addons.TestUtils;
+  var componentStore = Stores.componentStore;
+  var ApiBarController = ReactComponents.ApiBarController;
+
+
+  describe('ApiBarController', function () {
+    var container;
+
+    beforeEach(function () {
+      container = document.createElement('div');
+    });
+
+    afterEach(function () {
+      React.unmountComponentAtNode(container);
+      componentStore.reset();
+    });
+
+    it('Doesn\'t show up when explicitly set to visible false', function () {
+      var el = TestUtils.renderIntoDocument(<ApiBarController />, container);
+      Actions.updateAPIBar({
+        visible: false,
+        endpoint: 'http://link.com',
+        docURL: 'http://link.com'
+      });
+      assert.equal(el.getDOMNode(), null);
+    });
+
+    it('Shows up when set to visible', function () {
+      var el = TestUtils.renderIntoDocument(<ApiBarController />, container);
+      Actions.updateAPIBar({
+        visible: true,
+        endpoint: 'http://link.com',
+        docURL: 'http://link.com'
+      });
+      assert.notEqual(el.getDOMNode(), null);
+    });
+
+    it('Doesn\'t show up when set to visible BUT there\'s no endpoint defined', function () {
+      var el = TestUtils.renderIntoDocument(<ApiBarController />, container);
+      Actions.updateAPIBar({
+        visible: true,
+        endpoint: '',
+        docURL: 'http://link.com'
+      });
+      assert.equal(el.getDOMNode(), null);
+    });
+
+    it('Confirm hide/show actions update component', function () {
+      var el = TestUtils.renderIntoDocument(<ApiBarController />, container);
+
+      // set an initial value
+      Actions.updateAPIBar({ endpoint: 'http://link.com' });
+
+      Actions.showAPIBar();
+      assert.notEqual(el.getDOMNode(), null);
+
+      Actions.hideAPIBar();
+      assert.equal(el.getDOMNode(), null);
+    });
+
+    it('Confirm doc link icon appears when docURL set', function () {
+      var el = TestUtils.renderIntoDocument(<ApiBarController />, container);
+      Actions.updateAPIBar({ visible: true, endpoint: 'http://link.com', docURL: 'http://doc.com' });
+
+      TestUtils.Simulate.click($(el.getDOMNode()).find('.control-toggle-api-url')[0]);
+      assert.equal($(el.getDOMNode()).find('.help-link').length, 1);
+    });
+
+    it('Confirm doc link icon doesn\'t appear with no docURL', function () {
+      var el = TestUtils.renderIntoDocument(<ApiBarController />, container);
+      Actions.updateAPIBar({ visible: true, endpoint: 'http://link.com', docURL: null });
+
+      TestUtils.Simulate.click($(el.getDOMNode()).find('.control-toggle-api-url')[0]);
+      assert.equal($(el.getDOMNode()).find('.help-link').length, 0);
+    });
+
+    it('Confirm endpoint appears in markup', function () {
+      var el = TestUtils.renderIntoDocument(<ApiBarController />, container);
+      var link = 'http://booyah.ca';
+      Actions.updateAPIBar({ visible: true, endpoint: link, docURL: null });
+
+      TestUtils.Simulate.click($(el.getDOMNode()).find('.control-toggle-api-url')[0]);
+      assert.equal($(el.getDOMNode()).find('.text-field-to-copy').val(), link);
+    });
+
+    it('Confirm endpoint is updated in markup', function () {
+      var el = TestUtils.renderIntoDocument(<ApiBarController />, container);
+      var link = 'http://booyah.ca';
+      Actions.updateAPIBar({ visible: true, endpoint: link, docURL: null });
+
+      TestUtils.Simulate.click($(el.getDOMNode()).find('.control-toggle-api-url')[0]);
+      assert.equal($(el.getDOMNode()).find('.text-field-to-copy').val(), link);
+
+      var newLink = 'http://chickensarenoisy.com';
+      Actions.updateAPIBar({ endpoint: newLink });
+      assert.equal($(el.getDOMNode()).find('.text-field-to-copy').val(), newLink);
+    });
+
+    it('Confirm doc URL is updated in markup after a change', function () {
+      var el = TestUtils.renderIntoDocument(<ApiBarController />, container);
+      var docLink = 'http://mydoc.org';
+      Actions.updateAPIBar({ visible: true, endpoint: 'http://whatever.com', docURL: docLink });
+
+      TestUtils.Simulate.click($(el.getDOMNode()).find('.control-toggle-api-url')[0]);
+      assert.equal($(el.getDOMNode()).find('.help-link').attr('href'), docLink);
+
+      var newDocLink = 'http://newawesomedoclink.xxx';
+      Actions.updateAPIBar({ docURL: newDocLink });
+      assert.equal($(el.getDOMNode()).find('.help-link').attr('href'), newDocLink);
+    });
+
+  });
+});

--- a/app/addons/components/tests/storesSpec.js
+++ b/app/addons/components/tests/storesSpec.js
@@ -1,0 +1,68 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+define([
+  'app',
+  'api',
+  'testUtils',
+  'addons/components/stores',
+  'addons/components/actions'
+], function (app, FauxtonAPI, utils, Stores, ComponentActions, Resources) {
+
+  var assert = utils.assert;
+  var componentStore = Stores.componentStore;
+
+  describe('Components Store', function () {
+
+    afterEach(function () {
+      componentStore.reset();
+    });
+
+    it("UPDATE_API_BAR only updates whatever data is passed", function () {
+      var url    = 'http://whoanelly.com';
+      var docURL = 'http://website.com/docs';
+      ComponentActions.updateAPIBar({
+        visible: false,
+        endpoint: url,
+        docURL: docURL
+      });
+      assert.equal(componentStore.isAPIBarVisible(), false);
+      assert.equal(componentStore.getEndpoint(), url);
+      assert.equal(componentStore.getDocURL(), docURL);
+
+      ComponentActions.updateAPIBar({
+        visible: true
+      });
+      assert.equal(componentStore.isAPIBarVisible(), true);
+      assert.equal(componentStore.getEndpoint(), url);
+      assert.equal(componentStore.getDocURL(), docURL);
+
+      var newEndpoint = 'http://movies.com';
+      ComponentActions.updateAPIBar({
+        endpoint: newEndpoint
+      });
+      assert.equal(componentStore.isAPIBarVisible(), true);
+      assert.equal(componentStore.getEndpoint(), newEndpoint);
+      assert.equal(componentStore.getDocURL(), docURL);
+
+      var newDocURL = 'http://newwebsite.org';
+      ComponentActions.updateAPIBar({
+        docURL: newDocURL
+      });
+      assert.equal(componentStore.isAPIBarVisible(), true);
+      assert.equal(componentStore.getEndpoint(), newEndpoint);
+      assert.equal(componentStore.getDocURL(), newDocURL);
+    });
+
+  });
+
+});

--- a/app/addons/fauxton/base.js
+++ b/app/addons/fauxton/base.js
@@ -19,11 +19,12 @@ define([
   "addons/fauxton/navigation/components.react",
   "addons/fauxton/navigation/actions",
   'addons/fauxton/dependencies/ZeroClipboard',
-  'addons/components/react-components.react'
+  'addons/components/react-components.react',
+  'addons/components/actions'
 ],
 
 function (app, FauxtonAPI, Components, NotificationComponents, Actions, NavbarReactComponents, NavigationActions,
-          ZeroClipboard, ReactComponents) {
+          ZeroClipboard, ReactComponents, ComponentActions) {
 
   var Fauxton = FauxtonAPI.addon();
   FauxtonAPI.addNotification = function (options) {
@@ -61,12 +62,18 @@ function (app, FauxtonAPI, Components, NotificationComponents, Actions, NavbarRe
     FauxtonAPI.RouteObject.on('beforeFullRender', function (routeObject) {
       NavigationActions.setNavbarActiveLink(_.result(routeObject, 'selectedHeader'));
 
+      // always attempt to render the API Bar. Even if it's hidden on initial load, it may be enabled later
+      routeObject.setComponent('#api-navbar', ReactComponents.ApiBarController);
+
       if (routeObject.get('apiUrl')) {
         var apiAndDocs = routeObject.get('apiUrl');
-        routeObject.setComponent('#api-navbar', ReactComponents.ApiBarController, {
+        ComponentActions.updateAPIBar({
+          visible: true,
           endpoint: apiAndDocs[0],
-          documentation: apiAndDocs[1]
+          docURL: apiAndDocs[1]
         });
+      } else {
+        ComponentActions.hideAPIBar();
       }
 
       if (!routeObject.get('hideNotificationCenter')) {


### PR DESCRIPTION
The previous code used props on page load to set the API Bar
values (endpoint + doc URL). The problem was that because there
was no way to reference the APIBarController, it prohibited
on-the-fly updates to change the values without a route change.

This just tweaks it to store the API Bar data in a store that
can be updated by publishing an action. This will ultimately
allow us to do away with hacks like this:
https://github.com/apache/couchdb-fauxton/blob/master/app/addons/documents/header/header.react.jsx#L174

e.g. we could expand on this ticket and publish an
APIBAR_FADE_OUT” msg and the component would handle its own
fading out, rather than relying on other components directly
manipulating its DOM.