### PR TITLE
Fix database name escaping

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -68,7 +68,9 @@ var utils = {
 
   safeURLName: function (name) {
     var testName = name || "";
-    var checkforBad = testName.match(/[\$\-/,+-]/g);
+    // These special caracters are allowed by couch: _, $, (, ), +, -, and /
+    // From them only $ + and / are to be escaped in a URI component.
+    var checkforBad = testName.match(/[$+/]/g);
     return (checkforBad !== null) ? encodeURIComponent(name) : name;
   },
 


### PR DESCRIPTION
When having a database with the character `-` in addition with a URI escaped character `$ `, `+` or `/`, the name was URI escaped twice and the fetch of the database resources could not succeed.

For instance:

```js
safeURLName(safeURLName("foo-bar/baz")) // foo-bar%252Fbaz (should be foo-bar%2Fbaz)
safeURLName(safeURLName("foo-bar+baz")) // foo-bar%252Bbaz (should be foo-bar%2Bbaz)
```

This PR makes `utils.safeURLName` indempotent to fix this issue.
Also the code was testing for the character `,` which is not allowed by couch, I removed it form the regex.