### PR TITLE
Update NW to 0.8.18; asyncHookTimeout increased

### DIFF
--- a/app/addons/databases/tests/nightwatch/createsDatabase.js
+++ b/app/addons/databases/tests/nightwatch/createsDatabase.js
@@ -15,14 +15,14 @@ var helpers = require('../../../../../test/nightwatch_tests/helpers/helpers.js')
 module.exports = {
 
   before: function (client, done) {
-    var nano = helpers.getNanoInstance();
+    var nano = helpers.getNanoInstance(client.globals.test_settings.db_url);
     nano.db.destroy(newDatabaseName, function (err, body, header) {
       done();
     });
   },
 
   after: function (client, done) {
-    var nano = helpers.getNanoInstance();
+    var nano = helpers.getNanoInstance(client.globals.test_settings.db_url);
     nano.db.destroy(newDatabaseName, function (err, body, header) {
       done();
     });

--- a/app/addons/documents/tests/nightwatch/deleteDatabaseModal.js
+++ b/app/addons/documents/tests/nightwatch/deleteDatabaseModal.js
@@ -14,14 +14,14 @@ var helpers = require('../../../../../test/nightwatch_tests/helpers/helpers.js')
 module.exports = {
 
   before: function (client, done) {
-    var nano = helpers.getNanoInstance();
+    var nano = helpers.getNanoInstance(client.globals.test_settings.db_url);
     nano.db.create('_replicator', function (err, body, header) {
       done();
     });
   },
 
   after: function (client, done) {
-    var nano = helpers.getNanoInstance();
+    var nano = helpers.getNanoInstance(client.globals.test_settings.db_url);
     nano.db.destroy('_replicator', function (err, body, header) {
       done();
     });

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "imports-loader": "^0.6.5",
     "mocha": "^2.4.5",
     "mocha-phantomjs": "~4.0.2",
-    "nightwatch": "^0.6.0",
-    "phantomjs": "~1.9.1",
+    "nightwatch": "~0.8.18",
+    "phantomjs": "^1.9.1",
     "react-addons-test-utils": "^0.14.7",
     "sinon": "git+https://github.com/sinonjs/sinon.git"
   },

--- a/test/nightwatch_tests/custom-commands/checkForDatabaseCreated.js
+++ b/test/nightwatch_tests/custom-commands/checkForDatabaseCreated.js
@@ -23,7 +23,7 @@ function CheckForDatabaseCreated () {
 util.inherits(CheckForDatabaseCreated, events.EventEmitter);
 
 CheckForDatabaseCreated.prototype.command = function (databaseName, timeout) {
-  var couchUrl = helpers.test_settings.db_url;
+  var couchUrl = this.client.options.db_url;
 
   if (!timeout) {
     timeout = helpers.maxWaitTime;

--- a/test/nightwatch_tests/custom-commands/checkForDatabaseDeleted.js
+++ b/test/nightwatch_tests/custom-commands/checkForDatabaseDeleted.js
@@ -23,7 +23,7 @@ function CheckForDatabaseDeleted () {
 util.inherits(CheckForDatabaseDeleted, events.EventEmitter);
 
 CheckForDatabaseDeleted.prototype.command = function (databaseName, timeout) {
-  var couchUrl = helpers.test_settings.db_url;
+  var couchUrl = this.client.options.db_url;
 
   if (!timeout) {
     timeout = helpers.maxWaitTime;

--- a/test/nightwatch_tests/custom-commands/checkForDocumentCreated.js
+++ b/test/nightwatch_tests/custom-commands/checkForDocumentCreated.js
@@ -23,7 +23,7 @@ function CheckForDocumentCreated () {
 util.inherits(CheckForDocumentCreated, events.EventEmitter);
 
 CheckForDocumentCreated.prototype.command = function (doc, timeout, db) {
-  var couchUrl = helpers.test_settings.db_url;
+  var couchUrl = this.client.options.db_url;
 
   if (!db) {
     db = helpers.testDatabaseName;

--- a/test/nightwatch_tests/custom-commands/checkForStringNotPresent.js
+++ b/test/nightwatch_tests/custom-commands/checkForStringNotPresent.js
@@ -23,8 +23,7 @@ function CheckForStringNotPresent () {
 util.inherits(CheckForStringNotPresent, events.EventEmitter);
 
 CheckForStringNotPresent.prototype.command = function (path, string, timeout) {
-  var couchUrl = helpers.test_settings.db_url,
-      db = helpers.testDatabaseName;
+  var couchUrl = this.client.options.db_url;
 
   if (!timeout) {
     timeout = helpers.maxWaitTime;

--- a/test/nightwatch_tests/custom-commands/checkForStringPresent.js
+++ b/test/nightwatch_tests/custom-commands/checkForStringPresent.js
@@ -23,8 +23,7 @@ function CheckForStringPresent () {
 util.inherits(CheckForStringPresent, events.EventEmitter);
 
 CheckForStringPresent.prototype.command = function (path, string, timeout) {
-  var couchUrl = helpers.test_settings.db_url,
-      db = helpers.testDatabaseName;
+  var couchUrl = this.client.options.db_url;
 
   if (!timeout) {
     timeout = helpers.maxWaitTime;

--- a/test/nightwatch_tests/custom-commands/createDatabase.js
+++ b/test/nightwatch_tests/custom-commands/createDatabase.js
@@ -23,7 +23,7 @@ util.inherits(CreateDatabase, events.EventEmitter);
 
 CreateDatabase.prototype.command = function (databaseName) {
   var that = this,
-      nano = helpers.getNanoInstance();
+      nano = helpers.getNanoInstance(this.client.options.db_url);
 
   nano.db.create(databaseName, function (err, body, header) {
     if (err) {

--- a/test/nightwatch_tests/custom-commands/createDocument.js
+++ b/test/nightwatch_tests/custom-commands/createDocument.js
@@ -23,7 +23,7 @@ function CreateDocument () {
 util.inherits(CreateDocument, events.EventEmitter);
 
 CreateDocument.prototype.command = function (documentName, databaseName, docContents) {
-  var couchUrl = helpers.test_settings.db_url;
+  var couchUrl = this.client.options.db_url;
 
   if (!docContents) {
     docContents = { dummyKey: 'testingValue' };

--- a/test/nightwatch_tests/custom-commands/createManyDocuments.js
+++ b/test/nightwatch_tests/custom-commands/createManyDocuments.js
@@ -23,7 +23,7 @@ util.inherits(CreateManyDocuments, events.EventEmitter);
 
 CreateManyDocuments.prototype.command = function (amount, databaseName) {
   var that = this,
-      nano = helpers.getNanoInstance(),
+      nano = helpers.getNanoInstance(this.client.options.db_url),
       database = nano.use(databaseName),
       docs = [];
 

--- a/test/nightwatch_tests/custom-commands/deleteDatabase.js
+++ b/test/nightwatch_tests/custom-commands/deleteDatabase.js
@@ -22,7 +22,7 @@ util.inherits(DeleteDatabase, events.EventEmitter);
 
 DeleteDatabase.prototype.command = function (databaseName) {
   var that = this,
-      nano = helpers.getNanoInstance();
+      nano = helpers.getNanoInstance(this.client.options.db_url);
 
   nano.db.destroy(databaseName, function (err, body, header) {
     if (err) {

--- a/test/nightwatch_tests/custom-commands/deleteDocument.js
+++ b/test/nightwatch_tests/custom-commands/deleteDocument.js
@@ -12,7 +12,7 @@ util.inherits(DeleteDocument, events.EventEmitter);
 
 DeleteDocument.prototype.command = function (databaseName, documentName) {
   var that = this,
-      nano = helpers.getNanoInstance(),
+      nano = helpers.getNanoInstance(this.client.options.db_url),
       database = nano.use(databaseName),
       documentRev;
 

--- a/test/nightwatch_tests/custom-commands/populateDatabase.js
+++ b/test/nightwatch_tests/custom-commands/populateDatabase.js
@@ -24,9 +24,10 @@ util.inherits(PopulateDatabase, events.EventEmitter);
 
 PopulateDatabase.prototype.command = function (databaseName, count) {
   var that = this,
-      nano = helpers.getNanoInstance(),
+      nano = helpers.getNanoInstance(this.client.options.db_url),
       database = nano.use(databaseName),
-      i = 0;
+      i = 0,
+      db_url = that.client.options.db_url;
 
   async.whilst(
     function () { return i < (count ? count : 20); },
@@ -61,7 +62,7 @@ PopulateDatabase.prototype.command = function (databaseName, count) {
 
         createKeyView(null, function () {
           createBrokenView(null, function () {
-            createMangoIndex(null, function () {
+            createMangoIndex(null, db_url, function () {
               that.emit('complete');
             });
           });
@@ -105,9 +106,9 @@ PopulateDatabase.prototype.command = function (databaseName, count) {
     });
   }
 
-  function createMangoIndex (err, cb) {
+  function createMangoIndex (err, db_url, cb) {
     request({
-      uri: helpers.test_settings.db_url + '/' + databaseName + '/_index',
+      uri: db_url + '/' + databaseName + '/_index',
       method: 'POST',
       json: true,
       body: {

--- a/test/nightwatch_tests/custom-commands/replicateDatabase.js
+++ b/test/nightwatch_tests/custom-commands/replicateDatabase.js
@@ -23,7 +23,7 @@ util.inherits(ReplicateDatabase, events.EventEmitter);
 
 ReplicateDatabase.prototype.command = function (source, target, options, callback) {
   var that = this,
-      nano = helpers.getNanoInstance(),
+      nano = helpers.getNanoInstance(this.client.options.db_url),
       opts = options;
 
 

--- a/test/nightwatch_tests/helpers/helpers.js
+++ b/test/nightwatch_tests/helpers/helpers.js
@@ -14,15 +14,16 @@ var nano = require('nano');
 var async = require('async');
 
 module.exports = {
+  asyncHookTimeout: 20000,
   maxWaitTime: 30000,
   testDatabaseName : 'fauxton-selenium-tests',
 
-  getNanoInstance: function () {
-    return nano(this.test_settings.db_url);
+  getNanoInstance: function (dbURL) {
+    return nano(dbURL);
   },
 
   beforeEach: function (browser, done) {
-    var nano = module.exports.getNanoInstance(),
+    var nano = module.exports.getNanoInstance(browser.globals.test_settings.db_url),
         database = module.exports.testDatabaseName;
 
     console.log('nano setting up database');
@@ -44,7 +45,7 @@ module.exports = {
   },
 
   afterEach: function (browser, done) {
-    var nano = module.exports.getNanoInstance(),
+    var nano = module.exports.getNanoInstance(browser.globals.test_settings.db_url),
         database = module.exports.testDatabaseName;
 
     console.log('nano cleaning up');


### PR DESCRIPTION
This updates NW to use the latest version. Occasionally async
requests can fail to return by the default NW 10 second timeout;
this increases the value to 20 seconds to reduce the likelihood
of that occurring.

Note: the other refactoring was due to "this" no longer 
being consistent in the scenarios where it was called and 
helpers no longer being extended with all the runtime settings.