### PR TITLE
Tweaked CSS for more hover consistency and UX

### DIFF
--- a/app/addons/components/assets/less/docs.less
+++ b/app/addons/components/assets/less/docs.less
@@ -54,7 +54,7 @@
           font-size: 20px;
         }
         .fonticon-pencil:hover {
-          color: @docHeaderDocId;
+          color: @hoverRed;
         }
       }
     }

--- a/app/addons/components/assets/less/tab-element.less
+++ b/app/addons/components/assets/less/tab-element.less
@@ -68,6 +68,10 @@
 
   &.tab-element-checked {
     background-color: #fff;
+    label {
+      cursor: default;
+      pointer-events: none;
+    }
   }
 
   &.tab-element-checked .tab-element-content {

--- a/app/addons/documents/assets/less/changes.less
+++ b/app/addons/documents/assets/less/changes.less
@@ -11,6 +11,7 @@
 // the License.
 
 @import "../../../../../assets/less/animations.less";
+@import "../../../../../assets/less/variables.less";
 
 // used in changes.html
 .change-box {
@@ -58,6 +59,9 @@
 
     .btn-info {
       padding: 12px;
+      &:hover {
+        background-color: @hoverRed;
+      }
     }
   }
   .fonticon-filter {

--- a/app/addons/documents/assets/less/header-docs-left.less
+++ b/app/addons/documents/assets/less/header-docs-left.less
@@ -68,6 +68,7 @@ button.faux-header__doc-header-dropdown-toggle:focus {
 
 .faux-header__doc-header-backlink:hover {
   text-decoration: none;
+  color: @hoverRed;
 }
 
 // override bootstrap styles

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -665,6 +665,10 @@ body .control-toggle-include-docs span {
     .border-radius(6px);
     text-decoration: none;
     font-size: 19px;
+    &:hover {
+      background-color: @hoverRed;
+      color: white;
+    }
   }
   td {
     vertical-align: middle;


### PR DESCRIPTION
Related Cloudant fogbugz ticket:  https://cloudant.fogbugz.com/f/cases/76050/

This PR should address:
1. Changes feed filter button did not have proper hover color.
2. Database action items (replicated, permissions, delete) did not have proper hover colors.
3. TabElements remained clickable after becoming active.
4. Edit Pencil icon for doc edit did not have proper hover color.
5. "<" arrow in secondary nav when viewing a database did not have a hover color.