### PR TITLE
Revert "JS validation added for Add Database"

### DIFF
--- a/app/addons/databases/actions.js
+++ b/app/addons/databases/actions.js
@@ -81,9 +81,9 @@ function (app, FauxtonAPI, Stores, ActionTypes, Resources) {
     },
 
     createNewDatabase: function (databaseName) {
-      if (_.isNull(databaseName) || databaseName.trim().length === 0 || !this.isValidDatabaseName(databaseName)) {
+      if (_.isNull(databaseName) || databaseName.trim().length === 0) {
         FauxtonAPI.addNotification({
-          msg: 'Please enter a valid database name. The database must start with a letter and can only contain lowercase letters (a-z), digits (0-9) and the following characters _, $, (, ), +, -, and /.',
+          msg: 'Please enter a valid database name',
           type: 'error',
           clear: true
         });
@@ -134,10 +134,6 @@ function (app, FauxtonAPI, Stores, ActionTypes, Resources) {
           type: 'error'
         });
       }
-    },
-
-    isValidDatabaseName: function (databaseName) {
-      return (/^[a-z][a-z0-9_\$\(\)\+\/-]*$/).test(databaseName);
     }
   };
 });

--- a/app/addons/databases/tests/actionsSpec.js
+++ b/app/addons/databases/tests/actionsSpec.js
@@ -246,40 +246,6 @@ define([
 
     });
 
-    describe('isValidDatabaseName', function () {
-      it("accepts valid database names", function () {
-        [
-          "one",
-          "one$",
-          "one/",
-          "o-n-e",
-          "o_n_e",
-          "o+n+e",
-          "one(or-two)"
-        ].forEach(function (item) {
-          assert.equal(Actions.isValidDatabaseName(item), true);
-        });
-      });
-
-      it("rejects invalid database names", function () {
-        [
-          "ONE",
-          "_one",
-          "-blah",
-          "one%",
-          "one*",
-          "one@",
-          "one#",
-          "one^",
-          "one~",
-          "one two",
-          " one"
-        ].forEach(function (item) {
-          assert.equal(Actions.isValidDatabaseName(item), false, "item: " + item);
-        });
-      });
-    });
-
   });
 
 });


### PR DESCRIPTION
This reverts commit b8bbb87c6919469521ff277694fb75e898157a7c.

The commit was added in https://github.com/apache/couchdb-fauxton/pull/468
but the validation has to happen in the backend. The current
validation does not cover databases which are created via curl or
other apps. It also prevents users from creating an accidentally
deleted `_users` database.

The fix for the root cause has to happen in the backend.

We should avoid trying to add validations in multiple, different
places.

COUCHDB-2748