### PR TITLE
mango: shorten overflowing text in breadcrumbs

### DIFF
--- a/app/addons/components/assets/less/header-breadcrumbs.less
+++ b/app/addons/components/assets/less/header-breadcrumbs.less
@@ -23,6 +23,9 @@
   padding: 18px 10px;
   font-size: 24px;
   text-shadow: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .faux-header__breadcrumbs-link:hover {


### PR DESCRIPTION
<img width="703" alt="screen shot 2016-11-01 at 18 58 49" src="https://cloud.githubusercontent.com/assets/298166/19901819/b8a88258-a068-11e6-8dce-959df5195d4f.png">
