### PR TITLE
Removing persistent scrollbars from navbar

### DIFF
--- a/app/addons/fauxton/assets/less/navigation.less
+++ b/app/addons/fauxton/assets/less/navigation.less
@@ -6,7 +6,8 @@
   top: 0;
   bottom: 0;
   z-index: 5;
-  overflow: scroll;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .faux-navbar nav {


### PR DESCRIPTION
@justin-mcdavid-ibm reported his browser displayed vertical and horizontal scrollbars for the new navbar implementation even when there was no overflowed content.

This css tweak limits scrollbar rendering to vertical only if there is overflow.