### PR TITLE
views: remove fauxton side check for js warnings / errors

### DIFF
--- a/app/addons/documents/index-editor/actions.js
+++ b/app/addons/documents/index-editor/actions.js
@@ -90,6 +90,12 @@ function saveView (viewInfo) {
     FauxtonAPI.dispatch({ type: ActionTypes.VIEW_SAVED });
     var fragment = FauxtonAPI.urls('view', 'showView', viewInfo.database.safeID(), designDoc.safeID(), app.utils.safeURLName(viewInfo.viewName));
     FauxtonAPI.navigate(fragment, { trigger: true });
+  }, (xhr) => {
+    FauxtonAPI.addNotification({
+      msg: `${xhr.responseJSON.reason}`,
+      type: 'error',
+      clear: true
+    });
   });
 }
 

--- a/app/addons/documents/index-editor/components.react.jsx
+++ b/app/addons/documents/index-editor/components.react.jsx
@@ -271,25 +271,10 @@ var EditorController = React.createClass({
     }
   },
 
-  hasErrors: function () {
-    var mapEditorErrors = this.refs.mapEditor.getEditor().hasErrors();
-    var customReduceErrors = (store.hasCustomReduce()) ? this.refs.reduceEditor.getEditor().hasErrors() : false;
-    return mapEditorErrors || customReduceErrors;
-  },
-
   saveView: function (e) {
     e.preventDefault();
 
     if (!this.refs.designDocSelector.validate()) {
-      return;
-    }
-
-    if (this.hasErrors()) {
-      FauxtonAPI.addNotification({
-        msg: 'Please fix the Javascript errors and try again.',
-        type: 'error',
-        clear: true
-      });
       return;
     }
 

--- a/app/addons/documents/index-editor/tests/viewIndex.componentsSpec.react.jsx
+++ b/app/addons/documents/index-editor/tests/viewIndex.componentsSpec.react.jsx
@@ -259,24 +259,6 @@ describe('Editor', function () {
     sandbox.restore();
   });
 
-  it('returns false on invalid map editor code', function () {
-    var stub = sandbox.stub(editorEl.refs.mapEditor.getEditor(), 'hasErrors');
-    stub.returns(false);
-    assert.notOk(editorEl.hasErrors());
-  });
-
-  it('returns true on valid map editor code', function () {
-    var stub = sandbox.stub(editorEl.refs.mapEditor.getEditor(), 'hasErrors');
-    stub.returns(true);
-    assert.ok(editorEl.hasErrors());
-  });
-
-  it('returns false on non-custom reduce', function () {
-    var stub = sandbox.stub(Stores.indexEditorStore, 'hasCustomReduce');
-    stub.returns(false);
-    assert.notOk(editorEl.hasErrors());
-  });
-
   it('calls changeViewName on view name change', function () {
     var viewName = 'new-name';
     var spy = sandbox.spy(Actions, 'changeViewName');

--- a/app/addons/documents/tests/nightwatch/viewCreate.js
+++ b/app/addons/documents/tests/nightwatch/viewCreate.js
@@ -14,6 +14,30 @@
 
 module.exports = {
 
+  'creates design docs with js hint errors': function (client) {
+    const waitTime = client.globals.maxWaitTime;
+    const baseUrl = client.globals.test_settings.launch_url;
+
+    /*jshint multistr: true */
+    openDifferentDropdownsAndClick(client, '#header-dropdown-menu')
+      .waitForElementPresent('#new-ddoc', waitTime, false)
+      .setValue('#new-ddoc', 'test_design_doc-selenium-0')
+      .clearValue('#index-name')
+      .setValue('#index-name', 'furbie')
+      .execute('\
+        var editor = ace.edit("map-function");\
+        editor.getSession().setValue("function (doc) { if (doc != \'\') { emit(\'blerg\'); } else { emit(\'nana\'); }  }");\
+      ')
+      .execute('$("#save-view")[0].scrollIntoView();')
+      .waitForElementPresent('#save-view', waitTime, false)
+      .clickWhenVisible('#save-view', waitTime, false)
+      .checkForDocumentCreated('_design/test_design_doc-selenium-0')
+      .waitForElementPresent('.prettyprint', waitTime, false)
+      .waitForElementNotPresent('.loading-lines', waitTime, false)
+      .assert.containsText('.prettyprint', 'blerg')
+    .end();
+  },
+
   'Creates a Design Doc using the dropdown at "all documents"': function (client) {
     var waitTime = client.globals.maxWaitTime;
     var baseUrl = client.globals.test_settings.launch_url;


### PR DESCRIPTION
these should be checked in one single place, the database.

this way we don't have to maintain two separate whitelists for
errors.