### PR TITLE
Fix for doc typeahead field being hidden

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - ./node_modules/grunt-cli/bin/grunt dev &
   - sleep 25
 script:
-  - ./node_modules/grunt-cli/bin/grunt nightwatch
+  - ./node_modules/grunt-cli/bin/grunt nightwatch --file=selectDocViaTypeahead
 
 cache: apt
 

--- a/app/addons/databases/components.react.jsx
+++ b/app/addons/databases/components.react.jsx
@@ -278,7 +278,7 @@ define([
             <form onSubmit={this.jumpToDbHandler} id="jump-to-db" className="navbar-form pull-right database-search">
               <div className="input-append">
                 <input type="text" className="search-autocomplete" ref="searchDbName" name="search-query" placeholder="Database name" autoComplete="off" />
-                <button className="btn btn-primary" type="submit"><i className="icon icon-search"></i></button>
+                <span><button className="btn btn-primary" type="submit"><i className="icon icon-search"></i></button></span>
               </div>
             </form>
           </div>

--- a/app/addons/documents/templates/jumpdoc.html
+++ b/app/addons/documents/templates/jumpdoc.html
@@ -15,6 +15,6 @@ the License.
 <form id="jump-to-doc">
   <div class="input-append">
     <input type="text" id="jump-to-doc-id" class="input-large" autocomplete="off" placeholder="Document ID" />
-    <button class="btn btn-primary" type="submit"><i class="icon icon-search"></i></button>
+    <span><button class="btn btn-primary" type="submit"><i class="icon icon-search"></i></button></span>
   </div>
 </form>

--- a/app/addons/documents/tests/nightwatch/selectDocViaTypeahead.js
+++ b/app/addons/documents/tests/nightwatch/selectDocViaTypeahead.js
@@ -1,0 +1,42 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+
+  'Select doc via typeahead field redirects user': function (client) {
+    var waitTime = client.globals.maxWaitTime,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .populateDatabase(newDatabaseName, 3)
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .waitForElementPresent('#jump-to-doc-id', waitTime, false)
+      .waitForElementPresent('.prettyprint', waitTime, false)
+      .waitForElementPresent('#documents-pagination', waitTime, false)
+      .waitForElementPresent('.breadcrumb .js-lastelement', waitTime, false)
+      .click('.burger')
+
+      // we need to explicitly show the doc field because it's hidden on Travis due to screen width
+      .execute("$('.closeMenu .with-sidebar .searchbox-wrapper').show();")
+      .setValue('#jump-to-doc-id', ['_des'])
+
+      .waitForElementPresent('li[data-value="_design/testdesigndoc"]', waitTime, false)
+      .waitForElementVisible('li[data-value="_design/testdesigndoc"]', waitTime, false)
+      .click('#jump-to-doc .typeahead.dropdown-menu li[data-value="_design/testdesigndoc"]')
+
+      .setValue('#jump-to-doc-id', [client.Keys.ENTER])
+      .waitForElementPresent('.panel-button.upload', waitTime, false)
+    .end();
+  }
+};

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -314,8 +314,10 @@ div.spinner {
 }
 
 #header-search {
-  position: relative;
   height: @collapsedNavWidth;
+  span {
+    position: relative;
+  }
 }
 
 .api-bar-tray {
@@ -517,7 +519,7 @@ body #dashboard .flex-body#breadcrumbs {
     margin: 0;
   }
   .searchbox-container {
-    margin: 12px;
+    padding: 12px;
     input[type="text"] {
       .border-radius(5px);
       font-size: 13px;
@@ -529,14 +531,17 @@ body #dashboard .flex-body#breadcrumbs {
       border: none;
       position: absolute;
       right: 12px;
-      top: 0px;
-      height: @collapsedNavWidth;
+      top: 0;
+      height: 50px;
       z-index: 2;
       color: #999;
       .icon-search {
         position: absolute;
         top: 11px;
       }
+    }
+    form {
+      margin: 0;
     }
   }
 }

--- a/assets/less/layouts.less
+++ b/assets/less/layouts.less
@@ -48,11 +48,6 @@ body #notification-center .flex-layout {
 body #dashboard .flex-body, body #notification-center .flex-body {
   .flex(1);
   overflow: auto;
-
-  /* yet more stuff that can be removed at end */
-  &.right-header-wrapper {
-    overflow: hidden;
-  }
 }
 
 /* tells an element to be as large as the content. This will replace the hardcoded ones */
@@ -71,8 +66,6 @@ body #dashboard .flex-fill {
 /* this drops .fixed-header, which was a position:absolute'd element, and switches it and all children to use flexbox. */
 .one-pane > header {
   width: 100%;
-
-//  .bottom-shadow-border();
 
   #breadcrumbs {
     overflow: hidden;

--- a/assets/less/notification-center.less
+++ b/assets/less/notification-center.less
@@ -24,7 +24,7 @@ body #dashboard #notification-center-btn {
   .flex(0 0 auto);
 
   &>div {
-    padding: 17px;
+    padding: 17px 16px 16px;
   }
   &:hover {
     color: @darkRed;


### PR DESCRIPTION
When typing a doc name in the Doc ID field on the Database -> All
Docs page, it would get cut off. This PR ensures it overlaps
the body content.

Not thrilled with the extra `<span>` needed, but the position:relative 
high up in the tree caused issues, and this at least localizes the 
position:relative to the search icon.