### PR TITLE
Editor: don't throw if document has no id

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
-    "react"
+    "react",
+    "es2015"
   ]
 }

--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -31,7 +31,14 @@ define([
       if (context === undefined) {
         context = 'server';
       }
-      return FauxtonAPI.urls('document', context, this.getDatabase().safeID(), this.safeID());
+
+      // new without id make a POST to the DB and not a PUT on a DB
+      let id = this.safeID();
+      if (!id) {
+        id = '';
+      }
+
+      return FauxtonAPI.urls('document', context, this.getDatabase().safeID(), id);
     },
 
     initialize: function (_attrs, options) {

--- a/app/addons/documents/tests/nightwatch/createsDocumentWithoutId.js
+++ b/app/addons/documents/tests/nightwatch/createsDocumentWithoutId.js
@@ -11,7 +11,7 @@
 // the License.
 
 module.exports = {
-  'Creates a document' : function (client) {
+  'Creates a document without id' : function (client) {
     /*jshint multistr: true */
     var waitTime = client.globals.maxWaitTime,
         newDatabaseName = client.globals.testDatabaseName,
@@ -22,6 +22,7 @@ module.exports = {
       .createDatabase(newDatabaseName)
       .loginToGUI()
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+
       .clickWhenVisible('#new-all-docs-button a')
       .clickWhenVisible('#new-all-docs-button a[href="#/database/' + newDatabaseName + '/new"]')
       .waitForElementPresent('#editor-container', waitTime, false)
@@ -34,22 +35,15 @@ module.exports = {
 
       .execute('\
         var editor = ace.edit("doc-editor");\
-        editor.gotoLine(2,10);\
-        editor.removeWordRight();\
-        editor.insert("' + newDocumentName + '");\
+        editor.gotoLine(2,1);\
+        editor.removeLines();\
+        editor.insert(\'"foo": "bar"\');\
       ')
 
+      .checkForStringPresent(newDatabaseName + '/_all_docs', '"total_rows":0')
       .clickWhenVisible('#doc-editor-actions-panel .save-doc')
-      .checkForDocumentCreated(newDocumentName)
-      .url(baseUrl + '/' + newDatabaseName + '/_all_docs')
-      .waitForElementPresent('body', waitTime, false)
-      .getText('body', function (result) {
-        var data = result.value,
-            createdDocIsPresent = data.indexOf(newDocumentName);
+      .checkForStringPresent(newDatabaseName + '/_all_docs', '"total_rows":1')
 
-        this.verify.ok(createdDocIsPresent > 0,
-          'Checking if new document shows up in _all_docs.');
-      })
     .end();
   }
 };


### PR DESCRIPTION
Right now the editor throws if you try to create a doc that does
nto have an id, instead of doing a POST to the database, which
will cause CouchDB to create an id for us.

Sometimes you want to be able to not use the pre-generated id from
Fauxton. Use cases are copy pasting a JSON object into the editor
or if you want to let the server take care of creating the id.

This patch lets fixes an invalid POST to `$DB/undefined` in cases
where the id wasn't specified.

Thanks to Will Holley for reporting!
