### PR TITLE
replace url construction with FauxtonAPI lookup

### DIFF
--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -351,7 +351,7 @@ Documents.BulkDeleteDocCollection = FauxtonAPI.Collection.extend({
   },
 
   url: function () {
-    return app.host + '/' + this.databaseId + '/_bulk_docs';
+    return FauxtonAPI.urls('bulk_docs', 'server', this.databaseId, '');
   },
 
   bulkDelete: function () {


### PR DESCRIPTION
By using `Fauxton.urls` we limit the number of times we determine/construct the URL and allow for it be overridden elsewhere.