### PR TITLE
Robustify Replication Unit Tests

### DIFF
--- a/app/addons/replication/tests/newreplicationSpec.js
+++ b/app/addons/replication/tests/newreplicationSpec.js
@@ -23,8 +23,13 @@ describe('New Replication Component', () => {
 
   describe('validation', () => {
 
+    beforeEach(() => {
+      sinon.stub(FauxtonAPI.session, 'fetchUser');
+    });
+
     afterEach(() => {
       restore(FauxtonAPI.addNotification);
+      restore(FauxtonAPI.session.fetchUser);
     });
 
     it('returns true for local source and target selected', () => {

--- a/app/addons/replication/tests/newreplicationSpec.js
+++ b/app/addons/replication/tests/newreplicationSpec.js
@@ -130,6 +130,15 @@ describe('New Replication Component', () => {
   });
 
   describe('confirmButtonEnabled', () => {
+
+    beforeEach(() => {
+      sinon.stub(FauxtonAPI.session, 'fetchUser');
+    });
+
+    afterEach(() => {
+      restore(FauxtonAPI.session.fetchUser);
+    });
+
     it('returns false for default', () => {
       const newreplication = mount(<NewReplication
         updateFormField={() => {}}
@@ -185,6 +194,14 @@ describe('New Replication Component', () => {
   });
 
   describe("runReplicationChecks", () => {
+
+    beforeEach(() => {
+      sinon.stub(FauxtonAPI.session, 'fetchUser');
+    });
+
+    afterEach(() => {
+      restore(FauxtonAPI.session.fetchUser);
+    });
 
     it("shows conflict modal for existing replication doc", () => {
       let called = false;


### PR DESCRIPTION
Adding an additional stub for FauxtonAPI.session.fetchUser.  I suspect that calling `instance()` on a ReactWrapper forces all imports to be traversed and executed.

fetchUser will trigger an error if it fails [here](https://github.com/apache/couchdb-fauxton/blob/master/app/core/couchdbSession.js#L59-L65), and any upstream components subscribing to the state of the session will respond accordingly.  Because we're unit testing an isolated replication component, any errors triggered by the user session should be ignored.