### PR TITLE
76043 - tweaking hover color for attachment links

### DIFF
--- a/app/addons/documents/assets/less/doc-editor.less
+++ b/app/addons/documents/assets/less/doc-editor.less
@@ -11,6 +11,7 @@
 // the License.
 
 @import "../../../../../assets/less/mixins.less";
+@import "../../../../../assets/less/variables.less";
 
 
 #dashboard.doc-editor-page {
@@ -175,6 +176,9 @@
   max-width: 540px;
   text-align: left;
   overflow: hidden;
+  a:hover {
+    color: @hoverRed;
+  }
 }
 
 #editor-container div.string-editor-modal {


### PR DESCRIPTION
The hover style for attachment links was not consistency with the rest of Fauxton.