### PR TITLE
Style fix for menu dropdown in left header

### DIFF
--- a/app/addons/components/assets/less/components.less
+++ b/app/addons/components/assets/less/components.less
@@ -21,3 +21,4 @@
 @import "badges.less";
 @import "modals.less";
 @import "tab-element.less";
+@import "left-header.less";

--- a/app/addons/components/assets/less/left-header.less
+++ b/app/addons/components/assets/less/left-header.less
@@ -1,0 +1,26 @@
+@import "../../../../../assets/less/variables.less";
+
+.header-left #header-dropdown-menu {
+  top: 0;
+  height: 64px;
+  border-left: 1px solid #cccccc;
+  padding: 20px 0;
+
+  .dropdown {
+    font-size: 20px;
+    .dropdown-toggle {
+      padding: 10px 16px;
+      color: #555555;
+      &:before {
+        width: 10px;
+      }
+      &:hover {
+        color: @red;
+      }
+    }
+  }
+  .dropdown-menu {
+    left: -115px;
+    top: 34px;
+  }
+}


### PR DESCRIPTION
This fixes the styles for the ellipsis and the placement of the
dropdown that appears when you click it.

<img width="416" alt="screen shot 2016-05-31 at 1 41 18 pm" src="https://cloud.githubusercontent.com/assets/512116/15676350/62ff091e-2735-11e6-9ae1-cf1cd2a9d637.png">
