### PR TITLE
Change Grunt so we can separate files within addons

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -245,7 +245,7 @@ module.exports = function (grunt) {
         tasks: []
       },
       jsx: {
-        files: initHelper.watchFiles(['.jsx'], ["./app/**/*.jsx", '!./app/load_addons.jsx', "./assets/**/*.jsx", "./test/**/*.jsx"]),
+        files: initHelper.watchFiles(['.jsx'], ["./app/**/*.jsx", './app/**/**/*.jsx', '!./app/load_addons.jsx', "./assets/**/*.jsx", "./test/**/*.jsx"]),
         tasks: []
       },
       style: {


### PR DESCRIPTION
We can put a folder inside an addon folder, and have grunt watch the
jsx files