### PR TITLE
Be explicit about version of Node/npm required

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ See `fauxton --help` for extra options.
 
 ## Setting up Fauxton
 
-Please note that a recent installation of [node.js](http://nodejs.org/) and npm is required.
+Please note that [node.js](http://nodejs.org/) and npm is required. Speciifcally, Fauxton requires at least Node 6 and npm 3.
 
 1. make sure you have CouchDB installed. Instructions on how to install it can be  
 [found here](http://couchdb.readthedocs.org/en/latest/install/index.html)


### PR DESCRIPTION
Recently I traced many Jenkins CI failures to using an outdated version of Node/NPM (Node 4, npm 2). @garrensmith and @janl said this is outdated and that Node 6 / npm 3 was required.

This makes the dependency on these versions explicit.