### PR TITLE
Improve Less error display

### DIFF
--- a/build-helper/less.js
+++ b/build-helper/less.js
@@ -40,14 +40,15 @@ const parser = new less.Parser(options);
 
 
 function writeCSS (files) {
-  function concatCSS (src, cb) {
-    fs.readFile(root + src, 'utf8', (err, data) => {
+  function concatCSS (filePath, cb) {
+    fs.readFile(root + filePath, 'utf8', (err, data) => {
       if (err) {
         return cb(null, []);
       }
 
       parser.parse(data, (err, tree) => {
         if (err) {
+          console.log('--> error with: ', filePath, err);
           throw err;
         }
         return cb(null, [tree.toCSS()]);


### PR DESCRIPTION
When there's a Less file error thrown it doesn't contain any useful
information to help debug the issue. This tweaks it to output the 
filepath  and the error details.

e.g. it now displays something like:

```
--> error with:  app/addons/warehouse/assets/less/warehouse.less { [Error: '../../../../assets/less/mixins.less' wasn't found]
  type: 'File',
  message: '\'../../../../assets/less/mixins.less\' wasn\'t found',
  filename: 'input',
  index: 53,
  line: 2,
  callLine: NaN,
  callExtract: undefined,
  column: 0,
  extract: 
   [ '@import "../../../style/assets/less/variables.less";',
     '@import "../../../../assets/less/mixins.less";',
     '@import "../../../../assets/less/bootstrap/mixins.less";' ] }

```