### PR TITLE
Redux: update & fix

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -57,11 +57,19 @@ $(document).on("click", "a:not([data-bypass])", function (evt) {
   }
 });
 
+function getReducers (r) {
 
-const reducer = FauxtonAPI.reducers.reduce((el, acc) => {
-  acc[el] = el;
-  return acc;
-}, {});
+  if (!r.length) {
+    return function () {};
+  }
+
+  return FauxtonAPI.reducers.reduce((el, acc) => {
+    acc[el] = el;
+    return acc;
+  }, {});
+}
+
+const reducer = getReducers(FauxtonAPI.reducers);
 
 const middlewares = [thunk];
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-addons-css-transition-group": "~15.4.1",
     "react-bootstrap": "^0.30.7",
     "react-dom": "~15.4.1",
-    "react-redux": "^4.4.5",
+    "react-redux": "^5.0.0",
     "react-select": "1.0.0-rc.2",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",


### PR DESCRIPTION
`getReducers` is mostly covered by our other tests.

no additional test coverage as we would need to build a separate build process (one without permissions) to test, so the cost for the test is to high in relation to the usefulness.