### PR TITLE
Fix table for url with special char in password

### DIFF
--- a/app/addons/replication/__tests__/common-table.test.js
+++ b/app/addons/replication/__tests__/common-table.test.js
@@ -1,0 +1,32 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+import utils from "../../../../test/mocha/testUtils";
+import { shallow } from 'enzyme';
+import {formatUrl} from '../components/common-table';
+
+const {assert}  = utils;
+
+describe('Common Table Component', () => {
+  describe("formatUrl", () => {
+    it("renders a url with tricky password characters", () => {
+      const url = "http://hello:h#$!^@couchdb.com/my-db";
+      const el = shallow(formatUrl(url));
+      assert.equal(el.find('a').prop('href'), '#/database/my-db/_all_docs');
+    });
+
+    it("renders a url with no password characters", () => {
+      const url = "http://couchdb.com/my-db";
+      const el = shallow(formatUrl(url));
+      assert.equal(el.find('a').prop('href'), '#/database/my-db/_all_docs');
+    });
+  });
+});

--- a/app/addons/replication/components/common-table.js
+++ b/app/addons/replication/components/common-table.js
@@ -13,9 +13,10 @@ import React from 'react';
 import {Table, Tooltip, OverlayTrigger} from "react-bootstrap";
 import moment from 'moment';
 import {ErrorModal} from './modals';
+import {removeCredentialsFromUrl} from '../api';
 
-const formatUrl = (url) => {
-  const urlObj = new URL(url);
+export const formatUrl = (url) => {
+  const urlObj = new URL(removeCredentialsFromUrl(url));
   const encoded = encodeURIComponent(urlObj.pathname.slice(1));
 
   if (url.indexOf(window.location.hostname) > -1) {


### PR DESCRIPTION
Fixes an issue where the replication activity table wouldn't render if a
url had a password with a special character in it