### PR TITLE
Tweak tableViewConflicts NW test

### DIFF
--- a/app/addons/documents/tests/nightwatch/tableViewConflicts.js
+++ b/app/addons/documents/tests/nightwatch/tableViewConflicts.js
@@ -24,11 +24,12 @@ module.exports = {
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
 
       .clickWhenVisible('.alternative-header .two-sides-toggle-button button:last-child')
-      .waitForElementVisible('.table', client.globals.maxWaitTime, false)
+      .waitForElementVisible('.table', waitTime, false)
 
       .clickWhenVisible('.control-toggle-include-docs')
 
-      .waitForElementVisible('.table-container-autocomplete', client.globals.maxWaitTime, false)
+      .waitForElementVisible('.table-container-autocomplete', waitTime, false)
+      .waitForElementVisible('.tableview-conflict', waitTime, false)
 
       .assert.visible('.table [data-conflicts-indicator="true"]')
 


### PR DESCRIPTION
This test fails occasionally. This softens it a little to
ensure the expected parent DOM element is there before
asserting stuff on it.