### PR TITLE
Adding selectedHeader to mango routes

### DIFF
--- a/app/addons/documents/routes-mango.js
+++ b/app/addons/documents/routes-mango.js
@@ -23,6 +23,7 @@ import SidebarActions from "./sidebar/actions";
 import {MangoLayout} from './mangolayout';
 
 const MangoIndexEditorAndQueryEditor = FauxtonAPI.RouteObject.extend({
+  selectedHeader: 'Databases',
   hideApiBar: true,
   hideNotificationCenter: true,
   routes: {


### PR DESCRIPTION
When navigating to Mango in the dashboard we weren't highlighting the "Databases" section of the main nav.