### PR TITLE
3045 Replace safeURLName in code

### DIFF
--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -80,8 +80,7 @@ Documents.DdocInfo = FauxtonAPI.Model.extend({
   // treated separately. For instance, we could default into the
   // json editor for docs, or into a ddoc specific page.
   safeID: function () {
-    var ddoc = this.id.replace(/^_design\//, "");
-    return "_design/" + app.utils.safeURLName(ddoc);
+    return app.utils.getSafeIdForDoc(this.id);
   }
 });
 

--- a/app/addons/documents/sidebar/stores.react.jsx
+++ b/app/addons/documents/sidebar/stores.react.jsx
@@ -194,7 +194,7 @@ Stores.SidebarStore = FauxtonAPI.Store.extend({
     });
 
     return docs.map(function (doc) {
-      doc.safeId = app.utils.safeURLName(doc._id.replace(/^_design\//, ""));
+      doc.safeId = app.utils.getSafeIdForDoc(doc._id);
       return _.extend(doc, doc.doc);
     });
   },


### PR DESCRIPTION
**Task description from ticket:**
We have a still some usages of safeURLName where we manually slice of the _design prefix for design docs. Later we glue the prefix on again. We have a helper function that handles that already, which is also available in the utils.js file.

Task: find appearances of safeURLName with code search, understand how it is used, remove custom safeURLName shenanigans with their design doc handling and replace it with other helper function. 

**Change Description**
I located two places where it made sense to update safeURLName to getSafeIdForDoc.  While there were several places we use safeURLName in Fauxton, not all of them needed to be changed.  I'm open to feedback, however, if others feel as though I missed some instances where it did make sense to update.
