### PR TITLE
fix cors validation for hosts with no tld

### DIFF
--- a/app/addons/cors/components.react.jsx
+++ b/app/addons/cors/components.react.jsx
@@ -22,7 +22,7 @@ define([
   var validateOrigin = function (origin) {
     if (!Resources.validateCORSDomain(origin)) {
       FauxtonAPI.addNotification({
-        msg: 'Please enter a valid domain, starting with http/https and only containing the domain (not a subfolder).',
+        msg: 'Please enter a valid domain, starting with http/https.',
         type: 'error',
         clear: true
       });
@@ -157,7 +157,9 @@ define([
         return;
       }
 
-      this.props.addOrigin(this.state.origin);
+      var url = Resources.normalizeUrls(this.state.origin);
+
+      this.props.addOrigin(url);
       this.setState({origin: ''});
     },
 

--- a/app/addons/cors/resources.js
+++ b/app/addons/cors/resources.js
@@ -95,10 +95,20 @@ function (app, FauxtonAPI) {
 
   });
 
-  // simple helper function to validate the user entered a valid domain starting with http(s), optional port and
-  // doesn't include a subfolder
+  // simple helper function to validate the user entered a valid domain starting with http(s)
   CORS.validateCORSDomain = function (str) {
-    return (/^https?:\/\/[a-zA-Z0-9\-]+\.[a-zA-Z0-9\-\.]+(:\d{2,5})?$/).test(str);
+    return (/^https?:\/\/(.*)(:\d{2,5})?$/).test(str);
+  };
+
+  CORS.normalizeUrls = function (url) {
+    var el = document.createElement('a');
+    el.href = url;
+
+    if (/:/.test(url)) {
+      return el.protocol + '//' + el.host;
+    }
+
+    return el.protocol + '//' + el.hostname;
   };
 
   return CORS;

--- a/app/addons/cors/tests/componentsSpec.react.jsx
+++ b/app/addons/cors/tests/componentsSpec.react.jsx
@@ -97,9 +97,9 @@ define([
       });
 
       afterEach(function () {
-        Resources.validateCORSDomain.restore && Resources.validateCORSDomain.restore();
+        utils.restore(Resources.validateCORSDomain);
+        utils.restore(FauxtonAPI.addNotification);
         React.unmountComponentAtNode(container);
-        FauxtonAPI.addNotification.restore && FauxtonAPI.addNotification.restore();
       });
 
       it('calls validates each domain', function () {

--- a/app/addons/cors/tests/resourcesSpec.js
+++ b/app/addons/cors/tests/resourcesSpec.js
@@ -46,23 +46,32 @@ define([
         'http://something.com',
         'https://a.ca',
         'https://something.com:8000',
-        'https://www.some-valid-domain.com:80'
+        'https://www.some-valid-domain.com:80',
+        'http://localhost',
+        'https://localhost',
+        'http://192.168.1.113',
+        'http://192.168.1.113:1337'
       ];
       _.each(urls, function (url) {
         assert.isTrue(CORS.validateCORSDomain(url));
       });
     });
 
-    it('fails on invalid domains', function () {
+    it('fails on non http/https domains', function () {
       var urls = [
         'whoahnellythisaintright',
-        'http://something',
-        'ftp://site.com',
-        'https://this.has/subfolder'
+        'ftp://site.com'
       ];
       _.each(urls, function (url) {
         assert.isFalse(CORS.validateCORSDomain(url));
       });
+    });
+
+    it('normalizes common cases, like accidentally added subfolders', function () {
+      assert.equal('https://foo.com', CORS.normalizeUrls('https://foo.com/blerg'));
+      assert.equal('https://192.168.1.113', CORS.normalizeUrls('https://192.168.1.113/blerg'));
+      assert.equal('https://foo.com:1337', CORS.normalizeUrls('https://foo.com:1337/blerg'));
+      assert.equal('https://foo.com', CORS.normalizeUrls('https://foo.com'));
     });
 
   });


### PR DESCRIPTION
 - allow ips and things like: http://localhost:3000
 - normalize urls in case a path is given by removing the path

note:

in general the validation should be done in the backend as single
source of truth so that api users and fauxton users get the same
results and also the interfaces are consistent.