### PR TITLE
set jump-to-docs to be case sensitive

### DIFF
--- a/app/addons/documents/components/jumptodoc.react.jsx
+++ b/app/addons/documents/components/jumptodoc.react.jsx
@@ -25,6 +25,7 @@ const JumpToDoc = ({database, loadOptions}) => {
         placeholder="Document ID"
         loadOptions={loadOptions}
         clearable={false}
+        ignoreCase={false}
         onChange={({value: docId}) => {
           const url = FauxtonAPI.urls('document', 'app', app.utils.safeURLName(database.id), app.utils.safeURLName(docId));
           // We navigating away from the page. So we need to take that navigation out of the loop otherwise

--- a/app/addons/documents/tests/nightwatch/selectDocViaTypeahead.js
+++ b/app/addons/documents/tests/nightwatch/selectDocViaTypeahead.js
@@ -35,5 +35,29 @@ module.exports = {
       .keys(['\uE015', '\uE015', '\uE006'])
       .waitForElementPresent('.panel-button.upload', waitTime, false)
     .end();
+  },
+
+  'Select doc works for capitalised id': function (client) {
+    var waitTime = client.globals.maxWaitTime,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .populateDatabase(newDatabaseName, 3)
+      .createDocument('MY_CAP_DOC_ID', newDatabaseName, {value: 1, value: 2})
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .waitForElementPresent('.jump-to-doc', waitTime, false)
+      .keys(['\uE00C'])
+      .waitForElementPresent('.prettyprint', waitTime, false)
+      .waitForElementPresent('.documents-pagination', waitTime, false)
+      .click('.burger')
+
+      // we need to explicitly show the doc field because it's hidden on Travis due to screen width
+      .execute("$('.searchbox-wrapper').show();")
+      .setValue('.jump-to-doc .Select-input input', ['MY_CAP'])
+      .keys(['\uE015', '\uE015', '\uE006'])
+      .waitForElementPresent('.panel-button.upload', waitTime, false)
+    .end();
   }
 };


### PR DESCRIPTION
Previously you could not search for a document with capitals in it e.g `MY_DOCUMENT`. This sets React-select to be case sensitive