### PR TITLE
Updating hover colors for notification center to be consistent

### DIFF
--- a/assets/less/notification-center.less
+++ b/assets/less/notification-center.less
@@ -70,6 +70,9 @@ body #dashboard #notification-center-btn {
         margin: -18px -16px -14px; /* enlarges the hit area */
         font-size: 21px;
         color: #dddddd;
+        &:hover {
+          color: @hoverRed;
+        }
       }
     }
 
@@ -89,6 +92,12 @@ body #dashboard #notification-center-btn {
 
         &.selected {
           background-color: #555555;
+        }
+        &:hover {
+          background-color: @hoverRed;
+          .fonticon {
+            color: white;
+          }
         }
       }
       .fonticon {
@@ -129,6 +138,9 @@ body #dashboard #notification-center-btn {
           height: 20px;
           margin-top: -4px;
           margin-left: 6px;
+          &:hover {
+            color: @hoverRed;
+          }
         }
         p {
           margin-bottom: 0;
@@ -158,10 +170,10 @@ body #dashboard #notification-center-btn {
       .copy {
         color: @blue;
         text-decoration: none;
-        &:hover {
-          color: @red;
-          text-decoration: underline;
-        }
+      }
+      .copy.zeroclipboard-is-hover {
+        color: @hoverRed;
+        text-decoration: underline;
       }
     }
 

--- a/assets/less/variables.less
+++ b/assets/less/variables.less
@@ -26,6 +26,8 @@
 @yellow: #ffcc00;
 @pink: #c3325f;
 @purple: #7a43b6;
+@hoverOrange: #f3812d;
+@hoverRed: #e73d34;
 
 /* brand */
 @brandPrimary: @red;


### PR DESCRIPTION
Updated less files to support proper hover colors for the notification center.  Note the "copy" link is technically flash and required a custom definition (https://github.com/zeroclipboard/zeroclipboard/blob/master/docs/instructions.md#css-effects).