### PR TITLE
Allow tests to run on windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -402,7 +402,7 @@ module.exports = function (grunt) {
       },
 
       phantomjs: {
-        command: './node_modules/phantomjs/bin/phantomjs --debug=false ' +
+        command: 'node ./node_modules/phantomjs/bin/phantomjs --debug=false ' +
           '--ssl-protocol=sslv2 --web-security=false --ignore-ssl-errors=true ' +
           './node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee test/runner.html'
       }


### PR DESCRIPTION
build-jsx also has this - just do the same for running the test(s). Won't do harm anywhere else I suppose