### PR TITLE
Fix design doc with include_docs

### DIFF
--- a/app/addons/documents/queryoptions/stores.js
+++ b/app/addons/documents/queryoptions/stores.js
@@ -58,7 +58,7 @@ Stores.QueryOptionsStore = FauxtonAPI.Store.extend({
     this._isVisible = true;
   },
 
-  setTrayVisible: function (trayVisible) {
+  setTrayVisible (trayVisible) {
     this._trayVisible = trayVisible;
   },
 
@@ -78,11 +78,11 @@ Stores.QueryOptionsStore = FauxtonAPI.Store.extend({
     return this._betweenKeys;
   },
 
-  updateBetweenKeys: function (newBetweenKeys) {
+  updateBetweenKeys (newBetweenKeys) {
     this._betweenKeys = newBetweenKeys;
   },
 
-  updateSkip: function (skip) {
+  updateSkip (skip) {
     this._skip = skip;
   },
 
@@ -94,7 +94,7 @@ Stores.QueryOptionsStore = FauxtonAPI.Store.extend({
     return this._limit;
   },
 
-  updateLimit: function (limit) {
+  updateLimit (limit) {
     this._limit = limit;
   },
 
@@ -102,7 +102,7 @@ Stores.QueryOptionsStore = FauxtonAPI.Store.extend({
     return this._byKeys;
   },
 
-  updateByKeys: function (keys) {
+  updateByKeys (keys) {
     this._byKeys = keys;
   },
 
@@ -142,12 +142,26 @@ Stores.QueryOptionsStore = FauxtonAPI.Store.extend({
     return this._showBetweenKeys;
   },
 
-  updateGroupLevel: function (groupLevel) {
+  updateGroupLevel (groupLevel) {
     this._groupLevel = groupLevel;
   },
 
-  setQueryParams: function (params) {
+  sanitize (params) {
+    if (params.startkey) {
+      params.start_key = params.startkey;
+      delete params.startkey;
+    }
+
+    if (params.endkey) {
+      params.end_key = params.endkey;
+      delete params.endkey;
+    }
+
+  },
+
+  setQueryParams (params) {
     this.reset();
+    this.sanitize(params);
     if (params.include_docs) {
       this._includeDocs = true;
     }
@@ -243,7 +257,7 @@ Stores.QueryOptionsStore = FauxtonAPI.Store.extend({
     return this._includeDocs;
   },
 
-  dispatch: function (action) {
+  dispatch (action) {
     switch (action.type) {
       case ActionTypes.QUERY_RESET:
         this.setQueryParams(action.params);

--- a/app/addons/documents/queryoptions/tests/queryoptions.storesSpec.js
+++ b/app/addons/documents/queryoptions/tests/queryoptions.storesSpec.js
@@ -19,38 +19,38 @@ var dispatchToken;
 var store;
 var opts;
 
-describe('QueryOptions Store', function () {
-  beforeEach(function () {
+describe('QueryOptions Store', () => {
+  beforeEach(() => {
     store = new Stores.QueryOptionsStore();
     dispatchToken = FauxtonAPI.dispatcher.register(store.dispatch);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     FauxtonAPI.dispatcher.unregister(dispatchToken);
   });
 
-  describe('Toggle By Keys and Between Keys', function () {
+  describe('Toggle By Keys and Between Keys', () => {
 
-    it('toggling by keys sets by keys to true', function () {
+    it('toggling by keys sets by keys to true', () => {
 
       store.toggleByKeys();
 
       assert.ok(store.showByKeys());
     });
 
-    it('toggling between keys sets between keys to true', function () {
+    it('toggling between keys sets between keys to true', () => {
 
       store.toggleBetweenKeys();
       assert.ok(store.showBetweenKeys());
     });
 
-    it('toggling between keys sets by keys to false', function () {
+    it('toggling between keys sets by keys to false', () => {
       store._showByKeys = true;
       store.toggleBetweenKeys();
       assert.notOk(store.showByKeys());
     });
 
-    it('toggling by keys sets between keys to false', function () {
+    it('toggling by keys sets between keys to false', () => {
       store._showBetweenKeys = true;
       store.toggleByKeys();
       assert.notOk(store.showBetweenKeys());
@@ -58,12 +58,12 @@ describe('QueryOptions Store', function () {
 
   });
 
-  describe('getQueryParams', function () {
-    it('returns params for default', function () {
+  describe('getQueryParams', () => {
+    it('returns params for default', () => {
       assert.deepEqual(store.getQueryParams(), {});
     });
 
-    it('with betweenKeys', function () {
+    it('with betweenKeys', () => {
       store.toggleBetweenKeys();
       store.updateBetweenKeys({
         startkey:"a",
@@ -78,7 +78,7 @@ describe('QueryOptions Store', function () {
       });
     });
 
-    it('with byKeys', function () {
+    it('with byKeys', () => {
       store.toggleByKeys();
       store.updateByKeys("[1,2,3]");
 
@@ -88,9 +88,9 @@ describe('QueryOptions Store', function () {
     });
   });
 
-  describe('setQueryParams', function () {
+  describe('setQueryParams', () => {
 
-    it('sets all store values from given params', function () {
+    it('sets all store values from given params', () => {
 
       store.setQueryParams({
         include_docs: true,
@@ -105,7 +105,7 @@ describe('QueryOptions Store', function () {
       assert.equal(store.skip(), 5);
     });
 
-    it('sets between keys', function () {
+    it('sets between keys', () => {
       store.setQueryParams({
         start_key: 1,
         end_key: 5
@@ -117,13 +117,24 @@ describe('QueryOptions Store', function () {
       assert.ok(store.showBetweenKeys());
     });
 
-    it('sets by keys', function () {
+    it('sets by keys', () => {
       store.setQueryParams({
         keys: [1, 2, 3]
       });
 
       assert.deepEqual(store.byKeys(), [1, 2, 3]);
       assert.ok(store.showByKeys());
+    });
+
+    it('works with startkey and endkey', () => {
+      store.setQueryParams({
+        startkey: 1,
+        endkey: 5
+      });
+
+      assert.equal(store.betweenKeys().startkey, 1);
+      assert.equal(store.betweenKeys().endkey, 5);
+      assert.ok(store.showBetweenKeys());
     });
 
   });


### PR DESCRIPTION
This fixes the issue that if you are viewing the design docs for a
database and then click on the query options and click include_docs and
then run query it would stop showing the design docs.