### PR TITLE
76046 - The Documentation Link in the Query Options Panel Points to Futon Documentation

### DIFF
--- a/app/addons/documents/queryoptions/queryoptions.react.jsx
+++ b/app/addons/documents/queryoptions/queryoptions.react.jsx
@@ -30,13 +30,7 @@ var MainFieldsView = React.createClass({
     reduce: React.PropTypes.bool.isRequired,
     toggleReduce: React.PropTypes.func,
     updateGroupLevel: React.PropTypes.func,
-    docURL: React.PropTypes.string
-  },
-
-  getDefaultProps: function () {
-    return {
-      docURL: FauxtonAPI.constants.DOC_URLS.GENERAL
-    };
+    docURL: React.PropTypes.string.isRequired
   },
 
   toggleIncludeDocs: function (e) {
@@ -411,7 +405,8 @@ var QueryTray = React.createClass({
             reduce={this.props.reduce}
             toggleReduce={Actions.toggleReduce}
             groupLevel={this.props.groupLevel}
-            updateGroupLevel={Actions.updateGroupLevel} />
+            updateGroupLevel={Actions.updateGroupLevel}
+            docURL={FauxtonAPI.constants.DOC_URLS.GENERAL} />
           <KeySearchFields
             key={1}
             showByKeys={this.props.showByKeys}


### PR DESCRIPTION
This is from Cloudant ticket https://cloudant.fogbugz.com/f/cases/76046/.
Corresponding Cloudant dashboard PR:  https://github.com/cloudant/dashboard/pull/619

The documentation link still pointed to Fauxton docs instead of Cloudant docs.  The getDefaultProps() call was happening before FauxtonAPI.constants.DOC_URLS.GENERAL was tweaked for Cloudant specific values.

The getDefaultProps() function is now removed and the docURL is passed as a prop to MainFieldsView.  The docURL is now a required property for the React class per advice from Robert Kowalski.
