### PR TITLE
Move all React modals to use ReactBootstrap.Modal

### DIFF
--- a/app/addons/components/tests/stringEditModalSpec.react.jsx
+++ b/app/addons/components/tests/stringEditModalSpec.react.jsx
@@ -12,15 +12,18 @@
 define([
   'api',
   'addons/components/react-components.react',
+  'libs/react-bootstrap',
   'testUtils',
   'react'
-], function (FauxtonAPI, ReactComponents, utils, React) {
+], function (FauxtonAPI, ReactComponents, ReactBootstrap, utils, React) {
 
   var assert = utils.assert;
   var TestUtils = React.addons.TestUtils;
+  var Modal = ReactBootstrap.Modal;
+
 
   describe('String Edit Modal', function () {
-    var container, modalEl;
+    var container, el;
     var stub = function () { };
 
     beforeEach(function () {
@@ -34,52 +37,58 @@ define([
     describe('event methods called', function () {
       it('onClose called by top (x)', function () {
         var spy = sinon.spy();
-        modalEl = TestUtils.renderIntoDocument(
+        el = TestUtils.renderIntoDocument(
           <ReactComponents.StringEditModal visible={true} onClose={spy} onSave={stub} />,
           container
         );
-        TestUtils.Simulate.click($(modalEl.getDOMNode()).find('.close')[0]);
+        var modal = TestUtils.findRenderedComponentWithType(el, Modal);
+        var modalEl = React.findDOMNode(modal.refs.modal);
+
+        TestUtils.Simulate.click($(modalEl).find('.close')[0]);
         assert.ok(spy.calledOnce);
       });
 
       it('onClose called by cancel button', function () {
         var spy = sinon.spy();
-        modalEl = TestUtils.renderIntoDocument(
+        el = TestUtils.renderIntoDocument(
           <ReactComponents.StringEditModal visible={true} onClose={spy} onSave={stub} />,
           container
         );
-        TestUtils.Simulate.click($(modalEl.getDOMNode()).find('.cancel-button')[0]);
+        var modal = TestUtils.findRenderedComponentWithType(el, Modal);
+        var modalEl = React.findDOMNode(modal.refs.modal);
+        TestUtils.Simulate.click($(modalEl).find('.cancel-button')[0]);
         assert.ok(spy.calledOnce);
       });
     });
 
-    describe('setValue / onSave', function () {
-      it('setValue ensures same content returns on saving', function () {
+    describe('onSave', function () {
+      it('ensures same content returns on saving', function () {
+        var string = "a string!";
         var spy = sinon.spy();
-        modalEl = TestUtils.renderIntoDocument(
-          <ReactComponents.StringEditModal visible={true} onClose={stub} onSave={spy} />,
+        el = TestUtils.renderIntoDocument(
+          <ReactComponents.StringEditModal visible={true} onClose={stub} onSave={spy} value={string} />,
           container
         );
+        var modal = TestUtils.findRenderedComponentWithType(el, Modal);
+        var modalEl = React.findDOMNode(modal.refs.modal);
 
-        var string = "a string!";
-
-        modalEl.setValue(string);
-        TestUtils.Simulate.click($(modalEl.getDOMNode()).find('#string-edit-save-btn')[0]);
+        TestUtils.Simulate.click($(modalEl).find('#string-edit-save-btn')[0]);
         assert.ok(spy.calledOnce);
         assert.ok(spy.calledWith(string));
       });
 
       it('replaces "\\n" with actual newlines', function () {
         var spy = sinon.spy();
-        modalEl = TestUtils.renderIntoDocument(
-          <ReactComponents.StringEditModal visible={true} onSave={spy} />,
+        var string = 'I am a string\\nwith\\nlinebreaks\\nin\\nit';
+        el = TestUtils.renderIntoDocument(
+          <ReactComponents.StringEditModal visible={true} onSave={spy} value={string} />,
           container
         );
 
-        var string = 'I am a string\\nwith\\nlinebreaks\\nin\\nit';
+        var modal = TestUtils.findRenderedComponentWithType(el, Modal);
+        var modalEl = React.findDOMNode(modal.refs.modal);
 
-        modalEl.setValue(string);
-        TestUtils.Simulate.click($(modalEl.getDOMNode()).find('#string-edit-save-btn')[0]);
+        TestUtils.Simulate.click($(modalEl).find('#string-edit-save-btn')[0]);
         assert.ok(spy.calledOnce);
       });
     });

--- a/app/addons/documents/doc-editor/components.react.jsx
+++ b/app/addons/documents/doc-editor/components.react.jsx
@@ -6,11 +6,12 @@ define([
   'addons/documents/doc-editor/stores',
   'addons/fauxton/components.react',
   'addons/components/react-components.react',
+  'libs/react-bootstrap',
   'helpers'
-], function (FauxtonAPI, app, React, Actions, Stores, FauxtonComponents, GeneralComponents, Helpers) {
+], function (FauxtonAPI, app, React, Actions, Stores, FauxtonComponents, GeneralComponents, ReactBootstrap, Helpers) {
 
   var store = Stores.docEditorStore;
-
+  var Modal = ReactBootstrap.Modal;
 
   var DocEditorController = React.createClass({
 
@@ -281,34 +282,12 @@ define([
       };
     },
 
-    componentDidUpdate: function () {
-      var params = (this.props.visible) ? { show: true, backdrop: 'static', keyboard: true } : 'hide';
-      $(React.findDOMNode(this)).modal(params);
-    },
-
-    // ensure that if the user clicks ESC to close the window, the store gets wind of it
-    componentDidMount: function () {
-      $(React.findDOMNode(this)).on('hidden.bs.modal', function () {
-        Actions.hideUploadModal();
-      });
-    },
-
-    componentWillUnmount: function () {
-      $(React.findDOMNode(this)).off('hidden.bs.modal');
-    },
-
     closeModal: function () {
       if (this.state.inProgress) {
         Actions.cancelUpload();
       }
       Actions.hideUploadModal();
-
-      // timeout needed to only clear it once the animate close effect is done, otherwise the user sees it reset
-      // as it closes, which looks bad
-      setTimeout(function () {
-        Actions.resetUploadModal();
-        React.findDOMNode(this.refs.uploadForm).reset();
-      }.bind(this), 1000);
+      Actions.resetUploadModal();
     },
 
     upload: function () {
@@ -330,14 +309,12 @@ define([
       }
 
       return (
-        <div className="modal hide fade upload-file-modal" tabIndex="-1" data-js-visible={this.props.visible}>
-          <div className="modal-header">
-            <button type="button" className="close" onClick={this.closeModal} aria-hidden="true">&times;</button>
-            <h3>Upload Attachment</h3>
-          </div>
-          <div className="modal-body">
+        <Modal dialogClassName="upload-file-modal" show={this.props.visible} onHide={this.closeModal}>
+          <Modal.Header closeButton={true}>
+            <Modal.Title>Upload Attachment</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
             <div className={errorClasses}>{this.state.errorMessage}</div>
-
             <div>
               <form ref="uploadForm" className="form" method="post">
                 <p>
@@ -348,21 +325,20 @@ define([
                 <br />
               </form>
 
-              <div ref="loadIndicator" className={loadIndicatorClasses}>
+              <div className={loadIndicatorClasses}>
                 <div className="bar" style={{ width: this.state.loadPercentage + '%'}}></div>
               </div>
             </div>
-
-          </div>
-          <div className="modal-footer">
-             <button href="#" data-bypass="true" className="btn" onClick={this.closeModal}>
+          </Modal.Body>
+          <Modal.Footer>
+            <button href="#" data-bypass="true" className="btn" onClick={this.closeModal}>
               <i className="icon fonticon-cancel-circled"></i> Cancel
             </button>
             <button href="#" id="upload-btn" data-bypass="true" className="btn btn-success save" onClick={this.upload}>
               <i className="icon fonticon-ok-circled"></i> Upload
             </button>
-          </div>
-        </div>
+          </Modal.Footer>
+        </Modal>
       );
     }
   });
@@ -392,34 +368,6 @@ define([
         uuid.fetch().then(function () {
           this.setState({ uuid: uuid.next() });
         }.bind(this));
-        return;
-      }
-
-      var params = (this.props.visible) ? { show: true, backdrop: 'static', keyboard: true } : 'hide';
-      $(React.findDOMNode(this)).modal(params);
-      this.clearEvents();
-
-      // ensure that if the user clicks ESC to close the window, the store gets wind of it
-      $(React.findDOMNode(this)).on('hidden.bs.modal', function () {
-        Actions.hideCloneDocModal();
-      });
-
-      $(React.findDOMNode(this)).on('shown.bs.modal', function () {
-        this.focus();
-      }.bind(this));
-    },
-
-    focus: function () {
-      $(React.findDOMNode(this.refs.newDocId)).focus();
-    },
-
-    componentWillUnmount: function () {
-      this.clearEvents();
-    },
-
-    clearEvents: function () {
-      if (this.refs.newDocId) {
-        $(React.findDOMNode(this.refs.newDocId)).off('shown.bs.modal hidden.bs.modal');
       }
     },
 
@@ -437,28 +385,28 @@ define([
       }
 
       return (
-        <div className="modal hide fade clone-doc-modal" data-js-visible={this.props.visible} tabIndex="-1">
-          <div className="modal-header">
-            <button type="button" className="close" onClick={this.closeModal} aria-hidden="true">&times;</button>
-            <h3>Clone Document</h3>
-          </div>
-          <div className="modal-body">
+        <Modal dialogClassName="clone-doc-modal" show={this.props.visible} onHide={this.closeModal}>
+          <Modal.Header closeButton={true}>
+            <Modal.Title>Clone Document</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
             <form className="form" method="post">
               <p>
                 Set new document's ID:
               </p>
-              <input ref="newDocId" type="text" className="input-block-level" onChange={this.docIDChange} value={this.state.uuid} />
+              <input ref="newDocId" type="text" autoFocus={true} className="input-block-level"
+                onChange={this.docIDChange} value={this.state.uuid} />
             </form>
-          </div>
-          <div className="modal-footer">
+          </Modal.Body>
+          <Modal.Footer>
             <button className="btn" onClick={this.closeModal}>
               <i className="icon fonticon-cancel-circled"></i> Cancel
             </button>
             <button className="btn btn-success save" onClick={this.cloneDoc}>
               <i className="fonticon-ok-circled"></i> Clone
             </button>
-          </div>
-        </div>
+          </Modal.Footer>
+        </Modal>
       );
     }
   });

--- a/app/addons/documents/doc-editor/tests/doc-editor.componentsSpec.react.jsx
+++ b/app/addons/documents/doc-editor/tests/doc-editor.componentsSpec.react.jsx
@@ -20,9 +20,14 @@ define([
   'addons/documents/doc-editor/actions',
   'addons/documents/doc-editor/actiontypes',
   'addons/databases/base',
-  'testUtils'
-], function (app, FauxtonAPI, React, Documents, Components, Stores, Actions, ActionTypes, Databases, utils) {
+  'testUtils',
+  'libs/react-bootstrap'
+], function (app, FauxtonAPI, React, Documents, Components, Stores, Actions, ActionTypes, Databases, utils,
+  ReactBoostrap) {
+
   FauxtonAPI.router = new FauxtonAPI.Router([]);
+  var Modal = ReactBoostrap.Modal;
+
 
   var assert = utils.assert;
   var TestUtils = React.addons.TestUtils;
@@ -157,9 +162,15 @@ define([
           doc: doc
         }
       });
-      assert.ok($(el.getDOMNode()).find('.confirmation-modal')[0].getAttribute('data-js-visible') == 'false');
+
+      // this is unfortunate, but I can't find a better way to do it. Refs won't work for bootstrap modals because
+      // they add the modal to the page at the top level outside the component. There are 3 modals in the
+      // component: the upload modal, clone modal, delete doc modal. We locate it by index
+      var modals = TestUtils.scryRenderedComponentsWithType(el, Modal);
+
+      assert.equal(React.findDOMNode(modals[2].refs.modal), null);
       Actions.showDeleteDocModal();
-      assert.ok($(el.getDOMNode()).find('.confirmation-modal')[0].getAttribute('data-js-visible') == 'true');
+      assert.notEqual(React.findDOMNode(modals[2].refs.modal), null);
     });
 
     it('setting uploadDocModal=true in store shows modal', function () {
@@ -171,12 +182,14 @@ define([
           doc: doc
         }
       });
-      assert.ok($(el.getDOMNode()).find('.upload-file-modal')[0].getAttribute('data-js-visible') == 'false');
-      Actions.showUploadModal();
-      assert.ok($(el.getDOMNode()).find('.upload-file-modal')[0].getAttribute('data-js-visible') == 'true');
-    });
+      var modals = TestUtils.scryRenderedComponentsWithType(el, Modal);
 
+      assert.equal(React.findDOMNode(modals[1].refs.modal), null);
+      Actions.showUploadModal();
+      assert.notEqual(React.findDOMNode(modals[1].refs.modal), null);
+    });
   });
+
 
   describe("AttachmentsPanelButton", function () {
     var container, doc;

--- a/app/addons/documents/tests/nightwatch/createsDocument.js
+++ b/app/addons/documents/tests/nightwatch/createsDocument.js
@@ -26,7 +26,7 @@ module.exports = {
       .clickWhenVisible('#new-all-docs-button a[href="#/database/' + newDatabaseName + '/new"]')
       .waitForElementPresent('#editor-container', waitTime, false)
       .verify.urlEquals(baseUrl + '/#/database/' + newDatabaseName + '/new')
-      .waitForElementPresent('.ace_layer.ace_cursor-layer.ace_hidden-cursors', waitTime, false)
+      .waitForElementPresent('.ace_gutter-active-line', waitTime, false)
 
       // confirm the header elements are showing up
       .waitForElementVisible('.js-lastelement', waitTime, true)

--- a/app/addons/fauxton/components.react.jsx
+++ b/app/addons/fauxton/components.react.jsx
@@ -15,12 +15,15 @@ define([
   'api',
   'react',
   'addons/fauxton/dependencies/ZeroClipboard',
+  'libs/react-bootstrap',
 
   // needed to run the test individually. Don't remove
   'velocity.ui'
 ],
 
-function (app, FauxtonAPI, React, ZeroClipboard) {
+function (app, FauxtonAPI, React, ZeroClipboard, ReactBootstrap) {
+
+  var Modal = ReactBootstrap.Modal;
 
 
   // the path to the swf depends on whether we're in a bundled environment (e.g. prod) or local
@@ -339,32 +342,22 @@ function (app, FauxtonAPI, React, ZeroClipboard) {
       };
     },
 
-    componentDidUpdate: function () {
-      var params = (this.props.visible) ? { show: true, backdrop: 'static', keyboard: true } : 'hide';
-      $(React.findDOMNode(this)).modal(params);
-
-      $(React.findDOMNode(this)).on('hidden.bs.modal', function () {
-        this.props.onClose();
-      }.bind(this));
-    },
-
     render: function () {
       return (
-        <div className="modal hide confirmation-modal fade" tabIndex="-1" data-js-visible={this.props.visible}>
-          <div className="modal-header">
-            <button type="button" className="close" onClick={this.props.onClose} aria-hidden="true">&times;</button>
-            <h3>{this.props.title}</h3>
-          </div>
-          <div className="modal-body">
+        <Modal dialogClassName="confirmation-modal" show={this.props.visible} onHide={this.props.onClose}>
+          <Modal.Header closeButton={true}>
+            <Modal.Title>{this.props.title}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
             <p>
               {this.props.text}
             </p>
-          </div>
-          <div className="modal-footer">
+          </Modal.Body>
+          <Modal.Footer>
             <button className="btn" onClick={this.props.onClose}><i className="icon fonticon-cancel-circled"></i> Cancel</button>
             <button className="btn btn-success js-btn-success" onClick={this.props.onSubmit}><i className="fonticon-ok-circled"></i> Okay</button>
-          </div>
-        </div>
+          </Modal.Footer>
+        </Modal>
       );
     }
   });

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -601,6 +601,11 @@ footer.pagination-footer {
   z-index: 6;
 }
 
+.modal-title {
+  font-size: 22px;
+  margin: 0;
+  line-height: 30px;
+}
 
 // left navigationbar is opened
 @media (max-width: 780px) {


### PR DESCRIPTION
Benefits are less custom code and all modals standardized by
default, so behaviour like clicking outside the modal or clicking
escape will close it. These are configurable, but the “out the
box” modals will be all the same.

Affects:
- Confirmation modal (e.g. full page doc editor, “are you sure you want to delete this doc?”)
- Upload file modal
- String Edit modal
- Clone Doc modal