### PR TITLE
#3030 Centralise ajax requests

### DIFF
--- a/app/addons/components/actions.js
+++ b/app/addons/components/actions.js
@@ -11,8 +11,9 @@
 // the License.
 
 import FauxtonAPI from "../../core/api";
-import ActionTypes from "./actiontypes";
+import { del } from "../../core/ajax";
 
+import ActionTypes from "./actiontypes";
 function showAPIBarButton () {
   FauxtonAPI.dispatch({ type: ActionTypes.CMPNTS_SHOW_API_BAR_BUTTON });
 }
@@ -45,10 +46,8 @@ function showDeleteDatabaseModal (options) {
 function deleteDatabase (dbId) {
   var url = FauxtonAPI.urls('databaseBaseURL', 'server', dbId, '');
 
-  $.ajax({
-    url: url,
-    dataType: 'json',
-    type: 'DELETE'
+  del({
+    url,
   }).then(function () {
     this.showDeleteDatabaseModal({ showModal: true });
 

--- a/app/addons/config/resources.js
+++ b/app/addons/config/resources.js
@@ -12,6 +12,7 @@
 
 import app from "../../app";
 import FauxtonAPI from "../../core/api";
+import { put, del } from "../../core/ajax";
 
 var Config = FauxtonAPI.addon();
 
@@ -35,20 +36,16 @@ Config.OptionModel = Backbone.Model.extend({
   isNew: function () { return false; },
 
   sync: function (method, model, options) {
-
-    var params = {
+    const opts = {
       url: model.url(),
-      contentType: 'application/json',
-      dataType: 'json',
-      data: JSON.stringify(model.get('value'))
+      data: model.get('value'),
     };
 
     if (method === 'delete') {
-      params.type = 'DELETE';
-    } else {
-      params.type = 'PUT';
+      return del(opts);
     }
-    return $.ajax(params);
+
+    return put(opts);
   }
 });
 

--- a/app/addons/cors/resources.js
+++ b/app/addons/cors/resources.js
@@ -12,6 +12,7 @@
 
 import app from "../../app";
 import FauxtonAPI from "../../core/api";
+import { put, del } from "../../core/ajax";
 var CORS = FauxtonAPI.addon();
 
 
@@ -72,21 +73,16 @@ CORS.ConfigModel = Backbone.Model.extend({
   isNew: function () { return false; },
 
   sync: function (method, model, options) {
-
-    var params = {
+    const opts = {
       url: model.url(),
-      contentType: 'application/json',
-      dataType: 'json',
-      data: JSON.stringify(model.get('value'))
+      data: model.get('value'),
     };
 
     if (method === 'delete') {
-      params.type = 'DELETE';
-    } else {
-      params.type = 'PUT';
+      return del(opts);
     }
 
-    return $.ajax(params);
+    return put(opts);
   }
 
 });

--- a/app/addons/documents/components/actions.js
+++ b/app/addons/documents/components/actions.js
@@ -11,21 +11,20 @@
 // the License.
 import $ from 'jquery';
 import FauxtonAPI from "../../../core/api";
+import { get } from "../../../core/ajax";
 
 export default {
-  fetchAllDocsWithKey: (database) => {
-      return (id, callback) => {
+  fetchAllDocsWithKey(database) {
+    return (id, callback) => {
       const query = '?' + $.param({
         startkey: JSON.stringify(id),
         endkey: JSON.stringify(id + "\u9999"),
         limit: 100
       });
 
-      const url = FauxtonAPI.urls('allDocs', 'server', database.safeID(), query);
-      $.ajax({
+      get({
         cache: false,
-        url: url,
-        dataType: 'json'
+        url: FauxtonAPI.urls('allDocs', 'server', database.safeID(), query),
       }).then(({rows}) => {
         const options = rows.map(row => {
           return { value: row.id, label: row.id};
@@ -35,5 +34,5 @@ export default {
         });
       });
     };
-  }
+  },
 };

--- a/app/addons/documents/doc-editor/actions.js
+++ b/app/addons/documents/doc-editor/actions.js
@@ -14,6 +14,7 @@
 
 import app from "../../../app";
 import FauxtonAPI from "../../../core/api";
+import { del } from "../../../core/ajax";
 import ActionTypes from "./actiontypes";
 
 var xhr;
@@ -83,27 +84,23 @@ function deleteDoc (doc) {
   var databaseName = doc.database.safeID();
   var query = '?rev=' + doc.get('_rev');
 
-  $.ajax({
+  del({
     url: FauxtonAPI.urls('document', 'server', databaseName, doc.safeID(), query),
-    type: 'DELETE',
-    contentType: 'application/json; charset=UTF-8',
     xhrFields: {
       withCredentials: true
     },
-    success: function () {
-      FauxtonAPI.addNotification({
-        msg: 'Your document has been successfully deleted.',
-        clear: true
-      });
-      FauxtonAPI.navigate(FauxtonAPI.urls('allDocs', 'app', databaseName, ''));
-    },
-    error: function (resp) {
-      FauxtonAPI.addNotification({
-        msg: 'Failed to delete your document!',
-        type: 'error',
-        clear: true
-      });
-    }
+  }).then(() => {
+    FauxtonAPI.addNotification({
+      msg: 'Your document has been successfully deleted.',
+      clear: true
+    });
+    FauxtonAPI.navigate(FauxtonAPI.urls('allDocs', 'app', databaseName, ''));
+  }, (resp) => {
+    FauxtonAPI.addNotification({
+      msg: 'Failed to delete your document!',
+      type: 'error',
+      clear: true
+    });
   });
 }
 

--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -12,6 +12,7 @@
 
 import app from "../../app";
 import FauxtonAPI from "../../core/api";
+import { get, put, post, del } from "../../core/ajax";
 import Documents from "./shared-resources";
 import PagingCollection from "../../../assets/js/plugins/cloudant.pagingcollection";
 
@@ -256,19 +257,16 @@ Documents.MangoDocumentCollection = PagingCollection.extend({
               promise = FauxtonAPI.Deferred(),
               query = this.getPaginatedQuery();
 
-    $.ajax({
-      type: 'POST',
+    post({
       url: url,
-      contentType: 'application/json',
-      dataType: 'json',
-      data: JSON.stringify(query),
+      data: query,
     })
-    .then(function (res) {
+    .then((res) => {
       this.handleResponse(res, promise);
-    }.bind(this))
-    .fail(function (res) {
+    })
+    .fail((res) => {
       promise.reject(res.responseJSON);
-    }.bind(this));
+    });
 
     return promise;
   },
@@ -361,17 +359,13 @@ Documents.BulkDeleteDocCollection = FauxtonAPI.Collection.extend({
         promise = FauxtonAPI.Deferred(),
         that = this;
 
-    $.ajax({
-      type: 'POST',
+    post({
       url: this.url(),
-      contentType: 'application/json',
-      dataType: 'json',
-      data: JSON.stringify(payload),
+      data: payload,
     })
     .then(function (res) {
       that.handleResponse(res, promise);
-    })
-    .fail(function () {
+    }, function () {
       var ids = _.reduce(that.toArray(), function (acc, doc) {
         acc.push(doc.id);
         return acc;

--- a/app/addons/documents/rev-browser/rev-browser.actions.js
+++ b/app/addons/documents/rev-browser/rev-browser.actions.js
@@ -14,6 +14,7 @@
 
 import app from "../../../app";
 import FauxtonAPI from "../../../core/api";
+import { post } from "../../../core/ajax";
 import ActionTypes from "./rev-browser.actiontypes";
 import getTree from "visualizeRevTree/lib/getTree";
 import PouchDB from "pouchdb";
@@ -115,26 +116,22 @@ function selectRevAsWinner (databaseName, docId, paths, revToWin) {
   const revsToDelete = getConflictingRevs(paths, revToWin, []);
   const payload = buildBulkDeletePayload(docId, revsToDelete);
 
-  $.ajax({
+  post({
     url: FauxtonAPI.urls('bulk_docs', 'server', databaseName, ''),
-    type: 'POST',
-    contentType: 'application/json; charset=UTF-8',
-    data: JSON.stringify(payload),
-    success: () => {
-      FauxtonAPI.addNotification({
-        msg: 'Conflicts successfully solved.',
-        clear: true
-      });
-      showConfirmModal(false, null);
-      FauxtonAPI.navigate(FauxtonAPI.urls('allDocs', 'app', databaseName, ''));
-    },
-    error: (resp) => {
-      FauxtonAPI.addNotification({
-        msg: 'Failed to delete clean up conflicts!',
-        type: 'error',
-        clear: true
-      });
-    }
+    data: payload,
+  }).then(() => {
+    FauxtonAPI.addNotification({
+      msg: 'Conflicts successfully solved.',
+      clear: true
+    });
+    showConfirmModal(false, null);
+    FauxtonAPI.navigate(FauxtonAPI.urls('allDocs', 'app', databaseName, ''));
+  }, (resp) => {
+    FauxtonAPI.addNotification({
+      msg: 'Failed to delete clean up conflicts!',
+      type: 'error',
+      clear: true
+    });
   });
 }
 

--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -12,6 +12,7 @@
 
 import app from "../../app";
 import FauxtonAPI from "../../core/api";
+import { del, copy } from "../../core/ajax";
 import PagingCollection from "../../../assets/js/plugins/cloudant.pagingcollection";
 
 // defined here because this is contains the base resources used throughout the addon and outside,
@@ -145,10 +146,8 @@ Documents.Doc = FauxtonAPI.Model.extend({
 
   destroy: function () {
     var url = this.url() + "?rev=" + this.get('_rev');
-    return $.ajax({
-      url: url,
-      dataType: 'json',
-      type: 'DELETE'
+    return del({
+      url,
     });
   },
 
@@ -178,8 +177,7 @@ Documents.Doc = FauxtonAPI.Model.extend({
   },
 
   copy: function (copyId) {
-    return $.ajax({
-      type: 'COPY',
+    return copy({
       url: '/' + this.database.safeID() + '/' + this.safeID(),
       headers: {Destination: copyId}
     });

--- a/app/addons/setup/setup.actions.js
+++ b/app/addons/setup/setup.actions.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import FauxtonAPI from "../../core/api";
+import { post } from "../../core/ajax";
 import ConfigResources from "../config/resources";
 import SetupResources from "./resources";
 import ActionTypes from "./setup.actiontypes";
@@ -34,17 +35,12 @@ export default {
   },
 
   finishClusterSetup: function (message) {
-
-    $.ajax({
-      type: 'POST',
+    post({
       url: '/_cluster_setup',
-      contentType: 'application/json',
-      dataType: 'json',
-      data: JSON.stringify({
+      data: {
         action: 'finish_cluster'
-      })
-    })
-    .success(function (res) {
+      },
+    }).then((res) => {
       FauxtonAPI.addNotification({
         msg: message,
         type: 'success',
@@ -52,8 +48,7 @@ export default {
         clear: true
       });
       FauxtonAPI.navigate('#setup/finish');
-    })
-    .fail(function () {
+    }, () => {
       FauxtonAPI.addNotification({
         msg: 'There was an error. Please check your setup and try again.',
         type: 'error',

--- a/app/addons/verifyinstall/resources.js
+++ b/app/addons/verifyinstall/resources.js
@@ -12,6 +12,7 @@
 
 import app from "../../app";
 import FauxtonAPI from "../../core/api";
+import { get } from "../../core/ajax";
 import Databases from "../databases/resources";
 import Documents from "../documents/resources";
 var Verifyinstall = FauxtonAPI.addon();
@@ -117,17 +118,14 @@ Verifyinstall.testProcess = {
   },
 
   setupReplicate: function () {
-    return $.ajax({
+    return post({
       url: app.host + '/_replicate',
-      contentType: 'application/json',
-      type: 'POST',
-      dataType: 'json',
       processData: false,
-      data: JSON.stringify({
+      data: {
         create_target: true,
         source: 'verifytestdb',
         target: 'verifytestdb_replicate'
-      })
+      }
     });
   },
 

--- a/app/app.js
+++ b/app/app.js
@@ -18,6 +18,7 @@ import Bootstrap from "bootstrap";
 import Helpers from "./helpers";
 import Utils from "./core/utils";
 import FauxtonAPI from "./core/api";
+import { get } from "./core/ajax";
 import Couchdb from "./core/couchdbSession";
 import "backbone.layoutmanager";
 import "../assets/less/fauxton.less";
@@ -77,7 +78,7 @@ FauxtonAPI.Layout.configure({
       // Put fetch into `async-mode`.
       done = this.async();
       // Seek out the template asynchronously.
-      return $.ajax({ url: app.root + path }).then(function (contents) {
+      return get({ url: app.root + path }).then(function (contents) {
         done(JST[path] = _.template(contents));
       });
     }

--- a/app/core/ajax.js
+++ b/app/core/ajax.js
@@ -1,0 +1,188 @@
+import $ from 'jquery';
+
+export const buildQuery = (query) => (
+  `?${Object.keys(query).reduce((items, item) => (
+    query[item] ? [...items, `${item}=${encodeURIComponent(query[item])}`] : items
+  ), []).join('&')}`
+);
+
+export const url = (path, query) => (
+  `${path}${!emptyObject(query) ? buildQuery(query) : ''}`
+);
+
+const emptyObject = (object) => (
+  Object.keys(object || {}).length == 0
+);
+
+//  ----------------------------------------
+//  makes a GET request to the provided path
+//  arguments: (options, query)
+//  options: {
+//    path: '/foo', // the location you want to send the request to
+//  }
+//  Any optional query paramaters you want to pass
+//  query: {}
+//  for example
+//  query: {
+//    page: 1,
+//    term: 'foo',
+//  }
+//  will generate
+//  /${path}?page=1&term=foo
+export const request = (options, query) => (
+  $.ajax(Object.assign(
+    emptyObject(options.data)
+      ? options
+      : Object.assign(options, {
+          contentType: 'application/json; charset=UTF-8',
+          dataType: 'json',
+          data: JSON.stringify(options.data),
+        }), {
+    url: url(options.url, query),
+  }))
+);
+
+//  ----------------------------------------
+//  makes a GET request to the provided path
+//  arguments: (options, query)
+//  options: {
+//    path: '/foo', // the location you want to send the request to
+//  }
+//  Any optional query paramaters you want to pass
+//  query: {}
+//  for example
+//  query: {
+//    page: 1,
+//    term: 'foo',
+//  }
+//  will generate
+//  /${path}?page=1&term=foo
+export const get = (options, query = {}) => (
+  request(Object.assign({
+    path: '/',
+    type: 'GET',
+  }, options), query)
+);
+
+//  ----------------------------------------
+//  makes a PUT request to the provided path
+//  arguments: (options, query)
+//  options: {
+//    path: '/foo', // the location you want to send the request to
+//    data: {}, // the body of the request
+//  }
+//  Any optional query paramaters you want to pass
+//  query: {}
+//  for example
+//  query: {
+//    page: 1,
+//    term: 'foo',
+//  }
+//  will generate
+//  /${path}?page=1&term=foo
+export const put = (options, query = {}) => (
+  request(Object.assign({
+    path: '/',
+    type: 'PUT',
+  }, options), query)
+);
+
+//  ----------------------------------------
+//  makes a POST request to the provided path
+//  arguments: (options, query)
+//  options: {
+//    path: '/foo', // the location you want to send the request to
+//    data: {}, // the body of the request
+//  }
+//  Any optional query paramaters you want to pass
+//  query: {}
+//  for example
+//  query: {
+//    page: 1,
+//    term: 'foo',
+//  }
+//  will generate
+//  /${path}?page=1&term=foo
+export const post = (options, query = {}) => (
+  request(Object.assign({
+    path: '/',
+    type: 'POST',
+  }, options), query)
+);
+
+//  ----------------------------------------
+//  makes a DELETE request to the provided path
+//  arguments: (options, query)
+//  options: {
+//    path: '/foo', // the location you want to send the request to
+//    data: {}, // the body of the request
+//  }
+//  Any optional query paramaters you want to pass
+//  query: {}
+//  for example
+//  query: {
+//    page: 1,
+//    term: 'foo',
+//  }
+//  will generate
+//  /${path}?page=1&term=foo
+export const del = (options, query = {}) => (
+  request(Object.assign({
+    path: '/',
+    type: 'DELETE',
+  }, options), query)
+);
+
+//  ----------------------------------------
+//  makes a COPY request to the provided path
+//  arguments: (options, query)
+//  options: {
+//    path: '/foo', // the location you want to send the request to
+//    data: {}, // the body of the request
+//  }
+//  Any optional query paramaters you want to pass
+//  query: {}
+//  for example
+//  query: {
+//    page: 1,
+//    term: 'foo',
+//  }
+//  will generate
+//  /${path}?page=1&term=foo
+export const copy = (options, query = {}) => (
+  request(Object.assign({
+    path: '/',
+    type: 'COPY',
+  }, options), query)
+);
+
+//  ----------------------------------------
+//  makes a OPTIONS request to the provided path
+//  arguments: (options, query)
+//  options: {
+//    path: '/foo', // the location you want to send the request to
+//  }
+//  Any optional query paramaters you want to pass
+//  query: {}
+//  for example
+//  query: {
+//    page: 1,
+//    term: 'foo',
+//  }
+//  will generate
+//  /${path}?page=1&term=foo
+export const options = (opts, query = {}) => (
+  request(Object.assign({
+    path: '/',
+    type: 'OPTIONS',
+  }, opts), query)
+);
+
+export default {
+  get,
+  put,
+  post,
+  copy,
+  del,
+  options,
+};


### PR DESCRIPTION
The api for the ajax module is as follows

```
import { get, post } from 'core/ajax';

// GET: /some_enpoint?page=1&order=name
get({
 path: '/some_enpoint',
}, {
 page: 1,
 order: 'name',
}).then((response) => {
 // do stuff
}, (err) => {
 // something broke
}); 

// POST: /some_enpoint
         body={ foo: 'bar' }
post({
 path: '/some_enpoint',
 data: { foo: 'bar' },
}).then((response) => {
 // do stuff
}, (err) => {
 // something broke
}); 
```
