### PR TITLE
Configurable 'Generated: [date]' comments

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,6 +107,9 @@ module.exports = function (grunt) {
 
     Object.keys(settings.template).forEach(function (key) {
       settings.template[key].variables.generationDate = new Date().toISOString();
+      if (!settings.template[key].variables.generationLabel) {
+        settings.template[key].variables.generationLabel = 'Generated: ';
+      }
       settings.template[key].app.i18n = i18n;
     });
 

--- a/assets/index.underscore
+++ b/assets/index.underscore
@@ -45,7 +45,7 @@
   <!-- Application source. -->
   <script data-main="/config" src="<%= requirejs %>"></script>
 
-  <!-- Generated: <%= generationDate %> -->
+  <!-- <%= generationLabel %><%= generationDate %> -->
 
 </body>
 </html>


### PR DESCRIPTION
A while back we added in a comment to the foot of the generated
index.html file containing a "Generated: [data]" text. This has
proven to be extremely useful.

This PR just expands on it a little to make the label itself
configurable. So for environments using different bundles of
the Fauxton code, it can output the build target name, plus
the generation date, e.g.

```<!-- Env X. Generated: [date] -->```