### PR TITLE
Add callback to Clipboard component

### DIFF
--- a/app/addons/fauxton/components.react.jsx
+++ b/app/addons/fauxton/components.react.jsx
@@ -42,7 +42,8 @@ function (app, FauxtonAPI, React, ZeroClipboard) {
     getDefaultProps: function () {
       return {
         displayType: 'icon',
-        textDisplay: 'Copy'
+        textDisplay: 'Copy',
+        onClipboardClick: function () { }
       };
     },
 
@@ -60,6 +61,11 @@ function (app, FauxtonAPI, React, ZeroClipboard) {
     componentDidMount: function () {
       var el = this.getDOMNode();
       this.clipboard = new ZeroClipboard(el);
+      this.clipboard.on('load', function () {
+        this.clipboard.on('mouseup', function () {
+          this.props.onClipboardClick();
+        }.bind(this));
+      }.bind(this));
     },
 
     render: function () {


### PR DESCRIPTION
This just adds a callback to the `<Clipboard />` component that
gets called once the copy to clipboard action is completed.

Not testable due to Flash not being available on the testing environment.