### PR TITLE
81574 - API Url test intermittently fails

### DIFF
--- a/app/addons/fauxton/tests/nightwatch/updatesUrlsSameRouteobject.js
+++ b/app/addons/fauxton/tests/nightwatch/updatesUrlsSameRouteobject.js
@@ -27,6 +27,9 @@ module.exports = {
       .assert.valueContains('.text-field-to-copy', newDatabaseName + '/_find')
       .clickWhenVisible('.edit-link')
       .waitForElementVisible('.prettyprint', waitTime, false)
+      // We need to wait for the previous API Url modal to disappear before
+      // attempting to view it with the new text-field-to-copy.
+      .waitForElementNotPresent('.api-bar-tray', waitTime, false)
       .clickWhenVisible('.control-toggle-api-url')
       .waitForElementVisible('.text-field-to-copy', waitTime, false)
       .assert.valueContains('.text-field-to-copy', newDatabaseName + '/_index')


### PR DESCRIPTION
This test would periodically fail due to a timing issue.

Upon further investigation, the API Url modal would still be visible for a short amount of time after clicking on the Edit link.  Then when attempting to show the modal, the test framework would effectively be closing the modal instead.  This change essentially pauses the test suite until the old modal has time to unmount.