### PR TITLE
Increase height of clickable space for close notification

### DIFF
--- a/assets/less/notification-center.less
+++ b/assets/less/notification-center.less
@@ -126,7 +126,7 @@ body #dashboard #notification-center-btn {
           color: #dddddd;
           background: transparent;
           border: 0;
-          height: 10px;
+          height: 20px;
           margin-top: -4px;
           margin-left: 6px;
         }


### PR DESCRIPTION
There's a little "x" that appears in the notification center next
to each message that allows users to remove that single message.
On Firefox, the height of the clickable space wasn't quite large
enough so if you clicked the bottom of the x it wouldn't close.
This fixes it so that it covers the full "x".