### PR TITLE
views: remove non existent _id attribute from result

### DIFF
--- a/app/addons/documents/index-editor/stores.js
+++ b/app/addons/documents/index-editor/stores.js
@@ -54,9 +54,10 @@ function (FauxtonAPI, ActionTypes) {
     setView: function () {
       if (this._newView || this._newDesignDoc) {
         this._view = { reduce: '', map: this.defaultMap };
-      } else {
-        this._view = this.getDesignDoc().get('views')[this._viewName];
+        return;
       }
+
+      this._view = this.getDesignDoc().get('views')[this._viewName];
     },
 
     getDatabase: function () {

--- a/app/addons/documents/index-editor/tests/viewIndex.componentsSpec.react.jsx
+++ b/app/addons/documents/index-editor/tests/viewIndex.componentsSpec.react.jsx
@@ -108,7 +108,7 @@ define([
       container = document.createElement('div');
 
       var designDoc = {
-        "id": "_design/test-doc",
+        "_id": "_design/test-doc",
         "key": "_design/test-doc",
         "value": {
           "rev": "20-9e4bc8b76fd7d752d620bbe6e0ea9a80"

--- a/app/addons/documents/index-results/index-results.components.react.jsx
+++ b/app/addons/documents/index-results/index-results.components.react.jsx
@@ -207,8 +207,8 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents) {
            header={doc.header}
            docChecked={this.props.docChecked}
            isDeletable={doc.isDeletable}
-           docIdentifier={doc.id} >
-           {doc.url ? this.getUrlFragment('#' + doc.url) : doc.url}
+           docIdentifier={doc.id}>
+           {doc.url ? this.getUrlFragment('#' + doc.url) : null}
          </Components.Document>
        );
       }, this);

--- a/app/addons/documents/index-results/tests/index-results.componentsSpec.react.jsx
+++ b/app/addons/documents/index-results/tests/index-results.componentsSpec.react.jsx
@@ -163,7 +163,7 @@ define([
 
       it('does not render checkboxes for elements with no rev in a table (usual docs)', function () {
         IndexResultsActions.sendMessageNewResultList({
-          collection: createDocColumn([{id: '1', foo: 'testId1'}, {id: '1', bar: 'testId1'}])
+          collection: createDocColumn([{_id: '1', foo: 'testId1'}, {_id: '1', bar: 'testId1'}])
         });
 
         store.enableTableView();
@@ -182,7 +182,7 @@ define([
 
       it('renders checkboxes for elements with an id and rev in a table (usual docs)', function () {
         IndexResultsActions.sendMessageNewResultList({
-          collection: createDocColumn([{id: '1', foo: 'testId1', rev: 'foo'}, {bar: 'testId1', rev: 'foo'}])
+          collection: createDocColumn([{_id: '1', foo: 'testId1', rev: 'foo'}, {bar: 'testId1', rev: 'foo'}])
         });
 
         store.enableTableView();
@@ -201,7 +201,7 @@ define([
 
       it('renders checkboxes for elements with an id and rev in a json view (usual docs)', function () {
         IndexResultsActions.sendMessageNewResultList({
-          collection: createDocColumn([{id: '1', emma: 'testId1', rev: 'foo'}, {bar: 'testId1'}])
+          collection: createDocColumn([{_id: '1', emma: 'testId1', rev: 'foo'}, {bar: 'testId1'}])
         });
 
         IndexResultsActions.resultsListReset();

--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -160,7 +160,7 @@ define([
     },
 
     safeID: function () {
-      return app.utils.getSafeIdForDoc(this.id);
+      return app.utils.getSafeIdForDoc(this.id || this.get('id'));
     },
 
     destroy: function () {
@@ -176,11 +176,6 @@ define([
       if (resp.rev) {
         resp._rev = resp.rev;
         delete resp.rev;
-      }
-      if (resp.id) {
-        if (_.isUndefined(this.id)) {
-          resp._id = resp.id;
-        }
       }
 
       if (resp.ok) {

--- a/app/addons/documents/tests/nightwatch/viewCreate.js
+++ b/app/addons/documents/tests/nightwatch/viewCreate.js
@@ -33,6 +33,12 @@ module.exports = {
       .waitForElementPresent('.prettyprint', waitTime, false)
       .waitForElementNotPresent('.loading-lines', waitTime, false)
       .assert.containsText('.prettyprint', 'hasehase')
+      .getText('#dashboard-lower-content', function (result) {
+        var data = result.value;
+        this.verify.ok(data.indexOf('"_id":') === -1,
+          'Check if non existing _id attribute is there');
+      })
+      .assert.containsText('.prettyprint', 'hasehase')
     .end();
   },
 


### PR DESCRIPTION
this removes an addionial _id attribute that was added, even if it
was not part of the response.

regression was introduced in december with #c7fa6fad7c411
