### PR TITLE
Replication: hotfix url parsing for invalid urls

### DIFF
--- a/app/addons/replication/__tests__/api.tests.js
+++ b/app/addons/replication/__tests__/api.tests.js
@@ -20,13 +20,34 @@ import {
   encodeFullUrl,
   decodeFullUrl,
   getCredentialsFromUrl,
-  removeCredentialsFromUrl
+  removeCredentialsFromUrl,
+  removeSensitiveUrlInfo
 } from '../api';
 import Constants from '../constants';
 
 const assert = utils.assert;
 
 describe('Replication API', () => {
+
+  describe("removeSensiteiveUrlInfo", () => {
+    it('removes password username', () => {
+        const url = 'http://tester:testerpass@127.0.0.1/fancy/db/name';
+
+        const res = removeSensitiveUrlInfo(url);
+
+        expect(res).toBe('http://127.0.0.1/fancy/db/name');
+      });
+
+      // see https://issues.apache.org/jira/browse/COUCHDB-3257
+      // CouchDB accepts and returns invalid urls
+      it('does not throw on invalid urls', () => {
+        const url = 'http://tester:tes#terpass@127.0.0.1/fancy/db/name';
+
+        const res = removeSensitiveUrlInfo(url);
+
+        expect(res).toBe('http://tester:tes#terpass@127.0.0.1/fancy/db/name');
+      });
+  });
 
   describe('getSource', () => {
 

--- a/app/addons/replication/api.js
+++ b/app/addons/replication/api.js
@@ -197,9 +197,13 @@ export const createReplicationDoc = ({
   });
 };
 
-const removeSensitiveUrlInfo = (url) => {
-  const urlObj = new URL(url);
-  return `${urlObj.origin}/${decodeURIComponent(urlObj.pathname.slice(1))}`;
+export const removeSensitiveUrlInfo = (url) => {
+  try {
+    const urlObj = new URL(url);
+    return `${urlObj.origin}/${decodeURIComponent(urlObj.pathname.slice(1))}`;
+  } catch (e) {
+    return url;
+  }
 };
 
 export const getDocUrl = (doc) => {


### PR DESCRIPTION
See COUCHDB-3257: sometimes the replicator returns invalid urls
which are not encoded. This makes standard conforming url parsers
choke.

This catches the exception, with the tradeoff of displaying the
password in the cases where the url is invalid.