### PR TITLE
Change header z-index

### DIFF
--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -389,7 +389,7 @@ div.spinner {
     .bottom-shadow-border();
     position: absolute;
     width: 100%;
-    z-index: 1;
+    z-index: 2; /* needed because ace's selected row has a z-index of 1 & can't be overridden */
   }
 }
 


### PR DESCRIPTION
This increases the z-index of the headers from 1 to 2. The reason
is that Ace Editor's selected row has a z-index of 1 and the API
URL bar is being incorrectly overlapped.