### PR TITLE
Style update for metadata page

### DIFF
--- a/app/addons/documents/assets/less/documents.less
+++ b/app/addons/documents/assets/less/documents.less
@@ -88,7 +88,39 @@ button.beautify {
 }
 
 .metadata-page {
+  font-size: 14px;
   padding: 20px;
+
+  .preheading {
+    font-size: 14px;
+  }
+  h2 {
+    margin: 5px 0 15px;
+  }
+  h3 {
+    font-size: 22px;
+    margin-top: 12px;
+  }
+  header {
+    border-bottom: 1px solid #cccccc;
+    padding-bottom: 10px;
+  }
+  .icon-question-sign {
+    margin-left: 4px;
+  }
+  section {
+    line-height: 21px;
+    width: 100%;
+
+    ul {
+      list-style-type: none;
+      margin: 0 0 15px;
+      padding: 0;
+    }
+    .item-title {
+      margin-right: 6px;
+    }
+  }
 }
 
 button.delete {

--- a/app/addons/documents/designdocinfo/components.react.jsx
+++ b/app/addons/documents/designdocinfo/components.react.jsx
@@ -16,12 +16,14 @@ define([
   'react',
   './stores',
   './actions',
-  '../../components/react-components.react'
+  '../../components/react-components.react',
+  '../../fauxton/components.react'
 ],
 
-function (app, FauxtonAPI, React, Stores, Actions, ReactComponents) {
+function (app, FauxtonAPI, React, Stores, Actions, ReactComponents, GeneralComponents) {
   var designDocInfoStore = Stores.designDocInfoStore;
   var LoadLines = ReactComponents.LoadLines;
+  var Clipboard = GeneralComponents.Clipboard;
 
 
   var DesignDocInfo = React.createClass({
@@ -50,8 +52,15 @@ function (app, FauxtonAPI, React, Stores, Actions, ReactComponents) {
       this.setState(this.getStoreState());
     },
 
+    showCopiedMessage: function () {
+      FauxtonAPI.addNotification({
+        type: 'success',
+        msg: 'The MD5 sha has been copied to your clipboard.',
+        clear: true
+      });
+    },
+
     render: function () {
-      var formatSize = app.helpers.formatSize;
       var getDocUrl = app.helpers.getDocUrl;
       var viewIndex = this.state.viewIndex;
 
@@ -59,66 +68,88 @@ function (app, FauxtonAPI, React, Stores, Actions, ReactComponents) {
         return <LoadLines />;
       }
 
+      var actualSize = (viewIndex.data_size) ? viewIndex.data_size.toLocaleString('en') : 0;
+      var dataSize = (viewIndex.disk_size) ? viewIndex.disk_size.toLocaleString('en') : 0;
+
       return (
-      <div className="metadata-page">
-        <header className="page-header">
-          <h2>Design Document Metadata: _design/{this.state.ddocName} </h2>
-          <p className="help">Information about the specified design document, including the index,
-            index size and current status of the design document and associated index information.
-            <a href={getDocUrl('DESIGN_DOC_METADATA')} className="help-link" target="_blank" data-bypass="true">
-              <i className="icon-question-sign" />
+        <div className="metadata-page">
+          <header>
+            <div className="preheading">Design Document Metadata</div>
+            <h2>_design/{this.state.ddocName}</h2>
+
+            <p className="help">
+              Information about the specified design document, including the index, index size and current status of the
+              design document and associated index information.
+              <a href={getDocUrl('DESIGN_DOC_METADATA')} className="help-link" target="_blank" data-bypass="true">
+                <i className="icon-question-sign" />
               </a>
-          </p>
-        </header>
-        <div className="row-fluid">
-          <div className="span6">
-            <header>
-              <h3>Status</h3>
-            </header>
-            <dl>
-              <dt>Updater</dt>
-              <dd>{viewIndex.updater_running}</dd>
-              <dt>Compact</dt>
-              <dd>{viewIndex.compact_running }</dd>
-              <dt>Waiting Commit</dt>
-              <dd>{viewIndex.waiting_commit }</dd>
-              <dt>Waiting Clients</dt>
-              <dd>{viewIndex.waiting_clients }</dd>
-              <dt>Update Sequence</dt>
-              <dd>{viewIndex.update_seq }</dd>
-              <dt>Purge Sequence</dt>
-              <dd>{viewIndex.purge_seq }</dd>
-            </dl>
-          </div>
-          <div className="span6">
-            <header>
-              <h3>Information</h3>
-            </header>
-            <dl>
-              <dt>Language</dt>
-              <dd>{viewIndex.language }</dd>
-              <dt>Signature</dt>
-              <dd>{viewIndex.signature }</dd>
-            </dl>
-            <header>
-              <h3>Storage</h3>
-            </header>
-            <dl>
-              <dt>Data Size</dt>
-              <dd>{formatSize(viewIndex.data_size) }</dd>
-              <dt>Disk Size</dt>
-              <dd>{formatSize(viewIndex.disk_size) }</dd>
-            </dl>
-          </div>
+            </p>
+          </header>
+
+          <section className="container">
+            <h3>Index Information</h3>
+
+            <ul>
+              <li>
+                <span className="item-title">Language:</span>
+                <span className="capitalize">{viewIndex.language}</span>
+              </li>
+              <li>
+                <span className="item-title">Currently being updated?</span>
+                {viewIndex.updater_running ? 'Yes' : 'No'}
+              </li>
+              <li>
+                <span className="item-title">Currently running compaction?</span>
+                {viewIndex.compact_running ? 'Yes' : 'No'}
+              </li>
+              <li>
+                <span className="item-title">Waiting for a commit?</span>
+                {viewIndex.waiting_commit ? 'Yes' : 'No'}
+              </li>
+            </ul>
+
+            <ul>
+              <li>
+                <span className="item-title">Clients waiting for the index:</span>
+                {viewIndex.waiting_clients}
+              </li>
+              <li>
+                <span className="item-title">Update sequence on DB:</span>
+                {viewIndex.update_seq}
+              </li>
+              <li>
+                <span className="item-title">Processed purge sequence:</span>
+                {viewIndex.purge_seq}
+              </li>
+              <li>
+                <span className="item-title">Actual data size (bytes):</span>
+                {actualSize}
+              </li>
+              <li>
+                <span className="item-title">Data size on disk (bytes):</span>
+                {dataSize}
+              </li>
+            </ul>
+
+            <ul>
+              <li>
+                <span className="item-title">MD5 Signature:</span>
+                <Clipboard
+                  onClipboardClick={this.showCopiedMessage}
+                  text={viewIndex.signature} />
+              </li>
+            </ul>
+
+          </section>
+
         </div>
-      </div>
       );
     }
   });
 
 
-
   return {
     DesignDocInfo: DesignDocInfo
   };
+
 });

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -719,3 +719,7 @@ body .control-toggle-include-docs span {
     }
   }
 }
+
+.capitalize {
+  text-transform: capitalize;
+}


### PR DESCRIPTION
The metadata page was kinda ugly, and Tim White recently made
a few suggestions to me on how to improve the page. This implements 
many of his ideas and generally smartens up the page a bit.

#### Old page
<img width="1110" alt="metadata-page-old" src="https://cloud.githubusercontent.com/assets/512116/13616604/7ca67322-e52f-11e5-8a75-45b4c4b784fb.png">

#### New page
<img width="1214" alt="metadata-page-new" src="https://cloud.githubusercontent.com/assets/512116/13616613/844715a0-e52f-11e5-97c7-0de19d326f53.png">
