### PR TITLE
do not depend on second alert.info

### DIFF
--- a/app/addons/documents/tests/nightwatch/deletesDocuments.js
+++ b/app/addons/documents/tests/nightwatch/deletesDocuments.js
@@ -37,7 +37,6 @@ module.exports = {
       .clickWhenVisible('.bulk-action-component-selector-group button.fonticon-trash', waitTime, false)
       .acceptAlert()
 
-      .waitForElementVisible('.alert.alert-info', waitTime, false)
       .checkForStringNotPresent(newDatabaseName + '/_all_docs', newDocumentName)
       .checkForStringNotPresent(newDatabaseName + '/_all_docs', newDocumentName + '2')
       .url(baseUrl + '/' + newDatabaseName + '/_all_docs')


### PR DESCRIPTION
the two deletes make two notification boxes appear and disappear.

if the first one is removed in an unlucky timeframe, selenoum can't
find it any more with the current selector.

as the notification is not necessary for the test, remove it.