### PR TITLE
Show unreachable docs in jump to docs

### DIFF
--- a/app/addons/documents/assets/less/jumptodoc.less
+++ b/app/addons/documents/assets/less/jumptodoc.less
@@ -35,5 +35,4 @@
   min-width: 210px;
   max-width: 450px;
   width: auto;
-  overflow: hidden; /* for 450px max widths, enough is visible not to require scrolling */
 }

--- a/app/addons/documents/components/actions.js
+++ b/app/addons/documents/components/actions.js
@@ -18,7 +18,7 @@ export default {
       const query = '?' + $.param({
         startkey: JSON.stringify(id),
         endkey: JSON.stringify(id + "\u9999"),
-        limit: 100
+        limit: 30
       });
 
       const url = FauxtonAPI.urls('allDocs', 'server', database.safeID(), query);


### PR DESCRIPTION
This fixes the issues where some docs were not reachable in the scrollable list.