### PR TITLE
Fix for Beautify function within CodeEditorPanel component

### DIFF
--- a/app/addons/components/react-components.react.jsx
+++ b/app/addons/components/react-components.react.jsx
@@ -351,6 +351,7 @@ function (app, FauxtonAPI, React, Stores, FauxtonComponents, ace, beautifyHelper
 
     beautify: function (code) {
       this.setState({ code: code });
+      this.getEditor().setValue(code);
     },
 
     update: function () {
@@ -963,7 +964,7 @@ function (app, FauxtonAPI, React, Stores, FauxtonComponents, ace, beautifyHelper
       return (
         <button
           onClick={this.beautify}
-          className="beautify beautify_map btn btn-primary beautify-tooltip"
+          className="beautify beautify_map btn btn-primary btn-small beautify-tooltip"
           type="button"
           data-toggle="tooltip"
           title="Reformat your minified code to make edits to it."

--- a/app/addons/components/tests/beautifySpec.react.jsx
+++ b/app/addons/components/tests/beautifySpec.react.jsx
@@ -21,7 +21,7 @@ define([
   var TestUtils = React.addons.TestUtils;
 
   describe('Beautify', function () {
-    var container, beautifyEl, reduceStub;
+    var container, beautifyEl;
 
     beforeEach(function () {
       container = document.createElement('div');

--- a/app/addons/components/tests/codeEditorPanelSpec.react.jsx
+++ b/app/addons/components/tests/codeEditorPanelSpec.react.jsx
@@ -18,6 +18,7 @@ define([
 
   var assert = utils.assert;
   var TestUtils = React.addons.TestUtils;
+  var codeNoNewlines = 'function (doc) {emit(doc._id, 1);}';
   var code = 'function (doc) {\n  emit(doc._id, 1);\n}';
 
   describe('CodeEditorPanel', function () {
@@ -58,6 +59,26 @@ define([
           container
         );
         assert.equal($(codeEditorEl.getDOMNode()).find('.zen-editor-icon').length, 0);
+      });
+    });
+
+    describe('Beautify', function () {
+      it('confirm clicking beautify actually works within context of component', function () {
+        var container = document.createElement('div');
+        var codeEditorEl = TestUtils.renderIntoDocument(
+          <ReactComponents.CodeEditorPanel
+            defaultCode={codeNoNewlines}
+          />,
+          container
+        );
+
+        // confirm there are no newlines in the code at this point
+        assert.equal(codeEditorEl.getValue().match(/\n/g), null);
+
+        TestUtils.Simulate.click($(React.findDOMNode(codeEditorEl)).find('.beautify')[0]);
+
+        // now confirm newlines are found
+        assert.equal(codeEditorEl.getValue().match(/\n/g).length, 2);
       });
     });
 


### PR DESCRIPTION
Beautify wasn't working within the CodeEditorPanel component
because it didn't explicitly update the CodeEditor subcomponent.
This also reduces the size of the beautify button to make it more
appropriate.

As an example of where it was broken, edit a View with the function
on a single line and click the Beautify button. The btn would 
disappear but the code wasn't beautified.