### PR TITLE
react-dom-server@0.14.7

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -36,6 +36,7 @@ require.config({
     "react-autocomplete": "../assets/js/plugins/react-autocomplete",
     react: "../assets/js/libs/react",
     'react-dom': "../assets/js/libs/react-dom",
+    'react-dom-server': "../assets/js/libs/react-dom-server",
     flux: "../assets/js/libs/flux",
     "es5-shim": "../assets/js/libs/es5-shim",
     "css.escape": "../assets/js/libs/css.escape",

--- a/assets/js/libs/react-dom-server.js
+++ b/assets/js/libs/react-dom-server.js
@@ -1,0 +1,42 @@
+/**
+ * ReactDOMServer v0.14.7
+ *
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+// Based off https://github.com/ForbesLindesay/umd/blob/master/template.js
+;(function(f) {
+  // CommonJS
+  if (typeof exports === "object" && typeof module !== "undefined") {
+    module.exports = f(require('react'));
+
+    // RequireJS
+  } else if (typeof define === "function" && define.amd) {
+    define(['react'], f);
+
+    // <script>
+  } else {
+    var g;
+    if (typeof window !== "undefined") {
+      g = window;
+    } else if (typeof global !== "undefined") {
+      g = global;
+    } else if (typeof self !== "undefined") {
+      g = self;
+    } else {
+      // works providing we're not in "use strict";
+      // needed for Java 8 Nashorn
+      // see https://github.com/facebook/react/issues/3037
+      g = this;
+    }
+    g.ReactDOMServer = f(g.React);
+  }
+
+})(function(React) {
+  return React.__SECRET_DOM_SERVER_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+});


### PR DESCRIPTION
React 14 moved the `renderToStaticMarkup` to react-dom-server.
This is still a helpful method on the client, like for example,
funnelling markup into React Bootstrap components which require
markup as properties on DOM elements.