### PR TITLE
fix: cssclean should not rebase font urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "stylecheck": "eslint --ext=js,jsx .",
     "build:less:debug": "mkdirp ./dist/debug/css && node ./build-helper/less.js dist/debug/css/index.css",
     "build:less:release": "mkdirp ./dist/tmp-out && node ./build-helper/less.js dist/tmp-out/index.css",
-    "build:css-compress": "mkdirp ./dist/release/css/ && cleancss -o dist/release/css/index.css dist/tmp-out/index.css",
+    "build:css-compress": "mkdirp ./dist/release/css/ && cleancss --skip-rebase -o dist/release/css/index.css dist/tmp-out/index.css",
     "build:uglify": "mkdirp ./dist/release/js/ && uglifyjs --mangle --compress=warnings=false --screw-ie8 -o dist/release/js/require.js dist/tmp-out/require.js",
     "test": "grunt test",
     "couchdebug": "grunt couchdebug",


### PR DESCRIPTION
this leads to fonts not being loaded