### PR TITLE
Prevent navbar link underlines

### DIFF
--- a/app/addons/fauxton/assets/less/navigation.less
+++ b/app/addons/fauxton/assets/less/navigation.less
@@ -90,7 +90,7 @@
   text-decoration: none;
 }
 
-.faux-navbar__link:active {
+.faux-navbar__link:active, .faux-navbar__link:focus {
   text-decoration: none;
 }
 


### PR DESCRIPTION
@justin-mcdavid-ibm noticed that the links in the lefthand navbar temporarily receive an underline when they enter a "focus" state.  This PR prevents the temporary underline.