### PR TITLE
Fix CSS at bottom of expanded menu bar when v-scroll appears

### DIFF
--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -59,6 +59,7 @@
   bottom: 0;
   position: absolute;
   width: @navWidth;
+  overflow-x: hidden;
   .closeMenu & {
     width: @collapsedNavWidth;
     overflow-x: hidden;
@@ -105,7 +106,9 @@
     }
     .bottom-container {
       position: fixed;
-      bottom: 10px;
+      bottom: 0px;
+      background-color: @brown;
+      padding-bottom: 5px;
       .brand {
         .box-sizing(content-box);
         .hide-text;


### PR DESCRIPTION
Separate Question: How come the version info doesn't show up anymore?
I see: 
![screen shot 2016-09-09 at 12 23 38 am](https://cloud.githubusercontent.com/assets/836039/18375408/ef677c3c-7623-11e6-8064-e2a32c34867e.png)
in both 1.6 and 2.0, i can re-add it if it still shows up sometimes, but if we decided to not show it anymore, i'll like to change the css with that in mind
