### PR TITLE
remove doc-editor check

### DIFF
--- a/app/addons/documents/doc-editor/components.react.jsx
+++ b/app/addons/documents/doc-editor/components.react.jsx
@@ -58,41 +58,8 @@ define([
           autoFocus={true}
           editorCommands={editorCommands}
           notifyUnsavedChanges={true}
-          stringEditModalEnabled={true}
-          change={this.onChangeDoc} />
+          stringEditModalEnabled={true} />
       );
-    },
-
-    onChangeDoc: function (doc) {
-      // super ugly, but necessary. This tells the user they can't delete the _id or _rev fields as they type and actually
-      // prevents it from being removed in the editable doc
-      var json;
-      try {
-        json = JSON.parse(doc);
-      } catch (exception) {
-        return;
-      }
-
-      var keyChecked = ['_id'];
-      if (this.state.doc.get('_rev')) {
-        keyChecked.push('_rev');
-      }
-      if (_.isEmpty(_.difference(keyChecked, _.keys(json)))) {
-        return;
-      }
-
-      this.getEditor().setReadOnly(true);
-      setTimeout(function () { this.getEditor().setReadOnly(false); }.bind(this), 400);
-
-      // extend ensures _id stays at the top of the editor doc
-      json = _.extend({ _id: this.state.doc.id, _rev: this.state.doc.get('_rev') }, json);
-      this.getEditor().setValue(JSON.stringify(json, null, '  '));
-
-      FauxtonAPI.addNotification({
-        type: 'error',
-        msg: "Cannot remove a document's id or revision.",
-        clear: true
-      });
     },
 
     componentDidMount: function () {


### PR DESCRIPTION
i quite often run into the problem where i want to copy the json
of an existing doc for testing. i copy the whole json, click
"new doc" and have toremoev the _rev in order to save it.
sometimes i also want to remove the id, to get a random one. right
now i have to copy/paste the json into an offline editor before
that as the fauxton editor tells me i can't delete the rev or id
and refuses to make changes.