### PR TITLE
Allow multiple attachments to be uploaded at once.

### DIFF
--- a/app/addons/documents/doc-editor/components.react.jsx
+++ b/app/addons/documents/doc-editor/components.react.jsx
@@ -342,7 +342,7 @@ define([
                   Please select the file you want to upload as an attachment to this document. This creates a new
                   revision of the document, so it's not necessary to save after uploading.
                 </p>
-                <input ref="attachments" type="file" name="_attachments" />
+                <input ref="attachments" type="file" name="_attachments" multiple />
                 <br />
               </form>
 


### PR DESCRIPTION
The "multiple" attribute on a file input allows the user to select multiple attachments. 