### PR TITLE
code-split "brace" into second bundle

### DIFF
--- a/app/addons/components/components/codeeditor.js
+++ b/app/addons/components/components/codeeditor.js
@@ -12,12 +12,17 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import FauxtonAPI from "../../../core/api";
-import ace from "brace";
 import {StringEditModal} from './stringeditmodal';
 
-require('brace/mode/javascript');
-require('brace/mode/json');
-require('brace/theme/idle_fingers');
+function ensureAce(callback) {
+  // dynamically load brace because it's large
+  require.ensure([
+    'brace',
+    'brace/mode/javascript',
+    'brace/mode/json',
+    'brace/theme/idle_fingers'
+  ], callback);
+}
 
 export const CodeEditor = React.createClass({
   getDefaultProps () {
@@ -81,7 +86,7 @@ export const CodeEditor = React.createClass({
   },
 
   setupAce (props, shouldUpdateCode) {
-    this.editor = ace.edit(ReactDOM.findDOMNode(this.refs.ace));
+    this.editor = require('brace').edit(ReactDOM.findDOMNode(this.refs.ace));
 
     // suppresses an Ace editor error
     this.editor.$blockScrolling = Infinity;
@@ -170,21 +175,29 @@ export const CodeEditor = React.createClass({
   },
 
   componentDidMount () {
-    this.setupAce(this.props, true);
-    this.setupEvents();
+    var self = this;
+    ensureAce(function () {
+      self.setupAce(self.props, true);
+      self.setupEvents();
 
-    if (this.props.autoFocus) {
-      this.editor.focus();
-    }
+      if (self.props.autoFocus) {
+        self.editor.focus();
+      }
+    });
   },
 
   componentWillUnmount () {
     this.removeEvents();
-    this.editor.destroy();
+    if (this.editor) {
+      this.editor.destroy();
+    }
   },
 
   componentWillReceiveProps (nextProps) {
-    this.setupAce(nextProps, false);
+    var self = this;
+    ensureAce(function () {
+      self.setupAce(nextProps, false);
+    });
   },
 
   getAnnotations () {

--- a/app/addons/components/components/stringeditmodal.js
+++ b/app/addons/components/components/stringeditmodal.js
@@ -13,11 +13,17 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import {Modal} from "react-bootstrap";
-import ace from "brace";
 import Helpers from "../../documents/helpers";
-require('brace/mode/javascript');
-require('brace/mode/json');
-require('brace/theme/idle_fingers');
+
+function ensureAce(callback) {
+  // dynamically load brace because it's large
+  require.ensure([
+    'brace',
+    'brace/mode/javascript',
+    'brace/mode/json',
+    'brace/theme/idle_fingers'
+  ], callback);
+}
 
 // this appears when the cursor is over a string. It shows an icon in the gutter that opens the modal.
 export const StringEditModal = React.createClass({
@@ -56,8 +62,14 @@ export const StringEditModal = React.createClass({
     this.initEditor(val);
   },
 
-  initEditor (val) {
-    this.editor = ace.edit(ReactDOM.findDOMNode(this.refs.stringEditor));
+  initEditor(val) {
+    var self = this;
+    ensureAce(function () {
+      self.initEditorAsync(val);
+    });
+  },
+  initEditorAsync (val) {
+    this.editor = require('brace').edit(ReactDOM.findDOMNode(this.refs.stringEditor));
     this.editor.$blockScrolling = Infinity; // suppresses an Ace editor error
     this.editor.setShowPrintMargin(false);
     this.editor.setOption('highlightActiveLine', true);

--- a/app/addons/components/components/zenmodeoverlay.js
+++ b/app/addons/components/components/zenmodeoverlay.js
@@ -14,8 +14,6 @@ import ReactDOM from "react-dom";
 import app from "../../../app";
 import {CodeEditor} from './codeeditor';
 
-require('brace/theme/dawn');
-
 // Zen mode editing has very few options:
 // - It covers the full screen, hiding everything else
 // - Two themes: light & dark (choice stored in local storage)
@@ -60,6 +58,10 @@ export const ZenModeOverlay = React.createClass({
   componentDidMount () {
     $(ReactDOM.findDOMNode(this.refs.exit)).tooltip({ placement: 'left' });
     $(ReactDOM.findDOMNode(this.refs.theme)).tooltip({ placement: 'left' });
+
+    require.ensure(['brace/theme/dawn'], function () {
+      require('brace/theme/dawn');
+    });
   },
 
   exitZenMode () {

--- a/webpack.config.release.js
+++ b/webpack.config.release.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1}),
+    new webpack.optimize.LimitChunkCountPlugin({maxChunks: 2}),
     new webpack.DefinePlugin({
       'process.env': {
         'NODE_ENV': JSON.stringify('production') // This has effect on the react lib size


### PR DESCRIPTION
I am not 100% confident in this PR but maybe it's a good starting point for discussion.

I noticed that `brace` makes up a lot of the default bundle. I also noticed that you don't really need `brace` until you open an editor. So it seems like a good opportunity to code-split.

Before:

```
2554776	bundle.js
```

After:

```
252701	1.bundle.js
2302814	bundle.js
```

So this removes 251962 bytes (~250KB) from the default bundle.

I've tested this and it does indeed work. When you open up an editor, `1.bundle.js` downloads and you can edit JavaScript/JSON. Open questions, though:

1. What is zenmodeoverlay? I'm not sure how to test it. I'm also not sure how to dynamically load `brace/theme/dawn` inside of it.
2. Should we move `1.bundle.js` to `dashboard.assets`? TBH I'm not sure why we even move `bundle.js` into a content-addressed file. It shouldn't be extremely valuable to make it content-addressed, unless folks are frequently upgrading their databases and we're worried that the cache might be stale.