### PR TITLE
Disable strict SSL for Travis npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ git:
 addons:
   firefox: "38.0.1"
 before_install:
+  - npm config set strict-ssl false
+
   - sudo apt-get update -qq
   - sudo apt-get install -qq flashplugin-installer
   - sudo apt-get -y install libicu-dev libmozjs-dev pkg-config help2man libcurl4-openssl-dev
   - sudo apt-get -y install libtool automake autoconf autoconf-archive
   - sudo apt-get -y install haproxy
-
   - nvm install 4 && nvm use 4
 
   - cd ..


### PR DESCRIPTION
phantomJS fails to download pretty frequently due to
SSL strict being enabled. This patches it.