### PR TITLE
Remove extra spacing on dashboard content when navbar minimized

### DIFF
--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -433,9 +433,6 @@
     left: @sidebarWidth;
     right: 0;
     .box-sizing(border-box);
-    .closeMenu & {
-      left: @sidebarWidth+@collapsedNavWidth;
-    }
   }
   .with-tabs-sidebar & {
     overflow: hidden;


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/6378840/24413192/b7850d34-13a8-11e7-8a9e-ac818ff52d24.png)


After:
![image](https://cloud.githubusercontent.com/assets/6378840/24413123/820af60a-13a8-11e7-9ac1-b2b73c48cf3c.png)
