### PR TITLE
Handle trailing params when building URLs for views

### DIFF
--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -506,7 +506,7 @@ Documents.IndexCollection = PagingCollection.extend({
         view = app.utils.safeURLName(this.view),
         url = FauxtonAPI.urls('view', context, database, design, view);
 
-    return (url.indexOf("?") > -1) ? url + "&" + query : url + "?" + query;
+    return (url.indexOf("?") > -1) ? `${url}&${query}` : `${url}?${query}`;
   },
 
   url: function () {

--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -488,13 +488,13 @@ Documents.IndexCollection = PagingCollection.extend({
 
     if (params) {
       if (!_.isEmpty(params)) {
-        query = "?" + $.param(params);
+        query = $.param(params);
       } else {
         query = '';
       }
     } else if (this.params) {
       var parsedParam = Documents.QueryParams.stringify(this.params);
-      query = "?" + $.param(parsedParam);
+      query = $.param(parsedParam);
     }
 
     if (!context) {
@@ -506,7 +506,7 @@ Documents.IndexCollection = PagingCollection.extend({
         view = app.utils.safeURLName(this.view),
         url = FauxtonAPI.urls('view', context, database, design, view);
 
-    return url + query;
+    return (url.indexOf("?") > -1) ? url + "&" + query : url + "?" + query;
   },
 
   url: function () {

--- a/app/addons/documents/tests/resourcesSpec.js
+++ b/app/addons/documents/tests/resourcesSpec.js
@@ -486,8 +486,12 @@ describe('IndexCollection', function () {
     });
   });
 
-  it('creates the right url with correct params when trailing question mark', function () {
+  it('creates the right url with correct params when trailing question mark', () => {
     assert.ok(/\?bogusParam=foo&limit=20&reduce=false/.test(collection.urlRef('testWithTrailingQuestion')));
+  });
+
+  it('creates the right url with correct params without trailing question mark', () => {
+    assert.ok(/\?limit=20&reduce=false/.test(collection.urlRef()));
   });
 
 });

--- a/app/addons/documents/tests/resourcesSpec.js
+++ b/app/addons/documents/tests/resourcesSpec.js
@@ -9,6 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
+import app from "../../../app";
 import FauxtonAPI from "../../../core/api";
 import Models from "../resources";
 import testUtils from "../../../../test/mocha/testUtils";
@@ -460,5 +461,33 @@ describe('Bulk Delete', function () {
 
   });
 
+});
+
+// this should stay at the bottom due to manipulating the 'view' urls.  otherwise, update this to restore them.
+describe('IndexCollection', function () {
+  var collection;
+
+  beforeEach(function () {
+    FauxtonAPI.registerUrls('view', {
+      testWithTrailingQuestion: function (database, designDoc, viewName) {
+        return app.host + '/' + database + '/_design/' + designDoc + '/_view/' + viewName + "?bogusParam=foo";
+      }
+    });
+    collection = new Models.IndexCollection([{
+      id:'myId1',
+      doc: 'num1'
+    },
+    {
+      id:'myId2',
+      doc: 'num2'
+    }], {
+      database: {id: 'databaseId', safeID: function () { return this.id; }},
+      design: '_design/myDoc'
+    });
+  });
+
+  it('creates the right url with correct params when trailing question mark', function () {
+    assert.ok(/\?bogusParam=foo&limit=20&reduce=false/.test(collection.urlRef('testWithTrailingQuestion')));
+  });
 
 });


### PR DESCRIPTION
In some circumstances, FauxtonAPI.urls() returns paths with a query parameter already appended to the end.  This results in URLs that contain multiple ?'s instead of one ? and multiple &'s.  The fix in this PR no longer assumes FauxtonAPI.urls() returns paths in a specific format.