### PR TITLE
provide debugging help for monkey patched established methods

### DIFF
--- a/app/core/routeObject.js
+++ b/app/core/routeObject.js
@@ -102,17 +102,27 @@ _.extend(RouteObject.prototype, Backbone.Events, {
         establishError = _.bind(this.establishError, this),
         renderComplete = _.bind(this.renderComplete, this),
         callEstablish = _.bind(this.callEstablish, this),
-        renderReactComponents = _.bind(this.renderReactComponents, this),
-        promise = this.establish();
+        renderReactComponents = _.bind(this.renderReactComponents, this);
+
+    const promise = this.establish();
 
     // Only start the view rendering process once the template has been rendered
     // otherwise we get double renders
     promiseLayout.then(function () {
       renderReactComponents();
+
       callEstablish(promise)
         .then(renderAllViews, establishError)
-        .then(renderComplete);
-    });
+        .then(renderComplete, (err) => {
+          console.error('renderpipeline broke');
+          console.error('check your establish method');
+
+          console.log(this.establish.toString());
+          console.error(err);
+        });
+
+
+    }.bind(this));
   },
 
   setTemplateOnFullRender: function (masterLayout) {

--- a/app/core/routeObject.js
+++ b/app/core/routeObject.js
@@ -54,7 +54,7 @@ RouteObject.on = function (eventName, fn) {
  Current Events to subscribe to:
   * beforeFullRender -- before a full render is being done
   * beforeEstablish -- before the routeobject calls establish
-  * AfterEstablish -- after the routeobject has run establish
+  * afterEstablish -- after the routeobject has run establish
   * beforeRender -- before a view is rendered
   * afterRender -- a view is finished being rendered
   * renderComplete -- all rendering is complete


### PR DESCRIPTION
inheritance is so ridiculous. inheritance in javascript is
just monkey patching. today i spent 8 hrs to finding a bug where
a promise failed silently in a monkey patched route object.

i found it by stringifying a function at runtime with
`console.log(this.establish.toString());` in the renderpipeline
which calls establish on the routeobjects.

the promise in the establish fails, the whole renderpipeline
fails silently and the breadcrumbs component is not rendered.

this commit will make finding those issues in the future a lot
easier