### PR TITLE
Text tidying on Metadata Page

### DIFF
--- a/app/addons/documents/assets/less/documents.less
+++ b/app/addons/documents/assets/less/documents.less
@@ -86,7 +86,6 @@ button.beautify {
     margin-top: 12px;
   }
   header {
-    border-bottom: 1px solid #cccccc;
     padding-bottom: 10px;
   }
   .icon-question-sign {

--- a/app/addons/documents/designdocinfo/components.react.jsx
+++ b/app/addons/documents/designdocinfo/components.react.jsx
@@ -10,7 +10,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import app from "../../../app";
 import FauxtonAPI from "../../../core/api";
 import React from "react";
 import Stores from "./stores";
@@ -57,7 +56,6 @@ var DesignDocInfo = React.createClass({
   },
 
   render: function () {
-    var getDocUrl = app.helpers.getDocUrl;
     var viewIndex = this.state.viewIndex;
 
     if (this.state.isLoading) {
@@ -70,16 +68,7 @@ var DesignDocInfo = React.createClass({
     return (
       <div className="metadata-page">
         <header>
-          <div className="preheading">Design Document Metadata</div>
-          <h2>_design/{this.state.ddocName}</h2>
-
-          <p className="help">
-            Information about the specified design document, including the index, index size and current status of the
-            design document and associated index information.
-            <a href={getDocUrl('DESIGN_DOC_METADATA')} className="help-link" target="_blank" data-bypass="true">
-              <i className="icon-question-sign" />
-            </a>
-          </p>
+          <h2>_design/{this.state.ddocName} Metadata</h2>
         </header>
 
         <section className="container">


### PR DESCRIPTION
Removed redundant intro text on the ddoc metadata page.

Before:
![screen shot 2017-03-17 at 1 19 23 pm](https://cloud.githubusercontent.com/assets/12969375/24061376/7682f05e-0b14-11e7-924b-2e9dd5b6eb29.png)

After:
![screen shot 2017-03-17 at 1 15 22 pm](https://cloud.githubusercontent.com/assets/12969375/24061413/91c375be-0b14-11e7-8ed6-c9301b60fc89.png)

