### PR TITLE
Degruntify cssmin & uglify js. Separate testserver from building releases

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -178,16 +178,6 @@ module.exports = function (grunt) {
       }
     },
 
-    uglify: {
-      release: {
-        files: {
-          "dist/release/js/require.js": [
-            "dist/debug/js/require.js"
-          ]
-        }
-      }
-    },
-
     // Runs a proxy server for easier development, no need to keep deploying to couchdb
     couchserver: couchserver_config,
 
@@ -350,6 +340,10 @@ module.exports = function (grunt) {
         command: 'npm run build:css-compress'
       },
 
+      uglify: {
+        command: 'npm run build:uglify'
+      },
+
       stylecheckSingleFile: {
         command: '' // populated dynamically
       },
@@ -476,7 +470,6 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-jst');
   grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-shell');
   grunt.loadNpmTasks('grunt-md5');
 
@@ -500,7 +493,7 @@ module.exports = function (grunt) {
 
   // minify code and css, ready for release.
   grunt.registerTask('jsx', ['shell:build-jsx']);
-  grunt.registerTask('build', ['shell:build-less', 'jst', 'requirejs', 'concat:requirejs', 'uglify',
+  grunt.registerTask('build', ['shell:build-less', 'jst', 'requirejs', 'concat:requirejs', 'shell:uglify',
     'shell:css-compress', 'md5:requireJS', 'md5:css', 'template:release']);
 
   /*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -178,21 +178,6 @@ module.exports = function (grunt) {
       }
     },
 
-    cssmin: {
-      compress: {
-        files: {
-          "dist/release/css/index.css": [
-            'dist/debug/css/index.css',
-            'assets/css/*.css',
-            "app/addons/**/assets/css/*.css"
-          ]
-        },
-        options: {
-          report: 'min'
-        }
-      }
-    },
-
     uglify: {
       release: {
         files: {
@@ -361,6 +346,10 @@ module.exports = function (grunt) {
         command: 'npm run build:less'
       },
 
+      'css-compress': {
+        command: 'npm run build:css-compress'
+      },
+
       stylecheckSingleFile: {
         command: '' // populated dynamically
       },
@@ -488,7 +477,6 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-jst');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-cssmin');
   grunt.loadNpmTasks('grunt-shell');
   grunt.loadNpmTasks('grunt-md5');
 
@@ -511,10 +499,9 @@ module.exports = function (grunt) {
   grunt.registerTask('dependencies', ['get_deps', 'gen_load_addons:default']);
 
   // minify code and css, ready for release.
-  grunt.registerTask('minify', ['uglify', 'cssmin:compress']);
   grunt.registerTask('jsx', ['shell:build-jsx']);
   grunt.registerTask('build', ['shell:build-less', 'jst', 'requirejs', 'concat:requirejs', 'uglify',
-    'cssmin:compress', 'md5:requireJS', 'md5:css', 'template:release']);
+    'shell:css-compress', 'md5:requireJS', 'md5:css', 'template:release']);
 
   /*
    * Build the app in either dev, debug, or release mode

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,7 +152,7 @@ module.exports = function (grunt) {
           }
         },
         files: {
-          "dist/debug/templates.js": [
+          'dist/tmp-out/templates.js': [
             "app/templates/**/*.html",
             "app/addons/**/templates/**/*.html"
           ]
@@ -168,12 +168,12 @@ module.exports = function (grunt) {
     // index.html.
     concat: {
       requirejs: {
-        src: ["assets/js/libs/require.js", "dist/debug/templates.js", "dist/debug/require.js"],
-        dest: "dist/debug/js/require.js"
+        src: ["assets/js/libs/require.js", 'dist/tmp-out/templates.js', 'dist/tmp-out/require.js'],
+        dest: 'dist/tmp-out/require.js'
       },
 
       test_config_js: {
-        src: ["dist/debug/templates.js", "test/test.config.js"],
+        src: ['dist/tmp-out/templates.js', "test/test.config.js"],
         dest: 'test/test.config.js'
       }
     },
@@ -192,7 +192,7 @@ module.exports = function (grunt) {
       },
       style: {
         files: initHelper.watchFiles(['.less', '.css'], ["./app/**/*.css", "./app/**/*.less", "./assets/**/*.css", "./assets/**/*.less"]),
-        tasks: ['clean:watch', 'dependencies', 'shell:build-less']
+        tasks: ['clean:watch', 'dependencies', 'shell:build-less-debug']
       },
       html: {
         // the index.html is added in as a dummy file incase there is no
@@ -214,7 +214,7 @@ module.exports = function (grunt) {
           mainConfigFile: "app/config.js",
 
           // Output file.
-          out: "dist/debug/require.js",
+          out: 'dist/tmp-out/require.js',
 
           // Root application module.
           name: "config",
@@ -332,8 +332,12 @@ module.exports = function (grunt) {
         command: 'npm run stylecheck'
       },
 
-      'build-less': {
-        command: 'npm run build:less'
+      'build-less-debug': {
+        command: 'npm run build:less:debug'
+      },
+
+      'build-less-release': {
+        command: 'npm run build:less:release'
       },
 
       'css-compress': {
@@ -493,7 +497,7 @@ module.exports = function (grunt) {
 
   // minify code and css, ready for release.
   grunt.registerTask('jsx', ['shell:build-jsx']);
-  grunt.registerTask('build', ['shell:build-less', 'jst', 'requirejs', 'concat:requirejs', 'shell:uglify',
+  grunt.registerTask('build', ['shell:build-less-release', 'jst', 'requirejs', 'concat:requirejs', 'shell:uglify',
     'shell:css-compress', 'md5:requireJS', 'md5:css', 'template:release']);
 
   /*
@@ -503,11 +507,11 @@ module.exports = function (grunt) {
   grunt.registerTask('dev', ['debugDev', 'couchserver']);
 
   // build a debug release
-  grunt.registerTask('debug', ['lint', 'dependencies', "gen_initialize:development", 'jsx', 'concat:requirejs', 'shell:build-less',
+  grunt.registerTask('debug', ['lint', 'dependencies', "gen_initialize:development", 'jsx', 'concat:requirejs', 'shell:build-less-debug',
     'template:development', 'copy:debug']);
 
   grunt.registerTask('debugDev', ['clean', 'dependencies', "gen_initialize:development", 'jsx', 'shell:stylecheck',
-    'shell:build-less', 'template:development', 'copy:debug']);
+    'shell:build-less-debug', 'template:development', 'copy:debug']);
 
   grunt.registerTask('watchRun', ['clean:watch', 'dependencies', 'shell:stylecheck']);
 

--- a/build-helper/less.js
+++ b/build-helper/less.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const root = __dirname + '/../';
-const target = root + 'dist/debug/css/index.css';
+const target = root + process.argv[2];
 
 const fs = require('fs');
 const async = require('async');

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "async": "~0.2.6",
+    "clean-css": "^3.4.9",
     "couchapp": "~0.11.0",
     "eslint": "^1.6.0",
     "grunt": "~0.4.1",
@@ -25,7 +26,6 @@
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-cssmin": "~0.5.0",
     "grunt-contrib-jst": "~0.5.0",
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-contrib-uglify": "~0.2.0",
@@ -50,6 +50,7 @@
   "scripts": {
     "stylecheck": "eslint --ext=js,jsx .",
     "build:less": "mkdirp ./dist/debug/css && node ./build-helper/less.js",
+    "build:css-compress": "mkdirp ./dist/release/css/ && cleancss -o dist/release/css/index.css dist/debug/css/index.css",
     "test": "grunt test",
     "couchdebug": "grunt couchdebug",
     "couchdb": "grunt couchdb",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,10 @@
   },
   "scripts": {
     "stylecheck": "eslint --ext=js,jsx .",
-    "build:less": "mkdirp ./dist/debug/css && node ./build-helper/less.js",
-    "build:css-compress": "mkdirp ./dist/release/css/ && cleancss -o dist/release/css/index.css dist/debug/css/index.css",
-    "build:uglify": "mkdirp ./dist/release/js/ && uglifyjs --mangle --compress --screw-ie8 -o dist/release/js/require.js dist/debug/js/require.js",
+    "build:less:debug": "mkdirp ./dist/debug/css && node ./build-helper/less.js dist/debug/css/index.css",
+    "build:less:release": "mkdirp ./dist/tmp-out && node ./build-helper/less.js dist/tmp-out/index.css",
+    "build:css-compress": "mkdirp ./dist/release/css/ && cleancss -o dist/release/css/index.css dist/tmp-out/index.css",
+    "build:uglify": "mkdirp ./dist/release/js/ && uglifyjs --mangle --compress=warnings=false --screw-ie8 -o dist/release/js/require.js dist/tmp-out/require.js",
     "test": "grunt test",
     "couchdebug": "grunt couchdebug",
     "couchdb": "grunt couchdb",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-jst": "~0.5.0",
     "grunt-contrib-requirejs": "~0.4.1",
-    "grunt-contrib-uglify": "~0.2.0",
     "grunt-couchapp": "~0.2.1",
     "grunt-exec": "~0.4.0",
     "grunt-init": "~0.2.0",
@@ -43,6 +42,7 @@
     "react-tools": "^0.12.0",
     "request": "^2.54.0",
     "send": "~0.1.1",
+    "uglify-js": "^2.6.1",
     "underscore": "~1.4.2",
     "url": "~0.7.9",
     "urls": "~0.0.3"
@@ -51,6 +51,7 @@
     "stylecheck": "eslint --ext=js,jsx .",
     "build:less": "mkdirp ./dist/debug/css && node ./build-helper/less.js",
     "build:css-compress": "mkdirp ./dist/release/css/ && cleancss -o dist/release/css/index.css dist/debug/css/index.css",
+    "build:uglify": "mkdirp ./dist/release/js/ && uglifyjs --mangle --compress --screw-ie8 -o dist/release/js/require.js dist/debug/js/require.js",
     "test": "grunt test",
     "couchdebug": "grunt couchdebug",
     "couchdb": "grunt couchdb",


### PR DESCRIPTION
I am cleaning up our build further, by removing more of the grunt tools that have no real need

This PR saves us 21K by changing/optimizing the compression tools we have. 

Additionally I made first progress in separating the des/debug folder, used by the testserver we spin up and a production release. the index.css and the compiled require.js files are not copied from the debugserver.