### PR TITLE
Handle empty view attribute and does not set state for unmounted reduce

### DIFF
--- a/app/addons/documents/index-editor/components.react.jsx
+++ b/app/addons/documents/index-editor/components.react.jsx
@@ -213,7 +213,9 @@ function (app, FauxtonAPI, React, ReactDOM, Stores, Actions, Components, ReactCo
     },
 
     onChange: function () {
-      this.setState(this.getStoreState());
+      if (this.isMounted()) {
+        this.setState(this.getStoreState());
+      }
     },
 
     componentDidMount: function () {

--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -125,7 +125,7 @@ define([
         return false;
       }
 
-      var views = this.get('views'),
+      var views = this.get('views') || {},
           tempView = views[view] || {};
 
       if (reduce) {


### PR DESCRIPTION
See https://cloudant.fogbugz.com/f/cases/58137/Cannot-add-a-view-to-an-existing-design-doc-with-no-views-property

This should handle instances where users create a ddoc outside of the dashboard editor and fail to include a "views" attribute.
