### PR TITLE
travis docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ sudo: true
 addons:
   firefox: "38.0.1"
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq flashplugin-installer
-
   - nvm install 4 && nvm use 4
 
   - docker run -d -p 5984:5984 klaemo/couchdb:2.0-dev --with-haproxy --admin=tester:testerpass
@@ -29,14 +26,9 @@ before_script:
   - ./bin/fauxton &
   - sleep 30
 script:
-  - ./node_modules/grunt-cli/bin/grunt $COMMAND
+  - ./node_modules/grunt-cli/bin/grunt nightwatch
 
 cache: apt
-
-env:
-  matrix:
-    - COMMAND=test
-    - COMMAND=nightwatchtravis
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ services:
 
 addons:
   firefox: "38.0.1"
+  apt:
+    sources:
+      - flashplugin-installer
+      
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq flashplugin-installer
-
   - nvm install 4 && nvm use 4
 
   - docker run -d -p 5984:5984 klaemo/couchdb:2.0-dev --with-haproxy --admin=tester:testerpass

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ otp_release:
 git:
   depth: 10
 
-sudo:
-  false
-
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ git:
 services:
   - docker
 
+sudo: true
+
 addons:
   firefox: "38.0.1"
-  apt:
-    sources:
-      - flashplugin-installer
-      
 before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq flashplugin-installer
+
   - nvm install 4 && nvm use 4
 
   - docker run -d -p 5984:5984 klaemo/couchdb:2.0-dev --with-haproxy --admin=tester:testerpass
@@ -35,7 +36,7 @@ cache: apt
 env:
   matrix:
     - COMMAND=test
-    - COMMAND=nightwatch
+    - COMMAND=nightwatchtravis
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,21 @@ otp_release:
 git:
   depth: 10
 
+sudo:
+  false
+
+services:
+  - docker
+
 addons:
   firefox: "38.0.1"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq flashplugin-installer
-  - sudo apt-get -y install libicu-dev libmozjs-dev pkg-config help2man libcurl4-openssl-dev
-  - sudo apt-get -y install libtool automake autoconf autoconf-archive
-  - sudo apt-get -y install haproxy
 
   - nvm install 4 && nvm use 4
 
-  - cd ..
-  - git clone --depth=1 https://github.com/apache/couchdb
-  - cd couchdb
-  - ./configure --disable-docs
-  - make
-  - ./dev/run --admin=tester:testerpass &
-  - haproxy -f rel/haproxy.cfg &
-  - cd .. && cd couchdb-fauxton
+  - docker run -d -p 5984:5984 klaemo/couchdb:2.0-dev --with-haproxy --admin=tester:testerpass
   - npm install
 
   - export DISPLAY=:99.0
@@ -34,9 +30,14 @@ before_script:
   - ./bin/fauxton &
   - sleep 30
 script:
-  - ./node_modules/grunt-cli/bin/grunt nightwatch
+  - ./node_modules/grunt-cli/bin/grunt $COMMAND
 
 cache: apt
+
+env:
+  matrix:
+    - COMMAND=test
+    - COMMAND=nightwatch
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: erlang
-otp_release:
-   - 17.4
+language: node_js
+node_js:
+  "4.0"
 git:
   depth: 10
 
@@ -12,8 +12,6 @@ sudo: true
 addons:
   firefox: "38.0.1"
 before_install:
-  - nvm install 4 && nvm use 4
-
   - docker run -d -p 5984:5984 klaemo/couchdb:2.0-dev --with-haproxy --admin=tester:testerpass
   - npm install
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "dev": "node ./devserver.js",
     "nightwatch": "grunt nightwatch",
     "start": "node ./bin/fauxton",
-    "postinstall": "node version-check.js && grunt release"
+    "postinstall": "node version-check.js && grunt release",
+    "nightwatchtravis": "./node_modules/grunt-cli/bin/grunt dev & && sleep 25 && ./node_modules/grunt-cli/bin/grunt nightwatch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Uses CouchDB 2.0 via docker and runs nightwatch and the tests in parallel. Hopefully this should speed up our builds.