### PR TITLE
Database Pagination updates after receiving new store

### DIFF
--- a/app/addons/databases/__tests__/databasepagination.test.js
+++ b/app/addons/databases/__tests__/databasepagination.test.js
@@ -1,0 +1,47 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import Stores from "../stores";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import DatabaseComponents from "../components";
+import "../../documents/base";
+import DatabaseActions from "../actions";
+import {mount} from 'enzyme';
+
+const store = Stores.databasesStore;
+
+describe('Database Pagination', function () {
+
+  it('renders correct pagination upon store change', () => {
+    DatabaseActions.updateDatabases({
+      dbList: ['db1'],
+      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0}],
+      failedDbs: [],
+      fullDbList: ['db1']
+    });
+
+    const tempStore = {
+      getTotalAmountOfDatabases: () => { return 10; },
+      getPage: () => { return 1; },
+      on: () => {}
+    };
+
+    const pagination = mount(<DatabaseComponents.DatabasePagination store={tempStore} />);
+    expect(pagination.find('.all-db-footer__total-db-count').text()).toMatch('10');
+
+    // switch stores
+    pagination.setProps({store: store});
+    expect(pagination.find('.all-db-footer__total-db-count').text()).toMatch('1');
+  });
+
+});

--- a/app/addons/databases/components.js
+++ b/app/addons/databases/components.js
@@ -307,8 +307,8 @@ var DatabasePagination = React.createClass({
     };
   },
 
-  getStoreState () {
-    const {store} = this.props;
+  getStoreState (props) {
+    const {store} = props;
 
     return {
       totalAmountOfDatabases: store.getTotalAmountOfDatabases(),
@@ -317,12 +317,18 @@ var DatabasePagination = React.createClass({
   },
 
   getInitialState () {
-    return this.getStoreState();
+    return this.getStoreState(this.props);
   },
 
   componentDidMount () {
     const {store} = this.props;
 
+    store.on('change', this.onChange, this);
+  },
+
+  componentWillReceiveProps (nextProps) {
+    this.setState(this.getStoreState(nextProps));
+    const {store} = nextProps;
     store.on('change', this.onChange, this);
   },
 
@@ -332,7 +338,7 @@ var DatabasePagination = React.createClass({
   },
 
   onChange () {
-    this.setState(this.getStoreState());
+    this.setState(this.getStoreState(this.props));
   },
 
   render () {


### PR DESCRIPTION
The DatabasePagination component allows for a `store` prop even though it's not required.  If the component receives a new set of props and one of them is a `store`, we need to make sure that the component continues to update when the new `store` changes.