### PR TITLE
Update layout for pages with secondary nav

### DIFF
--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -421,8 +421,8 @@
     padding: 15px;
     bottom: 0px;
     top: @collapsedNavWidth;
-    position: fixed;
-    left: @sidebarWidth+@navWidth;
+    position: absolute;
+    left: @sidebarWidth;
     right: 0;
     .box-sizing(border-box);
     .closeMenu & {


### PR DESCRIPTION
When rendering the permanent notification at the top of the screen (see https://github.com/apache/couchdb-fauxton/pull/865), we noticed a bug in the layout of pages with the secondary nav.  The `#dashboard-content` pane would get covered by the notification and cause other odd layout issues.