### PR TITLE
New Navbar support for safari

### DIFF
--- a/app/addons/fauxton/assets/less/navigation.less
+++ b/app/addons/fauxton/assets/less/navigation.less
@@ -1,5 +1,4 @@
 .faux-navbar {
-  margin-top: 64px;
   background-color: @brandDark2;
   position: absolute;
   left: 0;
@@ -40,9 +39,6 @@
 .faux-navbar__burger {
   background-color: @brandDark2;
   padding: 19px 0 18px 18px;
-  position: fixed;
-  z-index: 100;
-  top: 0;
 }
 
 .faux-navbar--narrow {

--- a/app/addons/fauxton/navigation/components/NavBar.js
+++ b/app/addons/fauxton/navigation/components/NavBar.js
@@ -73,8 +73,8 @@ class NavBar extends Component {
     return (
       <div className={navClasses}>
         <nav>
-          <Burger isMinimized={isMinimized} toggleMenu={this.toggleMenu}/>
           <div className="faux-navbar__linkcontainer">
+            <Burger isMinimized={isMinimized} toggleMenu={this.toggleMenu}/>
             <div className="faux-navbar__links">
               {navLinks}
               {bottomNavLinks}


### PR DESCRIPTION
@garrensmith reported a bug with the navbar and safari.  The top burger was not rendering correctly, most likely to `position: fixed`.

I've moved the burger inside the flex container to completely remove the fixed positioning.