### PR TITLE
Style fix for doc ID block

### DIFF
--- a/app/addons/documents/assets/less/jumptodoc.less
+++ b/app/addons/documents/assets/less/jumptodoc.less
@@ -20,3 +20,20 @@
   overflow: visible;
   position: absolute;
 }
+
+#jump-to-doc {
+  .Select-control, .Select-menu-outer {
+    width: 210px;
+  }
+}
+
+/* this allows the jump-to-doc results expand as much as need be when the component is used in the header */
+#right-header #jump-to-doc .Select-menu-outer {
+  &>div>div {
+    padding-right: 25px; /* prevents overlapping of auto-generated scrollbar */
+  }
+  min-width: 210px;
+  max-width: 450px;
+  width: auto;
+  overflow: hidden; /* for 450px max widths, enough is visible not to require scrolling */
+}

--- a/app/addons/documents/jumptodoc.react.jsx
+++ b/app/addons/documents/jumptodoc.react.jsx
@@ -29,7 +29,7 @@ const JumpToDoc = ({database, allDocs}) => {
       <ReactSelect
         name="jump-to-doc"
         placeholder="Document ID"
-        className="input-large jump-to-doc"
+        className="jump-to-doc"
         options={options}
         clearable={false}
         onChange={({value: docId}) => {

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -528,7 +528,7 @@ body #dashboard .flex-body#breadcrumbs {
 }
 
 .Select .Select-menu {
-  min-height: 291px;
+  max-height: 291px;
   background-color: #333333;
 }
 


### PR DESCRIPTION
When you typed in something in the document ID typeahead field
it would look a little odd if there were no results (the grey
block would be fixed at 291px). This changes that to a max height
so it only ever appears as tall as it needs to be (and looks nice
when you're typing and honing in on a doc).

If I'm off the mark on this & there was a reason for the min-height,
just let me know.

Before: 
<img width="297" alt="screen shot 2016-05-31 at 1 46 43 pm" src="https://cloud.githubusercontent.com/assets/512116/15676860/6cb6f97e-2737-11e6-8f47-0f8f5a06eb34.png">

After: 
<img width="361" alt="screen shot 2016-05-31 at 1 51 54 pm" src="https://cloud.githubusercontent.com/assets/512116/15676863/7477326e-2737-11e6-91e0-34326d6fe583.png">
