### PR TITLE
react-select: disable cache

### DIFF
--- a/app/addons/databases/components.react.jsx
+++ b/app/addons/databases/components.react.jsx
@@ -222,9 +222,7 @@ var GraveyardInfo = React.createClass({
 const RightDatabasesHeader = () => {
   return (
     <div className="header-right right-db-header flex-layout flex-row">
-      <JumpToDatabaseWidget
-        loadOptions={Actions.fetchAllDbsWithKey}
-      />
+      <JumpToDatabaseWidget loadOptions={Actions.fetchAllDbsWithKey} />
       <AddDatabaseWidget />
     </div>
   );

--- a/app/addons/documents/components/actions.js
+++ b/app/addons/documents/components/actions.js
@@ -14,7 +14,7 @@ import FauxtonAPI from "../../../core/api";
 
 export default {
   fetchAllDocsWithKey: (database) => {
-      return (id, callback) => {
+    return (id, callback) => {
       const query = '?' + $.param({
         startkey: JSON.stringify(id),
         endkey: JSON.stringify(id + "\u9999"),

--- a/app/addons/documents/components/header-docs-right.jsx
+++ b/app/addons/documents/components/header-docs-right.jsx
@@ -31,7 +31,7 @@ const RightAllDocsHeader = ({database}) =>
 
     <div className="faux-header__searchboxwrapper">
       <div className="faux-header__searchboxcontainer">
-        <JumpToDoc loadOptions={Actions.fetchAllDocsWithKey(database)} database={database} />
+        <JumpToDoc cache={false} loadOptions={Actions.fetchAllDocsWithKey(database)} database={database} />
       </div>
     </div>
 

--- a/app/addons/documents/components/jumptodoc.react.jsx
+++ b/app/addons/documents/components/jumptodoc.react.jsx
@@ -26,6 +26,7 @@ const JumpToDoc = ({database, loadOptions}) => {
         loadOptions={loadOptions}
         clearable={false}
         ignoreCase={false}
+        cache={false}
         onChange={({value: docId}) => {
           const url = FauxtonAPI.urls('document', 'app', app.utils.safeURLName(database.id), app.utils.safeURLName(docId));
           // We navigating away from the page. So we need to take that navigation out of the loop otherwise

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-addons-css-transition-group": "~15.0.1",
     "react-bootstrap": "^0.28.5",
     "react-dom": "~15.0.1",
-    "react-select": "^1.0.0-beta12",
+    "react-select": "1.0.0-rc.2",
     "request": "^2.54.0",
     "semver": "^5.1.0",
     "send": "^0.13.1",


### PR DESCRIPTION
react-select caches the results which leads to database names
appearing in the list of document names after you opened the
dropdown on the _all_dbs page.