### PR TITLE
remove warnings on console

### DIFF
--- a/app/core/routeObject.js
+++ b/app/core/routeObject.js
@@ -136,8 +136,6 @@ function (FauxtonAPI, React, Backbone) {
       _.each(this.reactComponents, function (componentInfo, selector) {
         if ($(selector)[0]) {
           React.render(React.createElement(componentInfo.component, componentInfo.props), $(selector)[0]);
-        } else {
-          console.warn("Unable to mount reactor component. Missing selector: ", selector);
         }
       });
     },
@@ -263,8 +261,6 @@ function (FauxtonAPI, React, Backbone) {
       if (_.has(this.reactComponents, selector)) {
         if ($(selector)[0]) {
           React.unmountComponentAtNode($(selector)[0]);
-        } else {
-          console.warn("Unable to unmount react component. Missing selector: ", selector);
         }
         this.reactComponents[selector] = null;
         delete this.reactComponents[selector];


### PR DESCRIPTION
the warnings are displayed per default even for a valid release.

the warnings confuse people as they things something is broken,
but it is not.

this leads to a mindset were warnings are generally ignored as
the warning don't say anything about the status of the
application. this patch removes the warnings as debug logging can
get inserted again when there is something to debug.

more background info in this 5 minute lightning talk:  https://vimeo.com/146218883  (first talk)

