### PR TITLE
Fix for doc typeahead field being hidden

### DIFF
--- a/app/addons/documents/tests/nightwatch/selectDocViaTypeahead.js
+++ b/app/addons/documents/tests/nightwatch/selectDocViaTypeahead.js
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+
+  'Select doc via typeahead field redirects user': function (client) {
+    var waitTime = client.globals.maxWaitTime,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .populateDatabase(newDatabaseName, 3)
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .waitForElementPresent('#jump-to-doc-id', waitTime, false)
+      .waitForElementPresent('.prettyprint', waitTime, false)
+      .setValue('#jump-to-doc-id', '_des')
+      .waitForElementVisible('#jump-to-doc .typeahead.dropdown-menu li[data-value="_design/testdesigndoc"]', waitTime, false)
+      .click('#jump-to-doc .typeahead.dropdown-menu li[data-value="_design/testdesigndoc"]')
+      .setValue('#jump-to-doc-id', [client.Keys.ENTER])
+      .waitForElementPresent('.panel-button.upload', waitTime, false)
+    .end();
+  }
+};

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -314,7 +314,6 @@ div.spinner {
 }
 
 #header-search {
-  position: relative;
   height: @collapsedNavWidth;
 }
 
@@ -517,7 +516,7 @@ body #dashboard .flex-body#breadcrumbs {
     margin: 0;
   }
   .searchbox-container {
-    margin: 12px;
+    padding: 12px;
     input[type="text"] {
       .border-radius(5px);
       font-size: 13px;
@@ -529,14 +528,18 @@ body #dashboard .flex-body#breadcrumbs {
       border: none;
       position: absolute;
       right: 12px;
-      top: 0px;
+      top: 0;
       height: @collapsedNavWidth;
       z-index: 2;
       color: #999;
       .icon-search {
         position: absolute;
-        top: 11px;
+        top: 22px;
+        right: 7px;
       }
+    }
+    form {
+      margin: 0;
     }
   }
 }

--- a/assets/less/layouts.less
+++ b/assets/less/layouts.less
@@ -48,11 +48,6 @@ body #notification-center .flex-layout {
 body #dashboard .flex-body, body #notification-center .flex-body {
   .flex(1);
   overflow: auto;
-
-  /* yet more stuff that can be removed at end */
-  &.right-header-wrapper {
-    overflow: hidden;
-  }
 }
 
 /* tells an element to be as large as the content. This will replace the hardcoded ones */
@@ -72,7 +67,9 @@ body #dashboard .flex-fill {
 .one-pane > header {
   width: 100%;
 
-//  .bottom-shadow-border();
+  #header-search {
+    position: relative;
+  }
 
   #breadcrumbs {
     overflow: hidden;

--- a/assets/less/notification-center.less
+++ b/assets/less/notification-center.less
@@ -24,7 +24,7 @@ body #dashboard #notification-center-btn {
   .flex(0 0 auto);
 
   &>div {
-    padding: 17px;
+    padding: 17px 16px 16px;
   }
   &:hover {
     color: @darkRed;


### PR DESCRIPTION
When typing a doc name in the Doc ID field on the Database -> All
Docs page, it would get cut off. This PR ensures it overlaps
the body content.