### PR TITLE
remove update sequence from db list

### DIFF
--- a/app/addons/databases/components.react.jsx
+++ b/app/addons/databases/components.react.jsx
@@ -119,7 +119,6 @@ var DatabaseTable = React.createClass({
               <th>Name</th>
               <th>Size</th>
               <th># of Docs</th>
-              <th>Update Seq</th>
               {this.getExtensionColumns()}
               <th>Actions</th>
             </tr>
@@ -186,7 +185,6 @@ var DatabaseRow = React.createClass({
         </td>
         <td>{size}</td>
         <td>{row.status.numDocs()} {this.renderGraveyard(row)}</td>
-        <td>{row.status.updateSeq()}</td>
         {this.getExtensionColumns(row)}
         <td className="database-actions">
           <a className="db-actions btn fonticon-replicate set-replication-start"

--- a/app/addons/databases/resources.js
+++ b/app/addons/databases/resources.js
@@ -131,17 +131,6 @@ Databases.Status = FauxtonAPI.Model.extend({
     return this.numDeletedDocs() > this.numDocs();
   },
 
-  updateSeq: function (full) {
-    var updateSeq = this.get("update_seq");
-    if (full || (typeof(updateSeq) === 'number')) {
-      return updateSeq;
-    } else if (updateSeq) {
-      return updateSeq[0];
-    } else {
-      return 0;
-    }
-  },
-
   dataSize: function () {
     if (this.get("other")) {
       return this.get("other").data_size;

--- a/app/addons/databases/tests/componentsSpec.react.jsx
+++ b/app/addons/databases/tests/componentsSpec.react.jsx
@@ -19,6 +19,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import TestUtils from "react-addons-test-utils";
 import sinon from "sinon";
+import { mount } from 'enzyme';
 
 var assert = utils.assert;
 
@@ -49,9 +50,6 @@ describe('DatabasesController', function () {
             },
             "isGraveYard": function () {
               return false;
-            },
-            "updateSeq": function () {
-              return 99;
             }
           }
         },
@@ -76,9 +74,6 @@ describe('DatabasesController', function () {
             },
             "isGraveYard": function () {
               return true;
-            },
-            "updateSeq": function () {
-              return 399;
             }
           }
         }
@@ -102,7 +97,6 @@ describe('DatabasesController', function () {
     assert.equal("2.0 MB", el.getElementsByTagName('tr')[1].getElementsByTagName('td')[1].innerText.trim());
     assert.equal("88", el.getElementsByTagName('tr')[1].getElementsByTagName('td')[2].innerText.trim());
     assert.equal(0, el.getElementsByTagName('tr')[1].getElementsByTagName('td')[2].getElementsByTagName("i").length);
-    assert.equal(3, el.getElementsByTagName('tr')[1].getElementsByTagName('td')[4].getElementsByTagName("a").length);
     assert.equal("db2", el.getElementsByTagName('tr')[2].getElementsByTagName('td')[0].innerText.trim());
     assert.equal(1, el.getElementsByTagName('tr')[2].getElementsByTagName('td')[2].getElementsByTagName("i").length);
   });
@@ -189,8 +183,8 @@ describe('DatabaseTable', function () {
     );
     var cols = $(ReactDOM.findDOMNode(table)).find('th');
 
-    // (default # of rows is 5)
-    assert.equal(cols.length, 8, 'extra columns show up');
+    // (default # of rows is 4)
+    assert.equal(cols.length, 7, 'extra columns show up');
 
     FauxtonAPI.unRegisterExtension('DatabaseTable:head');
   });
@@ -207,7 +201,6 @@ describe('DatabaseTable', function () {
       loadSuccess: true,
       dataSize: function () { return 0; },
       numDocs: function () { return 0; },
-      updateSeq: function () { return 0; },
       isGraveYard: function () { return false; }
     };
 
@@ -217,8 +210,8 @@ describe('DatabaseTable', function () {
     );
     var links = $(ReactDOM.findDOMNode(databaseRow)).find('td');
 
-    // (default # of rows is 5)
-    assert.equal(links.length, 6, 'extra column shows up');
+    // (default # of rows is 4)
+    assert.equal(links.length, 5, 'extra column shows up');
 
     FauxtonAPI.unRegisterExtension('DatabaseTable:databaseRow');
 
@@ -231,7 +224,6 @@ describe('DatabaseTable', function () {
       loadSuccess: false,
       dataSize: function () { return 0; },
       numDocs: function () { return 0; },
-      updateSeq: function () { return 0; },
       isGraveYard: function () { return false; }
     };
 
@@ -248,7 +240,6 @@ describe('DatabaseTable', function () {
       loadSuccess: true,
       dataSize: function () { return 0; },
       numDocs: function () { return 0; },
-      updateSeq: function () { return 0; },
       isGraveYard: function () { return false; }
     };
 

--- a/app/addons/documents/index-results/stores.js
+++ b/app/addons/documents/index-results/stores.js
@@ -172,12 +172,6 @@ Stores.IndexResultsStore = FauxtonAPI.Store.extend({
     return this._pageStart + this._collection.length - 1;
   },
 
-  getUpdateSeq: function () {
-    if (!this._collection) { return false; }
-    if (!this._collection.updateSeq) { return false; }
-    return this._collection.updateSeq();
-  },
-
   clearSelectedItems: function () {
     this._bulkDeleteDocCollection.reset([]);
   },


### PR DESCRIPTION
right now the update sequence display is broken. they also make
no sense in a clustered setup.

this patch removes them test-wise. we can readd them if there is
a lot demand for seeing them, but as we got no bug reports in
almost 2 years it seems it is a dead feature.