### PR TITLE
Minor extensibility tweaks

### DIFF
--- a/app/addons/components/react-components.react.jsx
+++ b/app/addons/components/react-components.react.jsx
@@ -1113,6 +1113,12 @@ function (app, FauxtonAPI, React, Stores, FauxtonComponents, ace, beautifyHelper
       id: React.PropTypes.string.isRequired
     },
 
+    getDefaultProps: function () {
+      return {
+        className: ''
+      };
+    },
+
     componentDidMount: function () {
       $('body').on('click.' + this.props.id, _.bind(this.closeIfOpen, this));
       FauxtonAPI.Events.on(FauxtonAPI.constants.EVENTS.TRAY_HIDE, this.closeIfOpen, this);
@@ -1150,7 +1156,7 @@ function (app, FauxtonAPI, React, Stores, FauxtonComponents, ace, beautifyHelper
 
     render: function () {
       return (
-        <div>
+        <div className={this.props.className}>
           {this.renderChildren()}
         </div>
       );

--- a/app/addons/documents/assets/less/query-options.less
+++ b/app/addons/documents/assets/less/query-options.less
@@ -57,7 +57,7 @@
 }
 
 #query-options-tray:before {
-  right: 230px;
+  right: 175px;
 }
 
 #query-options-tray {
@@ -65,8 +65,8 @@
   padding-top: 6px;
 
   .query-group:first-child {
-    margin-top: 0px;
-    padding-top: 0px;
+    margin-top: 0;
+    padding-top: 0;
   }
 
   .icon-question-sign {

--- a/app/addons/documents/header/header.react.jsx
+++ b/app/addons/documents/header/header.react.jsx
@@ -43,7 +43,7 @@ function (app, FauxtonAPI, React, Actions, ReactComponents,
         selectedView: indexResultsStore.getCurrentViewType(),
         isTableView: indexResultsStore.getIsTableView(),
         includeDocs: queryOptionsStore.getIncludeDocsEnabled(),
-        bulkDocCollection: indexResultsStore.getBulkDocCollection(),
+        bulkDocCollection: indexResultsStore.getBulkDocCollection()
       };
     },
 

--- a/app/addons/documents/queryoptions/queryoptions.react.jsx
+++ b/app/addons/documents/queryoptions/queryoptions.react.jsx
@@ -21,12 +21,25 @@ define([
 
 function (app, FauxtonAPI, React, Stores, Actions, Components) {
   var store = Stores.queryOptionsStore;
-  var LoadLines = Components.LoadLines;
   var Tray = Components.Tray;
   var TrayContents = Components.TrayContents;
   var ToggleHeaderButton = Components.ToggleHeaderButton;
 
   var MainFieldsView = React.createClass({
+    propTypes: {
+      toggleIncludeDocs: React.PropTypes.func.isRequired,
+      includeDocs: React.PropTypes.bool.isRequired,
+      reduce: React.PropTypes.bool.isRequired,
+      toggleReduce: React.PropTypes.func,
+      updateGroupLevel: React.PropTypes.func,
+      docURL: React.PropTypes.string
+    },
+
+    getDefaultProps: function () {
+      return {
+        docURL: FauxtonAPI.constants.DOC_URLS.GENERAL
+      };
+    },
 
     toggleIncludeDocs: function (e) {
       this.props.toggleIncludeDocs();
@@ -83,14 +96,15 @@ function (app, FauxtonAPI, React, Stores, Actions, Components) {
         <div className="query-group" id="query-options-main-fields">
           <span className="add-on">
             Query Options
-            <a className="help-link" href={FauxtonAPI.constants.DOC_URLS.GENERAL} target="_blank" data-bypass="true">
+            <a className="help-link" href={this.props.docURL} target="_blank" data-bypass="true">
               <i className="icon-question-sign" />
             </a>
           </span>
           <div className="controls-group qo-main-fields-row">
             <div className="row-fluid fieldsets">
               <div className="checkbox inline">
-                <input disabled={this.props.reduce} onChange={this.toggleIncludeDocs} className="boom" id="qoIncludeDocs" name="include_docs" type="checkbox" checked={includeDocs} />
+                <input disabled={this.props.reduce} onChange={this.toggleIncludeDocs} id="qoIncludeDocs"
+                   name="include_docs" type="checkbox" checked={includeDocs} />
                 <label className={this.props.reduce ? 'disabled' : ''} htmlFor="qoIncludeDocs" id="qoIncludeDocsLabel">Include Docs</label>
               </div>
               {this.reduce()}
@@ -371,6 +385,7 @@ A key value is the first parameter emitted in a map function. For example emit("
 
   return {
     QueryOptionsController: QueryOptionsController,
+    QueryButtons: QueryButtons,
     MainFieldsView: MainFieldsView,
     KeySearchFields: KeySearchFields,
     AdditionalParams: AdditionalParams,

--- a/app/addons/documents/queryoptions/tests/queryoptions.componentsSpec.react.jsx
+++ b/app/addons/documents/queryoptions/tests/queryoptions.componentsSpec.react.jsx
@@ -39,7 +39,6 @@ define([
       var mainFieldsEl;
 
       it('returns null no reduce', function () {
-
         mainFieldsEl = TestUtils.renderIntoDocument(<Views.MainFieldsView reduce={false} includeDocs={false} showReduce={false}/>, container);
         assert.ok(_.isNull(mainFieldsEl.reduce()));
       });
@@ -67,6 +66,15 @@ define([
 
         assert.ok(spy.calledOnce);
       });
+
+      it('uses overridden URL prop if defined', function () {
+        var customDocURL = 'http://whatever.com';
+        mainFieldsEl = TestUtils.renderIntoDocument(
+          <Views.MainFieldsView reduce={false} includeDocs={false} showReduce={false} docURL={customDocURL} />,
+          container);
+        assert.equal($(React.findDOMNode(mainFieldsEl)).find('.help-link').attr('href'), customDocURL);
+      });
+
     });
 
     describe('KeySearchFields', function () {


### PR DESCRIPTION
This PR contains a bunch of really small unrelated changes
for general extensibility.
- optional top-level class added to Tray component
- QueryOptions component now exposed for use elsewhere
- MainFieldsView query options component now accepts the doc URL
via a prop.
- Improvement for Up arrow on the query options tray placement