### PR TITLE
Nav styles, button styles/text, other text/style changes

### DIFF
--- a/app/addons/auth/components.react.jsx
+++ b/app/addons/auth/components.react.jsx
@@ -97,7 +97,7 @@ var LoginForm = React.createClass({
               <input id="password" type="password" name="password" ref="password" placeholder="Password" size="24"
                 onChange={this.onInputChange} value={this.state.password} />
               <br/>
-              <button id="submit" className="btn btn-success" type="submit">Log In</button>
+              <button id="submit" className="btn btn-primary" type="submit">Log In</button>
             </form>
           </div>
         </div>
@@ -148,17 +148,15 @@ var ChangePasswordForm = React.createClass({
   render: function () {
     return (
       <div className="auth-page">
-        <h3>Change Password</h3>
-
         <form id="change-password" onSubmit={this.changePassword}>
           <p>
-            Enter your new password.
+            Enter and confirm a new password.
           </p>
 
           <input id="password" type="password" ref="password" name="password" placeholder="Password"
             size="24" onChange={this.onChangePassword} value={this.state.password} />
           <br />
-          <input id="password-confirm" type="password" name="password_confirm" placeholder= "Verify Password"
+          <input id="password-confirm" type="password" name="password_confirm" placeholder= "Password Confirmation"
             size="24" onChange={this.onChangePasswordConfirm} value={this.state.passwordConfirm} />
 
           <br />
@@ -223,19 +221,17 @@ var CreateAdminForm = React.createClass({
   render: function () {
     return (
       <div className="auth-page">
-        <h3>Create Admins</h3>
-
         <p>
-          Before a server admin is configured, all clients have admin privileges. This is fine when
-          HTTP access is restricted to trusted users. <strong>If end-users will be accessing this
-          CouchDB, you must create an admin account to prevent accidental (or malicious) data
+          Before a server admin is configured, all client connections have admin privileges. <strong>If HTTP access is open to non-trusted users, create an admin account to prevent data
           loss.</strong>
         </p>
         <p>
-          Server admins can create and destroy databases, install and update _design documents, run
-          the test suite, and edit all aspects of CouchDB configuration.
+          Connections with Admin privileges can create and destroy databases, install and update _design documents, run
+          the test suite, and modify the CouchDB configuration.
         </p>
-
+        <p>
+          Connections without Admin privileges have read and write access to all databases controlled by validation functions. CouchDB can be configured to block anonymous connections.
+        </p>
         <form id="create-admin-form" onSubmit={this.createAdmin}>
           <input id="username" type="text" ref="username" name="name" placeholder="Username" size="24"
             onChange={this.onChangeUsername} />
@@ -243,11 +239,8 @@ var CreateAdminForm = React.createClass({
           <input id="password" type="password" name="password" placeholder= "Password" size="24"
             onChange={this.onChangePassword} />
           <p>
-            Non-admin users have read and write access to all databases, which
-            are controlled by validation functions. CouchDB can be configured to block all
-            access to anonymous users.
+          <button type="submit" id="create-admin" className="btn btn-primary"><i className="icon icon-ok-circle" /> Grant Admin Privileges</button>
           </p>
-          <button type="submit" id="create-admin" className="btn btn-primary"><i className="icon icon-ok-circle" /> Create Admin</button>
         </form>
       </div>
     );

--- a/app/addons/auth/components.react.jsx
+++ b/app/addons/auth/components.react.jsx
@@ -163,7 +163,7 @@ var ChangePasswordForm = React.createClass({
 
           <br />
           <p>
-            <button type="submit" className="btn btn-primary">Change</button>
+            <button type="submit" className="btn btn-primary"><i className="icon icon-ok-circle" /> Change Password</button>
           </p>
         </form>
       </div>
@@ -247,7 +247,7 @@ var CreateAdminForm = React.createClass({
             are controlled by validation functions. CouchDB can be configured to block all
             access to anonymous users.
           </p>
-          <button type="submit" id="create-admin" className="btn btn-primary">Create Admin</button>
+          <button type="submit" id="create-admin" className="btn btn-primary"><i className="icon icon-ok-circle" /> Create Admin</button>
         </form>
       </div>
     );

--- a/app/addons/auth/routes.js
+++ b/app/addons/auth/routes.js
@@ -22,6 +22,8 @@ import {AuthLayout, AdminLayout} from './layout';
 const {LoginForm, CreateAdminForm} = Components;
 
 var AuthRouteObject = FauxtonAPI.RouteObject.extend({
+  selectedHeader: 'Login',
+
   routes: {
     'login?*extra': 'login',
     'login': 'login',

--- a/app/addons/components/assets/less/header-breadcrumbs.less
+++ b/app/addons/components/assets/less/header-breadcrumbs.less
@@ -28,10 +28,15 @@
   white-space: nowrap;
 }
 
-.faux-header__breadcrumbs-link:hover {
+a.faux-header__breadcrumbs-link {
+  color: @darkRed;
+  &:hover {
+  color: @hoverRed;
   text-decoration: none;
   cursor: hand;
+  }
 }
+
 
 .faux-header__breadcrumbs-divider {
   width: 13px;

--- a/app/addons/components/assets/less/modals.less
+++ b/app/addons/components/assets/less/modals.less
@@ -16,9 +16,10 @@
 .modal .cancel-link {
   margin: 0 15px;
   font-size: 14px;
-  color: @defaultText;
+  color: #666;
   &:hover {
-    color: @brandPrimaryDark;
-    cursor: pointer;
+    color: @hoverRed;
+    text-decoration: none;
+    cursor: hand;
   }
 }

--- a/app/addons/components/components/deletedatabasemodal.js
+++ b/app/addons/components/components/deletedatabasemodal.js
@@ -110,7 +110,7 @@ export const DeleteDatabaseModal = React.createClass({
             disabled={this.state.disableSubmit}
             onClick={this.onDeleteClick}
             className="btn btn-danger delete">
-            <i className="icon fonticon-cancel-circled" /> Delete
+            <i className="icon icon-trash" /> Delete
           </button>
         </Modal.Footer>
       </Modal>

--- a/app/addons/components/components/deletedatabasemodal.js
+++ b/app/addons/components/components/deletedatabasemodal.js
@@ -88,7 +88,7 @@ export const DeleteDatabaseModal = React.createClass({
     return (
       <Modal dialogClassName="delete-db-modal" show={showDeleteModal} onHide={this.close}>
         <Modal.Header closeButton={true}>
-          <Modal.Title>Delete Database</Modal.Title>
+          <Modal.Title>Confirm Deletion</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           {warning}
@@ -110,7 +110,7 @@ export const DeleteDatabaseModal = React.createClass({
             disabled={this.state.disableSubmit}
             onClick={this.onDeleteClick}
             className="btn btn-danger delete">
-            <i className="icon icon-trash" /> Delete
+            <i className="icon icon-trash" /> Delete Database
           </button>
         </Modal.Footer>
       </Modal>

--- a/app/addons/components/components/stringeditmodal.js
+++ b/app/addons/components/components/stringeditmodal.js
@@ -85,7 +85,7 @@ export const StringEditModal = React.createClass({
         </Modal.Body>
         <Modal.Footer>
           <a className="cancel-link" onClick={this.closeModal}>Cancel</a>
-          <button id="string-edit-save-btn" onClick={this.save} className="btn btn-success save">
+          <button id="string-edit-save-btn" onClick={this.save} className="btn btn-primary save">
             <i className="fonticon-circle-check"></i> Modify Text
           </button>
         </Modal.Footer>

--- a/app/addons/config/routes.js
+++ b/app/addons/config/routes.js
@@ -37,7 +37,7 @@ var ConfigDisabledRouteObject = FauxtonAPI.RouteObject.extend({
 
 var ConfigPerNodeRouteObject = FauxtonAPI.RouteObject.extend({
   roles: ['_admin'],
-  selectedHeader: 'Config',
+  selectedHeader: 'Configuration',
 
   apiUrl: function () {
     return [this.configs.url(), this.configs.documentation];

--- a/app/addons/cors/assets/less/cors.less
+++ b/app/addons/cors/assets/less/cors.less
@@ -85,7 +85,7 @@
   }
 
   .input-append {
-      width: 90%;
+      width: 80%;
   }
 
   input[type='text'] {

--- a/app/addons/cors/components.react.jsx
+++ b/app/addons/cors/components.react.jsx
@@ -183,7 +183,7 @@ var OriginInput = React.createClass({
         <div className="origin-domains">
           <div className="input-append">
             <input type="text" name="new_origin_domain" onChange={this.onInputChange} onKeyUp={this.onKeyUp} value={this.state.origin} placeholder="https://example.com"/>
-            <button onClick={this.addOrigin} className="btn btn-primary add-domain"><i className="icon fonticon-ok-circled"></i> Add Domain</button>
+            <button onClick={this.addOrigin} className="btn btn-secondary add-domain"><i className="icon fonticon-ok-circled"></i> Add Domain</button>
           </div>
         </div>
       </div>
@@ -334,7 +334,7 @@ var CORSController = React.createClass({
             <br />
             <button
               type="button"
-              className="enable-disable btn btn-success"
+              className="enable-disable btn btn-secondary"
               onClick={this.enableCorsChange}
               disabled={this.state.isLoading ? 'disabled' : null}
             >

--- a/app/addons/cors/components.react.jsx
+++ b/app/addons/cors/components.react.jsx
@@ -182,8 +182,8 @@ var OriginInput = React.createClass({
       <div id="origin-domains-container">
         <div className="origin-domains">
           <div className="input-append">
-            <input type="text" name="new_origin_domain" onChange={this.onInputChange} onKeyUp={this.onKeyUp} value={this.state.origin} placeholder="e.g., https://site.com"/>
-            <button onClick={this.addOrigin} className="btn btn-primary add-domain"> Add </button>
+            <input type="text" name="new_origin_domain" onChange={this.onInputChange} onKeyUp={this.onKeyUp} value={this.state.origin} placeholder="https://example.com"/>
+            <button onClick={this.addOrigin} className="btn btn-primary add-domain"><i className="icon fonticon-ok-circled"></i> Add Domain</button>
           </div>
         </div>
       </div>

--- a/app/addons/documents/assets/less/changes.less
+++ b/app/addons/documents/assets/less/changes.less
@@ -82,6 +82,7 @@
     margin: 20px 0;
   }
   .remove-filter {
+    color: #333333;
     text-shadow: none;
     background-color: transparent;
     font-size: 20px;
@@ -89,7 +90,7 @@
     padding-left: 0;
     margin-right: 8px;
     &:hover {
-      color: #111111;
+      color: #E73D34;
     }
   }
 }

--- a/app/addons/documents/assets/less/doc-editor.less
+++ b/app/addons/documents/assets/less/doc-editor.less
@@ -79,6 +79,20 @@
 
   .cancel-button {
     font-size: 14px;
+    color: #666;
+    &:hover {
+      color: @hoverRed;
+      text-decoration: none;
+      cursor: hand;
+    }
+  }
+  .panel-button {
+    color: #666;
+    &:hover {
+      color: @hoverRed;
+      text-decoration: none;
+      cursor: hand;
+    }
   }
 
   .bgEditorGutter {

--- a/app/addons/documents/assets/less/documents.less
+++ b/app/addons/documents/assets/less/documents.less
@@ -91,6 +91,10 @@ button.beautify {
   }
   .icon-question-sign {
     margin-left: 4px;
+    color: @secondaryBlue;
+    &:hover {
+      color: @hoverRed;
+    }
   }
   section {
     line-height: 21px;

--- a/app/addons/documents/assets/less/header-docs-left.less
+++ b/app/addons/documents/assets/less/header-docs-left.less
@@ -76,7 +76,7 @@ button.faux-header__doc-header-dropdown-toggle:focus {
   padding: 10px 15px 10px 12px;
 }
 .faux-header__doc-header-dropdown-itemwrapper .faux-header__doc-header-dropdown-item:hover {
-  background-color: @navBG;
+  background-color: @hoverRed;
   color: #fff;
   cursor: pointer;
 }

--- a/app/addons/documents/assets/less/query-options.less
+++ b/app/addons/documents/assets/less/query-options.less
@@ -72,6 +72,10 @@
   .icon-question-sign {
     margin-left: 3px;
     font-size: 17.5px;
+    color: @secondaryBlue;
+    &:hover {
+      color: @hoverRed;
+    }
   }
 
   .query-group {
@@ -120,6 +124,13 @@
       border: none;
       box-shadow: none;
       color: @red;
+      line-height: 1em;
+    }
+    .btn-cancelDark, .btn-cancelDark:active {
+      background: none;
+      border: none;
+      box-shadow: none;
+      color: #CCC;
       line-height: 1em;
     }
     select {
@@ -208,10 +219,7 @@
   .hide {
     display: none;
   }
-
-  .icon-question-sign:hover {
-    color: @linkColorHover;
-  }
+  
   .additionalParams {
     margin-bottom: 2px;
   }

--- a/app/addons/documents/assets/less/sidenav.less
+++ b/app/addons/documents/assets/less/sidenav.less
@@ -188,8 +188,8 @@
 #index-menu-component-popover {
   .border-radius(0);
   .box-shadow(2px 2px rgba(0, 0, 0, 0.2));
-  background-color: black;
-  color: #dddddd;
+  background-color: @brown;
+  color: #FFF;
   font-size: 12px;
   padding: 0;
   margin-left: -7px;
@@ -200,12 +200,12 @@
   }
   li {
     padding: 10px;
-    background-color: #202326;
+    background-color: @greyBrown;
     margin-bottom: 2px;
     cursor: pointer;
     .transition(all 0.25s linear);
     &:hover {
-      background-color: @brandPrimaryDark;
+      background-color: @hoverRed;
     }
     &:last-child {
       margin-bottom: 0;

--- a/app/addons/documents/assets/less/sidenav.less
+++ b/app/addons/documents/assets/less/sidenav.less
@@ -45,6 +45,7 @@
     & + span.index-menu-toggle {
       color: white;
     }
+
   }
 
   li {
@@ -61,7 +62,7 @@
         color: white;
       }
       p {
-        background-color: @darkRed;
+        background-color: @hoverRed;
       }
     }
     .accordion-list-item p {
@@ -113,7 +114,7 @@
           &:hover {
             color: #fff;
             text-decoration: none;
-            background-color: @darkRed;
+            background-color: @hoverRed;
           }
           border-top: none;
           &.accordion-header{
@@ -175,7 +176,7 @@
     padding-left: 4px;
     .transition(all 0.25s linear);
     &:hover {
-      color: @linkColor;
+      color: @hoverRed;
     }
     &:before {
       font-size: 17px;

--- a/app/addons/documents/assets/less/sidenav.less
+++ b/app/addons/documents/assets/less/sidenav.less
@@ -16,7 +16,7 @@
 #sidebar-content {
   .loading-lines {
     margin-top: 20px;
-  }  
+  }
 }
 
 .sidenav {
@@ -35,7 +35,7 @@
   }
 
   .dropdown-toggle:hover {
-    color: @linkColor;
+    color: #E73D34;
   }
 
   // ugly! This styles the (+) icon to make it white when a user hovers over a row. Better solution would be to move the

--- a/app/addons/documents/assets/less/view-editor.less
+++ b/app/addons/documents/assets/less/view-editor.less
@@ -222,7 +222,13 @@
   }
 }
 
-.index-cancel-link {
+a.index-cancel-link {
   margin-left: 10px;
   font-size: 14px;
+  color: #666;
+  &:hover {
+    color: @hoverRed;
+    text-decoration: none;
+    cursor: hand;
+  }
 }

--- a/app/addons/documents/doc-editor/components.react.jsx
+++ b/app/addons/documents/doc-editor/components.react.jsx
@@ -364,7 +364,7 @@ var UploadModal = React.createClass({
         <Modal.Footer>
           <a href="#" data-bypass="true" className="cancel-link" onClick={this.closeModal}>Cancel</a>
           <button href="#" id="upload-btn" data-bypass="true" className="btn btn-success save" onClick={this.upload}>
-            Upload Attachment
+            <i className="icon icon-upload" /> Upload Attachment
           </button>
         </Modal.Footer>
       </Modal>

--- a/app/addons/documents/doc-editor/components.react.jsx
+++ b/app/addons/documents/doc-editor/components.react.jsx
@@ -431,6 +431,9 @@ const CloneDocModal = React.createClass({
             <p>
               Document cloning copies the saved version of the document. Unsaved document changes will be discarded.
             </p>
+            <p>
+              You can modify the following generated ID for your new document.
+            </p>
             <input ref="newDocId" type="text" autoFocus={true} className="input-block-level"
               onChange={this.docIDChange} value={this.state.uuid} />
           </form>

--- a/app/addons/documents/doc-editor/components.react.jsx
+++ b/app/addons/documents/doc-editor/components.react.jsx
@@ -169,7 +169,7 @@ var DocEditorController = React.createClass({
       <div>
         <div id="doc-editor-actions-panel">
           <div className="doc-actions-left">
-            <button className="save-doc btn btn-success save" type="button" onClick={this.saveDoc}>
+            <button className="save-doc btn btn-primary save" type="button" onClick={this.saveDoc}>
               <i className="icon fonticon-ok-circled"></i> {saveButtonLabel}
             </button>
             <div>
@@ -349,8 +349,8 @@ var UploadModal = React.createClass({
           <div>
             <form ref="uploadForm" className="form">
               <p>
-                Please select the file you want to upload as an attachment to this document. This creates a new
-                revision of the document, so it's not necessary to save after uploading.
+                Select a file to upload as an attachment to this document. Uploading a file saves the document as a new
+                revision.
               </p>
               <input ref="attachments" type="file" name="_attachments" />
               <br />
@@ -363,7 +363,7 @@ var UploadModal = React.createClass({
         </Modal.Body>
         <Modal.Footer>
           <a href="#" data-bypass="true" className="cancel-link" onClick={this.closeModal}>Cancel</a>
-          <button href="#" id="upload-btn" data-bypass="true" className="btn btn-success save" onClick={this.upload}>
+          <button href="#" id="upload-btn" data-bypass="true" className="btn btn-primary save" onClick={this.upload}>
             <i className="icon icon-upload" /> Upload Attachment
           </button>
         </Modal.Footer>
@@ -429,7 +429,7 @@ const CloneDocModal = React.createClass({
         <Modal.Body>
           <form className="form" onSubmit={(e) => { e.preventDefault(); this.cloneDoc(); }}>
             <p>
-              Set new document's ID:
+              Document cloning copies the saved version of the document. Unsaved document changes will be discarded.
             </p>
             <input ref="newDocId" type="text" autoFocus={true} className="input-block-level"
               onChange={this.docIDChange} value={this.state.uuid} />
@@ -437,8 +437,8 @@ const CloneDocModal = React.createClass({
         </Modal.Body>
         <Modal.Footer>
           <a href="#" data-bypass="true" className="cancel-link" onClick={this.closeModal}>Cancel</a>
-          <button className="btn btn-success save" onClick={this.cloneDoc}>
-            <i className="fonticon-ok-circled"></i> Clone Document
+          <button className="btn btn-primary save" onClick={this.cloneDoc}>
+            <i className="icon-repeat"></i> Clone Document
           </button>
         </Modal.Footer>
       </Modal>

--- a/app/addons/documents/index-editor/components.react.jsx
+++ b/app/addons/documents/index-editor/components.react.jsx
@@ -311,7 +311,7 @@ var EditorController = React.createClass({
     }
 
     var pageHeader = (this.state.isNewView) ? 'New View' : 'Edit View';
-    var btnLabel = (this.state.isNewView) ? 'Create Document and Build Index' : 'Save Document and Build Index';
+    var btnLabel = (this.state.isNewView) ? 'Create Document and then Build Index' : 'Save Document and then Build Index';
 
     var cancelLink = '#' + FauxtonAPI.urls('view', 'showView', this.state.database.id, this.state.designDocId, this.state.viewName);
     return (

--- a/app/addons/documents/queryoptions/queryoptions.react.jsx
+++ b/app/addons/documents/queryoptions/queryoptions.react.jsx
@@ -272,10 +272,7 @@ var QueryButtons = React.createClass({
     return (
       <div className="controls-group query-group">
         <div id="button-options" className="controls controls-row">
-          <button type="submit" className="btn btn-success">
-            <i className="fonticon-play icon" />
-            Run Query
-          </button>
+          <button type="submit" className="btn btn-success">Run Query</button>
           <a onClick={this.hideTray} className="btn btn-cancel">Cancel</a>
         </div>
       </div>

--- a/app/addons/documents/queryoptions/queryoptions.react.jsx
+++ b/app/addons/documents/queryoptions/queryoptions.react.jsx
@@ -272,8 +272,8 @@ var QueryButtons = React.createClass({
     return (
       <div className="controls-group query-group">
         <div id="button-options" className="controls controls-row">
-          <button type="submit" className="btn btn-success">Run Query</button>
-          <a onClick={this.hideTray} className="btn btn-cancel">Cancel</a>
+          <button type="submit" className="btn btn-secondary">Run Query</button>
+          <a onClick={this.hideTray} className="btn btn-cancelDark">Cancel</a>
         </div>
       </div>
     );

--- a/app/addons/documents/sidebar/sidebar.react.jsx
+++ b/app/addons/documents/sidebar/sidebar.react.jsx
@@ -643,7 +643,7 @@ var CloneIndexModal = React.createClass({
         </Modal.Body>
         <Modal.Footer>
           <a href="#" className="cancel-link" onClick={this.close} data-bypass="true">Cancel</a>
-          <button onClick={this.submit} data-bypass="true" className="btn btn-success save">
+          <button onClick={this.submit} data-bypass="true" className="btn btn-primary save">
             <i className="icon fonticon-ok-circled" /> Clone {this.props.indexLabel}</button>
         </Modal.Footer>
       </Modal>

--- a/app/addons/fauxton/assets/less/components.less
+++ b/app/addons/fauxton/assets/less/components.less
@@ -43,6 +43,9 @@
 button.clipboard-copy-element {
   background: transparent;
   border: 0;
+  &:hover {
+    color: #E73D34;
+  }
 }
 
 #perma-warning {

--- a/app/addons/fauxton/assets/less/components.less
+++ b/app/addons/fauxton/assets/less/components.less
@@ -25,6 +25,10 @@
 
     .icon-question-sign {
       margin-left: 3px;
+      color: @secondaryBlue;
+      &:hover {
+        color: @hoverRed;
+      }
     }
   }
 }

--- a/app/addons/fauxton/navigation/components.react.jsx
+++ b/app/addons/fauxton/navigation/components.react.jsx
@@ -127,13 +127,8 @@ export const NavBar = React.createClass({
         <nav id="main_navigation">
           <ul id="nav-links" className="nav">
             {navLinks}
+            {bottomNavLinks}
           </ul>
-
-          <div id="bottom-nav">
-            <ul id="bottom-nav-links" className="nav">
-              {bottomNavLinks}
-            </ul>
-          </div>
         </nav>
         <div id="primary-nav-right-shadow"/>
 

--- a/app/addons/permissions/components/PermissionsSection.js
+++ b/app/addons/permissions/components/PermissionsSection.js
@@ -133,7 +133,7 @@ const PermissionsSection = React.createClass({
             <p>Specify users who will have {this.props.section} access to this database.</p>
           </header>
           <form onSubmit={this.addNames} className="permission-item-form permissions-add-user form-inline">
-            <input onChange={this.nameChange} value={this.state.newName} type="text" className="item input-small" placeholder="Add User" />
+            <input onChange={this.nameChange} value={this.state.newName} type="text" className="item input-small" placeholder="Username" />
             <button type="submit" className="btn btn-success"><i className="icon fonticon-plus-circled" /> Add User</button>
           </form>
           <ul className="unstyled permission-items span10">
@@ -146,7 +146,7 @@ const PermissionsSection = React.createClass({
             <p>Users with any of the following role(s) will have {this.props.section} access.</p>
           </header>
           <form onSubmit={this.addRoles} className="permission-item-form permissions-add-role form-inline">
-            <input onChange={this.roleChange} value={this.state.newRole} type="text" className="item input-small" placeholder="Add Role" />
+            <input onChange={this.roleChange} value={this.state.newRole} type="text" className="item input-small" placeholder="Role" />
             <button type="submit" className="btn btn-success"><i className="icon fonticon-plus-circled" /> Add Role</button>
           </form>
           <ul className="unstyled permission-items span10">

--- a/app/addons/permissions/components/PermissionsSection.js
+++ b/app/addons/permissions/components/PermissionsSection.js
@@ -134,7 +134,7 @@ const PermissionsSection = React.createClass({
           </header>
           <form onSubmit={this.addNames} className="permission-item-form permissions-add-user form-inline">
             <input onChange={this.nameChange} value={this.state.newName} type="text" className="item input-small" placeholder="Username" />
-            <button type="submit" className="btn btn-success"><i className="icon fonticon-plus-circled" /> Add User</button>
+            <button type="submit" className="btn btn-primary"><i className="icon fonticon-plus-circled" /> Add User</button>
           </form>
           <ul className="unstyled permission-items span10">
             {this.getNames()}
@@ -147,7 +147,7 @@ const PermissionsSection = React.createClass({
           </header>
           <form onSubmit={this.addRoles} className="permission-item-form permissions-add-role form-inline">
             <input onChange={this.roleChange} value={this.state.newRole} type="text" className="item input-small" placeholder="Role" />
-            <button type="submit" className="btn btn-success"><i className="icon fonticon-plus-circled" /> Add Role</button>
+            <button type="submit" className="btn btn-primary"><i className="icon fonticon-plus-circled" /> Add Role</button>
           </form>
           <ul className="unstyled permission-items span10">
             {this.getRoles()}

--- a/app/addons/replication/assets/less/replication.less
+++ b/app/addons/replication/assets/less/replication.less
@@ -254,7 +254,9 @@ input.replication__bulk-select-input[type="checkbox"] {
   border: 1px solid #aaa;
   background-color: rgba(0, 0, 0, 0);
   margin-left: 3px;
-  padding-left: 8px
+  padding-left: 8px;
+  &:hover{
+    color: @hoverRed}
 }
 
 .replication__row-actions-list {
@@ -272,6 +274,9 @@ input.replication__bulk-select-input[type="checkbox"] {
   cursor: pointer;
   padding-right: 8px;
   padding-left: 8px;
+  color: #666;
+  &:hover{ color: @hoverRed
+  }
 }
 
 .replication__row-btn--no-left-pad {
@@ -304,13 +309,13 @@ button.replication__error-continue {
 
 .replication__error-cancel,
 .replication__error-continue {
-  background-color: #0082BF;
+  background-color: @secondaryBlue;
   color: #FFF;
 }
 
 .replication__error-cancel:hover,
 .replication__error-continue:hover {
-  background-color: #e73d34;
+  background-color: @hoverRed;
   color: #FFF;
 }
 
@@ -319,11 +324,11 @@ td.replication__empty-row {
 }
 
 .replication__remote_icon_help {
-  color: #E33F3B
+  color: @secondaryBlue
 }
 
 .replication__remote_icon_help:hover {
-  color: #af2d24;
+  color: @hoverRed;
 }
 
 .replication__tooltip {

--- a/app/addons/replication/assets/less/replication.less
+++ b/app/addons/replication/assets/less/replication.less
@@ -305,11 +305,13 @@ button.replication__error-continue {
 .replication__error-cancel,
 .replication__error-continue {
   background-color: #0082BF;
+  color: #FFF;
 }
 
 .replication__error-cancel:hover,
 .replication__error-continue:hover {
   background-color: #e73d34;
+  color: #FFF;
 }
 
 td.replication__empty-row {

--- a/app/addons/replication/assets/less/replication.less
+++ b/app/addons/replication/assets/less/replication.less
@@ -275,14 +275,15 @@ input.replication__bulk-select-input[type="checkbox"] {
   padding-right: 8px;
   padding-left: 8px;
   color: #666;
-  &:hover {
-    color: @hoverRed;
-    text-decoration: none;
-  }
   &:visited {
     color: #666;
     text-decoration: none;
   }
+  &:hover {
+    color: @hoverRed;
+    text-decoration: none;
+  }
+
 }
 
 .replication__row-btn--no-left-pad {

--- a/app/addons/replication/assets/less/replication.less
+++ b/app/addons/replication/assets/less/replication.less
@@ -275,17 +275,18 @@ input.replication__bulk-select-input[type="checkbox"] {
   padding-right: 8px;
   padding-left: 8px;
   color: #666;
-  &:hover{ color: @hoverRed
+  &:hover {
+    color: @hoverRed;
+    text-decoration: none;
+  }
+  &:visited {
+    color: #666;
+    text-decoration: none;
   }
 }
 
 .replication__row-btn--no-left-pad {
   padding-left: 0px;
-}
-
-.replication__row-btn:visited,
-.replication__row-btn:hover {
-  text-decoration: none;
 }
 
 .replication__row-btn--warning {

--- a/app/addons/replication/components/common-activity.js
+++ b/app/addons/replication/components/common-activity.js
@@ -36,7 +36,7 @@ export const ReplicationHeader = ({filter, onFilterChange}) => {
     <div className="replication__activity_header">
       <div></div>
       <ReplicationFilter value={filter} onChange={onFilterChange} />
-      <a href="#/replication/_create" className="btn save replication__activity_header-btn btn-success">
+      <a href="#/replication/_create" className="btn save replication__activity_header-btn btn-primary">
         <i className="icon fonticon-plus-circled"></i>
         New Replication
       </a>

--- a/app/addons/replication/components/modals.js
+++ b/app/addons/replication/components/modals.js
@@ -30,7 +30,7 @@ export const DeleteModal = ({
 
   let header = "";
   let btnText = `Delete ${isReplicationDB ? 'Document' : 'Replication Job'}`;
-  let infoSection = `Deleting a replication ${isReplicationDB ? 'document' : 'job'} stops continuous replication 
+  let infoSection = `Deleting a replication ${isReplicationDB ? 'document' : 'job'} stops continuous replication
           and incomplete one-time replication, but does not affect replicated documents.`;
 
   if (multipleDocs > 1) {
@@ -137,7 +137,7 @@ export const ConflictModal = ({visible, docId, onClose, onClick}) => {
           Change Document ID
         </button>
         <button onClick={onClick} className="btn replication__error-continue">
-          Overwrite Existing Document
+          <i className="icon icon-eraser" /> Overwrite Existing Document
         </button>
       </Modal.Footer>
     </Modal>

--- a/app/addons/setup/route.js
+++ b/app/addons/setup/route.js
@@ -21,6 +21,7 @@ import {OnePaneSimpleLayout} from '../components/layouts';
 
 var RouteObject = FauxtonAPI.RouteObject.extend({
   roles: ['_admin'],
+  selectedHeader: 'Setup',
 
   routes: {
     'setup': 'setupInitView',

--- a/app/addons/setup/setup.react.jsx
+++ b/app/addons/setup/setup.react.jsx
@@ -341,23 +341,21 @@ var SetupFirstStepController = React.createClass({
       <div className="setup-screen">
         <h2>Welcome to {app.i18n.en_US['couchdb-productname']}!</h2>
         <p>
-          The recommended way to run the wizard is directly on your
-          node (e.g without a Loadbalancer) in front of it.
+          This wizard should be run directly on the node, rather than through a load-balancer.
         </p>
         <p>
-          Do you want to setup a cluster with multiple nodes
-          or just a single node CouchDB installation?
+          You can configure a single node, or a multi-node CouchDB installation.
         </p>
         <div>
           <ConfirmButton
             onClick={this.redirectToMultiNodeSetup}
             showIcon={false}
-            text="Configure	Cluster" />
+            text="Configure	a Cluster" />
           <ConfirmButton
             onClick={this.redirectToSingleNodeSetup}
             showIcon={false}
             id="setup-btn-no-thanks"
-            text="Configure	Single	Node" />
+            text="Configure	a Single Node" />
         </div>
       </div>
     );

--- a/assets/less/bootstrap/close.less
+++ b/assets/less/bootstrap/close.less
@@ -8,15 +8,13 @@
   font-size: 20px;
   font-weight: bold;
   line-height: @baseLineHeight;
-  color: @black;
+  color: #B9B9B9;
   text-shadow: 0 1px 0 rgba(255,255,255,1);
-  .opacity(20);
   &:hover,
   &:focus {
-    color: @black;
+    color: @hoverRed;
     text-decoration: none;
-    cursor: pointer;
-    .opacity(40);
+    cursor: pointer
   }
 }
 

--- a/assets/less/bootstrap/dropdowns.less
+++ b/assets/less/bootstrap/dropdowns.less
@@ -49,7 +49,8 @@
   min-width: 160px;
   margin: 2px 0 0; // override default ul
   list-style: none;
-  background-color: @dropdownBackground;
+  background-color: #564E4C;
+  color: #B3B4B4;
   border: 1px solid #ccc; // Fallback for IE7-8
   border: 1px solid @dropdownBorder;
   *border-right-width: 2px;
@@ -64,8 +65,8 @@
     left: auto;
   }
   li.header-label{
-    background-color: #1A1A1A;
-    color: #676767;
+    background-color: #3A2C2B;
+    color: #FFFFFF;
     padding: 3px 20px;
     font-size: 13px;
   }

--- a/assets/less/formstyles.less
+++ b/assets/less/formstyles.less
@@ -79,22 +79,20 @@ button:focus {
   }
 }
 .btn-primary {
-  background: @brandPrimary;
+  background: #2bb673;
+  color: #fff;
 }
 .btn.btn-danger {
   background-color: #f00;
-  color: #fff;
-}
-.btn.btn-danger:hover {
-  background-color: #e73d34;
   color: #fff;
 }
 .btn.btn-info, .btn-secondary {
   background-color: #0082BF;
   color: #fff;
 }
-.btn.btn-info:hover, .btn-secondary:hover {
-  background-color: #E73D34;
+.btn-primary:hover, .btn-secondary:hover, .btn.btn-danger:hover, .btn.btn-info:hover {
+  background-color: @hoverRed;
+  color: #fff;
 }
 
 .btn-primary a:visited {
@@ -151,9 +149,14 @@ label {
   font-size: 12px;
 }
 
-a.help-link:hover {
+a.help-link{
+  color: @secondaryBlue;
   text-decoration: none;
+  &:hover {
+    color: @hoverRed
+  }
 }
+
 
 input[type=text].error {
   border: red 1px solid;

--- a/assets/less/formstyles.less
+++ b/assets/less/formstyles.less
@@ -267,15 +267,16 @@ div.add-dropdown {
       right: 4px;
     }
     a {
-      background-color: #202326;
-      color: rgba(255, 255, 255, 0.8);
+      background-color: #564E4C;
+      color: #B3B4B4;
       &:hover {
-        background-color: @navBG;
+        background-color: @hoverRed;
         color: white;
       }
     }
     li a {
       padding: 10px 15px 10px 12px;
+
     }
   }
   .dropdown-toggle {
@@ -312,12 +313,8 @@ input.errorHighlight {
 
     }
     &.active {
-      background-color: #f1f1f1;
-      color: #af2d24;
-      &:hover {
-        background-color: #f1f1f1;
-        color: #af2d24;
-      }
+      background-color: #AF2D24;
+      color: #FFFFFF;
       .box-shadow(none);
     }
   }

--- a/assets/less/notification-center.less
+++ b/assets/less/notification-center.less
@@ -27,7 +27,7 @@ body #dashboard #notification-center-btn {
     padding: 17px 16px 16px;
   }
   &:hover {
-    color: @darkRed;
+    color: #E73D34;
   }
 }
 
@@ -233,4 +233,3 @@ body #dashboard #notification-center-btn {
   0% { max-height: 1000px; }
   100% { max-height:0; }
 }
-

--- a/assets/less/prettyprint.less
+++ b/assets/less/prettyprint.less
@@ -20,7 +20,7 @@ pre.prettyprint {
 }
 .prettyprint {
   .pln, .pun, .typ {
-    color: #333;
+    color: #B3B4B4;
   }
   .kwd {
     color: #dddddd;

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -87,7 +87,7 @@
       position: absolute;
       z-index: 100;
       top: 0;
-      background-color: @primaryNav;
+      background-color: @brown;
       width: @navWidth;
       .closeMenu & {
         width: @collapsedNavWidth;
@@ -96,7 +96,7 @@
         height: 4px;
         width: 24px;
         .border-radius(2);
-        background-color: @navBG;
+        background-color: #B3B4B4;
         margin: 2px 0px;
       }
       &:hover div {
@@ -146,7 +146,7 @@
 
           a {
             font-size: 10px;
-            color: @linkColor;
+            color: #B3B4B4;
             padding: 0px;
             text-shadow: none;
             width: 100%;
@@ -155,7 +155,7 @@
           &.active, &:hover {
             a {
               text-decoration: underline;
-              color: @darkRed;
+              color: @red;
             }
           }
         }
@@ -177,13 +177,20 @@
           font-weight: normal;
           font-family: helvetica;
           .box-sizing(border-box);
-          background-color: @navBG;
+          background-color: #564E4C;
           border-bottom:  1px solid @primaryNav;
           height: 48px;
           min-height: 48px;
           position: relative;
 
-          &.active, &:hover {
+          &.active {
+            a {
+              .box-shadow(none);
+            }
+            background-color: #AF2D24;
+            pointer-events: none;
+          }
+          &:hover {
             a {
               .box-shadow(none);
             }
@@ -452,8 +459,8 @@
     .divider {
       border: none;
     }
-    > li > a:hover{
-      background-color: @linkColorHover;
+    > li > a:hover {
+      background-color: @hoverRed;
       color: #fff;
     }
     li.active > a {

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -155,7 +155,7 @@
           &.active, &:hover {
             a {
               text-decoration: underline;
-              color: @red;
+              color: @hoverRed;
             }
           }
         }

--- a/assets/less/variables.less
+++ b/assets/less/variables.less
@@ -14,11 +14,11 @@
 
 /* colors */
 @brown: #3A2C2B;
-@red: #E33F3B;
+@red: #E73D34;
 @orange: #F3622D;
 @darkRed: #AF2D24;
 @linkRed: #DA4F49;
-@greyBrown: #554D4C;
+@greyBrown: #564E4C;
 @greyBrownLighter: #A59D9D;
 @blue: #049cdb;
 @blueDark: #0064cd;
@@ -52,11 +52,11 @@
 @navBGHighlight: @brandPrimary;
 @navBGHover: @brandPrimary;
 @navWidth: 220px;
-@navIconColor: @brandPrimaryDark;
+@navIconColor: #B3B4B4;
 @navIconHighlight: #FFFFFF;
 @bottomNav: @greyBrown;
 @NavIconActive: #ffffff;
-@NavIcon: @brown;
+@NavIcon: #B3B4B4;
 
 /*top header*/
 @breadcrumbBG: #F1F1F1;

--- a/assets/less/variables.less
+++ b/assets/less/variables.less
@@ -28,6 +28,7 @@
 @purple: #7a43b6;
 @hoverOrange: #f3812d;
 @hoverRed: #e73d34;
+@secondaryBlue: #0082BF;
 
 /* brand */
 @brandPrimary: @red;


### PR DESCRIPTION
In main nav:
Updated main nav so that listed items are consistently colored in a base state.
Changed main-nav-icon (and hamburger) colors to be more visible.
Updated "hover" highlighting to hoverRed
![image](https://cloud.githubusercontent.com/assets/12969375/24217865/7a4c8086-0efe-11e7-8d30-e5e881e83dfb.png)

In secondary nav panel, changed hover highlighting to hoverRed.
![image](https://cloud.githubusercontent.com/assets/12969375/24217891/8c3cee98-0efe-11e7-945f-faecb802f6c0.png)

Updated Add New menus' color/interaction scheme to (mostly) match that of primary nav.
![image](https://cloud.githubusercontent.com/assets/12969375/24217907/9bd9745c-0efe-11e7-91e3-23d519065a54.png)
![image](https://cloud.githubusercontent.com/assets/12969375/24217960/c473cfb6-0efe-11e7-9f78-56667ac87e59.png)

Updated brackets/punctuation on JSON cards to a more visible color:
![image](https://cloud.githubusercontent.com/assets/12969375/24217919/a8a6b38e-0efe-11e7-8663-89ce804b4ddf.png)

Updated JSON/Table toggle to consistent active/hover colors
![image](https://cloud.githubusercontent.com/assets/12969375/24217974/d40e4e56-0efe-11e7-9a2f-22c6d39fef35.png)
![image](https://cloud.githubusercontent.com/assets/12969375/24217993/dcfee868-0efe-11e7-8a12-00ac6c2d8a97.png)

Updated "Add Domain" button text/icon in the CORS section, and reduced the input-field length.
![image](https://cloud.githubusercontent.com/assets/12969375/24218016/f5ffb4b4-0efe-11e7-8d19-cceb76ac8541.png)

Updated "Change Password" button text/icon.
![image](https://cloud.githubusercontent.com/assets/12969375/24218057/19fd0704-0eff-11e7-81c6-cc3506e707c1.png)

Updated Database-deletion-modal text and button text/icon.
![image](https://cloud.githubusercontent.com/assets/12969375/24218070/24f72860-0eff-11e7-88f8-da587bea93ed.png)

Re-added hover state to copy-to-clipboard icons.
![image](https://cloud.githubusercontent.com/assets/12969375/24218088/3820e250-0eff-11e7-9d2f-eb81b9bfd38d.png)

Updated hover states on index-wrench icons to hoverRed.
![image](https://cloud.githubusercontent.com/assets/12969375/24218106/470e3074-0eff-11e7-9236-44d018846d31.png)

Updated button text and in-field help text of the Permissions section.
![image](https://cloud.githubusercontent.com/assets/12969375/24218247/c13c2b12-0eff-11e7-96ab-c3bd530cb727.png)

Updated many buttons to primary/secondary styles, and clarified button text .
![image](https://cloud.githubusercontent.com/assets/12969375/24226771/bb5c9b2a-0f25-11e7-8523-927455fc4f26.png)
![image](https://cloud.githubusercontent.com/assets/12969375/24226782/caf01d46-0f25-11e7-9f2d-d8c22dcf7354.png)

Updated breadcrumbs to have consistent active/hover state with rest of CouchDB styles.
![image](https://cloud.githubusercontent.com/assets/12969375/24226792/daf30014-0f25-11e7-9ed7-53e994bd6d57.png)

Updated embedded-help icons to have consistent (secondary) active/hover states.
![image](https://cloud.githubusercontent.com/assets/12969375/24226803/f60df9bc-0f25-11e7-8ab9-6785c77c7a84.png)

Gave hover state to items in doc-editor header
![image](https://cloud.githubusercontent.com/assets/12969375/24226814/061e3894-0f26-11e7-935e-c4663ad2bf6b.png)

Gave hover state to bulk-delete trashcan icon in Replication (still need to do this in other sections, I see)
![image](https://cloud.githubusercontent.com/assets/12969375/24226833/3060623a-0f26-11e7-8435-285e751f186b.png)

Edited Welcome text
![image](https://cloud.githubusercontent.com/assets/12969375/24226844/4232e3e8-0f26-11e7-8510-ca4206cce2fe.png)

Edited Admins text
![image](https://cloud.githubusercontent.com/assets/12969375/24226852/548e4f50-0f26-11e7-9573-2638489c5c18.png)

Edited modal text for doc cloning
![image](https://cloud.githubusercontent.com/assets/12969375/24226879/7474ae40-0f26-11e7-9185-42de3914d6ee.png)

Updated Views/Indexes dropdown panel to match color scheme
![image](https://cloud.githubusercontent.com/assets/12969375/24226894/89f64184-0f26-11e7-8c08-5bd9abb2488e.png)

Styled many cancel buttons to be consistent across the dashboard
![image](https://cloud.githubusercontent.com/assets/12969375/24226906/a336ff1c-0f26-11e7-8c69-78c05f293844.png)

Changed a few instances of in-field explanatory text from imperatives to noun phrases. And made the URL example conventional.
![image](https://cloud.githubusercontent.com/assets/12969375/24226931/c9155d78-0f26-11e7-97ba-347705462fc4.png)

![image](https://cloud.githubusercontent.com/assets/12969375/24226966/f82fa79e-0f26-11e7-8651-fc77529c883f.png)
![image](https://cloud.githubusercontent.com/assets/12969375/24227004/4b4a0870-0f27-11e7-9c50-ed614f66d3ff.png)


