### PR TITLE
trim moment locale using IgnorePlugin

### DIFF
--- a/webpack.config.release.js
+++ b/webpack.config.release.js
@@ -30,6 +30,9 @@ module.exports = {
         'NODE_ENV': JSON.stringify('production') // This has effect on the react lib size
       }
     }),
+    // moment doesn't offer a modular API, so manually remove locale
+    // see https://github.com/moment/moment/issues/2373
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin({
       compress: {


### PR DESCRIPTION
This trims the release bundle.js size from 2554776 bytes to 2372243 bytes. Apparently there is a large part of the bundle taken up by moment.js, but AFAICT we're not actually using moment/locale anywhere, so this removes it.

See https://github.com/moment/moment/issues/2373 for why this seemed like a good idea.