### PR TITLE
remove sourcemaps in webpack

### DIFF
--- a/webpack.config.release.js
+++ b/webpack.config.release.js
@@ -93,6 +93,5 @@ module.exports = {
       "underscore": "lodash",
       "bootstrap": "../assets/js/libs/bootstrap",
     }
-  },
-  devtool: 'source-map',
+  }
 };


### PR DESCRIPTION
We don't use this functionality so its just creating an unnecessary request.