### PR TITLE
display not exist error just on 404

### DIFF
--- a/app/addons/documents/doc-editor/actions.js
+++ b/app/addons/documents/doc-editor/actions.js
@@ -36,7 +36,10 @@ function initDocEditor (params) {
       params.onLoaded();
     }
   }, function (xhr, reason, msg) {
-    errorNotification('The document does not exist.');
+    if (xhr.status === 404) {
+      errorNotification('The document does not exist.');
+    }
+
     FauxtonAPI.navigate(FauxtonAPI.urls('allDocs', 'app', params.database.id, ''));
   });
 }


### PR DESCRIPTION
just in case of a 404 the notification "The document does not
exist" is relevant.