### PR TITLE
Add/update contribution guidelines, issue/PR templates for GH Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Browser Name and version:
+* Operating System and version (desktop or mobile):
+* Link to your project:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!-- Thank you for your contribution!
+
+     Please file this form by replacing the Markdown comments
+     with your text. If a section needs no action - remove it.
+
+     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
+     of code collaboration. Positive feedback is represented +1 from committers
+     and negative is a -1. The -1 also means veto, and needs to be addressed
+     to proceed. Once there are no objections, the PR can be merged by a
+     CouchDB committer.
+
+     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->
+
+## Overview
+
+<!-- Please give a short brief for the pull request,
+     what problem it solves or how it makes things better. -->
+
+## Testing recommendations
+
+<!-- Describe how we can test your changes.
+     Does it provides any behaviour that the end users
+     could notice? -->
+
+## GitHub issue number
+
+<!-- If this is a significant change, please file a separate issue at:
+     https://github.com/apache/couchdb-fauxton/issues
+     and include the number here and in commit message(s) using
+     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->
+
+## Related Pull Requests
+
+<!-- If your changes affects multiple components in different
+     repositories please put links to those pull requests here.  -->
+
+## Checklist
+
+- [ ] Code is written and works correctly;
+- [ ] Changes are covered by tests;
+- [ ] Documentation reflects the changes;
+- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,24 @@
 # Contributing to Fauxton
 
-CouchDB is an Apache project, which is why we keep all our issues in Jira.  You can find or submit issues for Fauxton 
-[here](https://issues.apache.org/jira/issues/?jql=project%20%3D%20COUCHDB%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20Fauxton%20ORDER%20BY%20priority%20DESC).
+Please take a moment to review this document in order to make the contribution
+process easy and effective for everyone involved.
 
-We try to keep all tickets up to date with Skill level for you to have an idea of the level of effort or comfort 
-with the framework you'd need to complete the task.
+Following these guidelines helps to communicate that you respect the time of
+the developers managing and developing this open source project. In return,
+they should reciprocate that respect in addressing your issue, assessing
+changes, and helping you finalize your pull requests.
 
-The [Readme file](https://github.com/apache/couchdb-fauxton/blob/master/readme.md) has information about how to get the project running.
+Contributions to CouchDB are governed by our [Code of Conduct][6] and a set of
+[Project Bylaws][7]. Apache CouchDB itself also has a [CONTRIBUTING.md][9] if
+you want to help with the larger project. Come join us!
+
 
 ## Contributor quick start
+
+If you never created a pull request before, welcome :tada: :smile: [Here is a great tutorial](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
+on how to send one :)
+
+The [Readme file](https://github.com/apache/couchdb-fauxton/blob/master/readme.md) has information about how to get the project running.
 
 Instructions to get a dev environment up and running as fast as possible:
 
@@ -47,16 +57,17 @@ Now run:
 
 And your Fauxton dev server will be up and running at `localhost:8000`.
 
+
 ## Guide to Contributions
 
 We follow our coding-styleguide to make it easier for everyone to write, read and review code: 
 [https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md](https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md)
 
-To start working on a specific ticket, create a branch with the Jira ID # followed by a traincase description of the issue.
+To start working on a specific ticket, create a branch with the GitHub Issue # followed by a traincase description of the issue.
 
 > e.g.   1234-Added-support-for-list-functions
 
-If there is no Jira ticket for the issue you have, you don't have to create one.
+If there is no GH Issue for the issue you have, you don't have to create one.
 
 Please describe the issue, how it happens and how you fixed it in the commit message. Before you submit the Pull 
 Request, please run our testsuite and make sure that it passes:
@@ -77,12 +88,13 @@ Followed by further explanation if needed, this should be wrapped at
 around 72 characters. Most commits should reference an existing
 issue
 
-Closes COUCHDB-XXXX (if there is a Jira ticket)
+Fixes #XXX (if there is a GH Issue)
+Fixes apache/couchdb#XXX (if there is a CouchDB project GH Issue)
 ```
 
 When you're ready for a review, submit a Pull Request. We regularly check the PR list for Fauxton and should get back 
-to you with a code review.  If no one has responded to you yet, you can find us on IRC in #couchdb-dev.  
-Ping **Garren**, **robertkowalski** or **michellep** though anyone in the room should be able to help you.
+to you with a code review.  If no one has responded to you yet, you can find us on [Freenode IRC in #couchdb-dev][8].
+Ping **garren**, **robertkowalski** or **michellep** though anyone in the room should be able to help you.
 
 ## Get in Touch
 
@@ -93,4 +105,8 @@ there is room for improvement.
 
 -- Fauxton team
 
-PS - If you are new to contributing to open source, or using GitHub reach out to us on irc (#couchdb-dev)! We will happily help you.
+
+[6]: http://couchdb.apache.org/conduct.html
+[7]: http://couchdb.apache.org/bylaws.html
+[8]: http://webchat.freenode.net?channels=%23couchdb-dev
+[9]: https://github.com/apache/couchdb/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
## Overview

We're getting ready to move from JIRA to GH Issues. This PR removes references to JIRA and expands our user experience by adding or updating a CONTRIBUTING.md file and GH Issue and PR templates. It also updates the README file to reflect these changes.

As Fauxton already had a fairly rich CONTRIBUTING.md file, I didn't update with everything I put in the main CouchDB CONTRIBUTING.md file. Instead I just put a link to our main one. You may, though, want to merge the two yourselves in the future - there's some good stuff in there for absolute beginners that might encourage new contributors.

## Related Pull Requests
Similar PRs are being issued in all repos officially hosted on GitHub:
* apache/couchdb
* apache/couchdb-docker
* apache/couchdb-documentation
* apache/couchdb-fauxton
* apache/couchdb-nano
* apache/couchdb-pkg