### PR TITLE
Allow hyphen in key name when matching edit line

### DIFF
--- a/app/addons/components/components/codeeditor.js
+++ b/app/addons/components/components/codeeditor.js
@@ -253,7 +253,7 @@ export const CodeEditor = React.createClass({
     // one JS(ON) string can't span more than one line - we edit one string, so ensure we don't select several lines
     if (selStart >= 0 && selEnd >= 0 && selStart === selEnd && this.isRowExpanded(selStart)) {
       var editLine = this.getLine(selStart),
-          editMatch = editLine.match(/^([ \t]*)("[a-zA-Z0-9_]*["|']: )?(["|'].*",?[ \t]*)$/);
+          editMatch = editLine.match(/^([ \t]*)("[a-zA-Z0-9_\-]*["|']: )?(["|'].*",?[ \t]*)$/);
 
       if (editMatch) {
         return editMatch;


### PR DESCRIPTION
In my design doc, I can open a string editor for

```
"updates" : {
   "foobar" : "//comment"
   "foo_bar" : "//comment"
}
```
but not

```
"updates" : {
   "foo-bar" : "//comment"
}
```

An editor opens in the later case with no content.

This works however, as the key is map, not foo-bar when matching the edit line.
```
"views" : {
   "foo-bar" : {
        "map": "// a comment"
   }
}
```