### PR TITLE
Fix build & config addon

### DIFF
--- a/app/addons/config/routes.js
+++ b/app/addons/config/routes.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+import React from 'react';
 import FauxtonAPI from "../../core/api";
 import Config from "./resources";
 import CORSActions from "../cors/actions";
@@ -49,7 +50,7 @@ var ConfigPerNodeRouteObject = FauxtonAPI.RouteObject.extend({
     '_config/:node/cors': 'configCorsForNode'
   },
 
-  initialize: function (_a, _b, options) {
+  initialize: function (_a, options) {
     var node = options[0];
 
     this.configs = new Config.ConfigModel({ node: node });

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "grunt": "~1.0.1",
     "grunt-cli": "~1.2.0",
     "grunt-contrib-clean": "~1.0.0",
-    "grunt-contrib-copy": "~0.4.1",
+    "grunt-contrib-copy": "~1.0.0",
     "grunt-couchapp": "~0.2.1",
     "grunt-exec": "~1.0.1",
     "grunt-md5": "^0.1.11",


### PR DESCRIPTION
Bump `grunt-contrib-copy` to version 1.0.0 required because `npm install` generate this error:
```
$ npm install
npm WARN peerDependencies The peer dependency grunt@~0.4.0 included from grunt-contrib-copy will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm ERR! Linux 3.16.0
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install"
npm ERR! node v4.7.3
npm ERR! npm  v2.15.11
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package grunt@1.0.1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer grunt-contrib-clean@1.0.0 wants grunt@>= 0.4.5
npm ERR! peerinvalid Peer grunt-contrib-copy@0.4.1 wants grunt@~0.4.0
npm ERR! peerinvalid Peer grunt-exec@1.0.1 wants grunt@>=0.4
npm ERR! peerinvalid Peer grunt-md5@0.1.12 wants grunt@>=0.4.0
npm ERR! peerinvalid Peer grunt-shell@2.1.0 wants grunt@>=0.4.0

npm ERR! Please include the following file with any support request:
npm ERR!     /usr/src/couchdb-fauxton/npm-debug.log
```

Changes in `app/addons/config/routes.js` because it throws this errors< when trying open confugration in Fauxton:
```
Uncaught TypeError: Cannot read property '0' of undefined
    at child.initialize (bundle.js:162713)
    at child.RouteObject (bundle.js:42514)
    at new child (bundle.js:42202)
    at Object.<anonymous> (bundle.js:42335)
    at Object.<anonymous> (bundle.js:3745)
    at fire (bundle.js:3566)
    at Object.add [as done] (bundle.js:3625)
    at Array.<anonymous> (bundle.js:3744)
    at Function.each (bundle.js:744)
    at Object.<anonymous> (bundle.js:3740)
```

and 

```
Uncaught ReferenceError: React is not defined
    at child.configForNode (routes.js:60)
    at child.routeCallback (routeObject.js:77)
    at Object.<anonymous> (router.js:66)
    at Object.<anonymous> (jquery.js:3366)
    at fire (jquery.js:3187)
    at Object.add [as done] (jquery.js:3246)
    at Array.<anonymous> (jquery.js:3365)
    at Function.each (jquery.js:365)
    at Object.<anonymous> (jquery.js:3361)
    at Function.Deferred (jquery.js:3427)
```