### PR TITLE
Allow db names starting with underscore

### DIFF
--- a/app/addons/databases/actions.js
+++ b/app/addons/databases/actions.js
@@ -83,7 +83,7 @@ function (app, FauxtonAPI, Stores, ActionTypes, Resources) {
     createNewDatabase: function (databaseName) {
       if (_.isNull(databaseName) || databaseName.trim().length === 0 || !this.isValidDatabaseName(databaseName)) {
         FauxtonAPI.addNotification({
-          msg: 'Please enter a valid database name. The database must start with a letter and can only contain lowercase letters (a-z), digits (0-9) and the following characters _, $, (, ), +, -, and /.',
+          msg: 'Please enter a valid database name. The database must start with a letter or underscore and can only contain lowercase letters (a-z), digits (0-9) and the following characters _, $, (, ), +, -, and /.',
           type: 'error',
           clear: true
         });
@@ -137,7 +137,7 @@ function (app, FauxtonAPI, Stores, ActionTypes, Resources) {
     },
 
     isValidDatabaseName: function (databaseName) {
-      return (/^[a-z][a-z0-9_\$\(\)\+\/-]*$/).test(databaseName);
+      return (/^[a-z_][a-z0-9_\$\(\)\+\/-]*$/).test(databaseName);
     }
   };
 });

--- a/app/addons/databases/tests/actionsSpec.js
+++ b/app/addons/databases/tests/actionsSpec.js
@@ -251,6 +251,7 @@ define([
         [
           "one",
           "one$",
+          "_one",
           "one/",
           "o-n-e",
           "o_n_e",
@@ -264,7 +265,6 @@ define([
       it("rejects invalid database names", function () {
         [
           "ONE",
-          "_one",
           "-blah",
           "one%",
           "one*",


### PR DESCRIPTION
The JS validation unnecessarily stopped users from creating
database names with underscores. This removes that restriction.