### PR TITLE
Improvements for table view

### DIFF
--- a/app/addons/documents/assets/less/index-results.less
+++ b/app/addons/documents/assets/less/index-results.less
@@ -103,8 +103,11 @@
   .tableview-checkbox-cell input {
     margin: 0 0 0 8px;
   }
+  .tableview-conflict {
+    color: #FF0000;
+  }
   .tableview-el-last {
-    width: 50px;
+    width: 75px;
   }
   .tableview-el-copy {
     width: 35px;

--- a/app/addons/documents/header/header.actions.js
+++ b/app/addons/documents/header/header.actions.js
@@ -26,8 +26,10 @@ function (app, FauxtonAPI, ActionTypes, ActionsQueryOptions) {
 
       if (state) {
         delete params.include_docs;
+        delete params.conflicts;
       } else {
         params.include_docs = true;
+        params.conflicts = true;
       }
 
       app.utils.localStorageSet('include_docs_bulkdocs', bulkDocsCollection.toJSON());

--- a/app/addons/documents/index-results/index-results.components.react.jsx
+++ b/app/addons/documents/index-results/index-results.components.react.jsx
@@ -128,21 +128,40 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents, Fauxto
       );
     },
 
-    getAttachmentRow: function (el) {
+    getAdditionalInfoRow: function (el) {
       var attachmentCount = Object.keys(el._attachments || {}).length;
-      var paperClip = null;
-      var text = null;
+      var attachmentIndicator = null;
+      var textAttachments = null;
+
+      var conflictCount = Object.keys(el._conflicts || {}).length;
+      var conflictIndicator = null;
+      var textConflicts = null;
+
 
       if (attachmentCount) {
-        text = attachmentCount === 1 ? attachmentCount + ' Attachment' : attachmentCount + ' Attachments';
-        paperClip = (
-          <div><i className="icon fonticon-paperclip"></i> {attachmentCount}</div>
+        textAttachments = attachmentCount === 1 ? attachmentCount + ' Attachment' : attachmentCount + ' Attachments';
+        attachmentIndicator = (
+          <div style={{display: 'inline', marginLeft: '5px'}} title={textAttachments}>
+            <i className="icon fonticon-paperclip"></i>{attachmentCount}
+          </div>
+        );
+      }
+
+      if (conflictCount) {
+        textConflicts = conflictCount === 1 ? conflictCount + ' Conflict' : conflictCount + ' Conflicts';
+        conflictIndicator = (
+          <div className="tableview-conflict" data-conflicts-indicator style={{display: 'inline'}} title={textConflicts}>
+            <i
+              style={{fontSize: '17px'}}
+              className="icon icon-code-fork"></i>{conflictCount}
+          </div>
         );
       }
 
       return (
-        <td title={text} className="tableview-el-last">
-          {paperClip}
+        <td className="tableview-el-last">
+          {conflictIndicator}
+          {attachmentIndicator}
         </td>
       );
     },
@@ -178,7 +197,7 @@ function (app, FauxtonAPI, React, Stores, Actions, Components, Documents, Fauxto
           {this.getCopyButton(docContent)}
           {this.maybeGetSpecialField(el, i)}
           {this.getRowContents(el, i)}
-          {this.getAttachmentRow(docContent)}
+          {this.getAdditionalInfoRow(docContent)}
         </tr>
       );
     }

--- a/app/addons/documents/tests/nightwatch/tableViewConflicts.js
+++ b/app/addons/documents/tests/nightwatch/tableViewConflicts.js
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+module.exports = {
+
+  'Shows how many conflicts have appeared': function (client) {
+    var waitTime = client.globals.maxWaitTime,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .populateDatabaseWithConflicts(newDatabaseName)
+      .checkForDocumentCreated('outfit1')
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+
+      .clickWhenVisible('.alternative-header .two-sides-toggle-button button:last-child')
+      .waitForElementVisible('.table', client.globals.maxWaitTime, false)
+
+      .clickWhenVisible('.control-toggle-include-docs')
+
+      .waitForElementVisible('.table-container-autocomplete', client.globals.maxWaitTime, false)
+
+      .assert.visible('.table [data-conflicts-indicator="true"]')
+
+      .end();
+  }
+};

--- a/test/nightwatch_tests/custom-commands/populateDatabaseWithConflicts.js
+++ b/test/nightwatch_tests/custom-commands/populateDatabaseWithConflicts.js
@@ -1,0 +1,73 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+var util = require('util'),
+    events = require('events'),
+    helpers = require('../helpers/helpers.js'),
+    request = require('request');
+
+function PopulateDatabaseWithConflicts () {
+  events.EventEmitter.call(this);
+}
+
+util.inherits(PopulateDatabaseWithConflicts, events.EventEmitter);
+
+PopulateDatabaseWithConflicts.prototype.command = function (databaseName) {
+  var nano = helpers.getNanoInstance(),
+      database = nano.use(databaseName);
+
+  database.insert({
+    hat: 'flamingo'
+  }, 'outfit1', function () {
+    createConflictingDoc(null, function () {
+      this.emit('complete');
+    }.bind(this));
+  }.bind(this));
+
+  function createConflictingDoc (err, cb) {
+    request({
+      uri: helpers.test_settings.db_url + '/' + databaseName + '/conflictingdoc',
+      method: 'PUT',
+      json: true,
+      body: {
+        id: 'conflictingdoc',
+        rocko: 'dances'
+      }
+    }, function (err, res, body) {
+      if (err) {
+        console.log(
+          'Error in nano populateDatabase Function: ' + err.message
+        );
+      }
+      request({
+        uri: helpers.test_settings.db_url + '/' + databaseName + '/conflictingdoc?new_edits=false',
+        method: 'PUT',
+        json: true,
+        body: {
+          _rev: '4-afae890a0310210db079b0f49fb2569d',
+          rocko: 'jumps'
+        }
+      }, function (err, res, body) {
+        if (err) {
+          console.log('Error in nano populateDatabase Function: ' +
+            err.message);
+        }
+
+        cb && cb();
+      });
+    });
+  }
+
+  return this;
+};
+
+module.exports = PopulateDatabaseWithConflicts;


### PR DESCRIPTION
 - show conflicts / conflict-count in table-view
 
to create a conflict for the document `elephant` in `animaldb` use the `new_edits=false` parameter with a random rev:

```
curl -XPUT http://localhost:8000/animaldb/elephant?new_edits=false -d '{"_rev":"4-afae890a0310210db079b0f49fb2569d","foo":"bar"}' -H 'Content-Type: application/json'
```