### PR TITLE
Clean up version data css in nav footer

### DIFF
--- a/app/addons/fauxton/navigation/components.react.jsx
+++ b/app/addons/fauxton/navigation/components.react.jsx
@@ -24,10 +24,9 @@ const Footer = React.createClass({
     if (!version) { return null; }
     return (
       <div className="version-footer">
-        Fauxton on
-        <a href="http://couchdb.apache.org/"> Apache CouchDB</a>
-        <br/>
-        v. {version}
+        Fauxton on {" "}
+        <a href="http://couchdb.apache.org/">Apache CouchDB</a>
+        {" "} v. {version}
       </div>
     );
   }

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -67,7 +67,8 @@
   .version-footer {
     color: #fff;
     font-size: 10px;
-    padding-left: 10px;
+    text-align: center;
+    background-color: @brown;
   }
   .closeMenu & {
     .version-footer {
@@ -104,7 +105,7 @@
     }
     .bottom-container {
       position: fixed;
-      bottom: 0;
+      bottom: 10px;
       .brand {
         .box-sizing(content-box);
         .hide-text;
@@ -116,7 +117,7 @@
         background: #3a2c2b;
         .icon {
           .box-sizing(content-box);
-          background: url(../img/CouchDB-negative-logo.png) no-repeat 28px 0px;
+          background: url(../img/CouchDB-negative-logo.png) no-repeat 23px 0px;
           background-size: 150px;
           display: block;
           height: 100%;
@@ -137,18 +138,20 @@
       #footer-nav-links {
         width: 100%;
         margin: 0;
-        background: #3a2c2b;
-        li {
-          a {
-            font-size: 12px;
-            color: @linkColor;
-            padding: 0px 0px 15px 85px;
-            text-shadow: none;
+        background: @brown;
 
-            .closeMenu & {
-              padding: 0px 0px 15px 15px;
-            }
+        li {
+          width: 100%;
+          text-align: center;
+
+          a {
+            font-size: 10px;
+            color: @linkColor;
+            padding: 0px;
+            text-shadow: none;
+            width: 100%;
           }
+
           &.active, &:hover {
             a {
               text-decoration: underline;


### PR DESCRIPTION
This changes the CSS for the version data info in the nav bar.

I couldn't see the version data in dev mode with v.1.6.1, so
to view otherwise, run:  `$ npm run test-before-publish` then, `$ fauxton`
