### PR TITLE
Design Docs filtered view occasionally incorrect

### DIFF
--- a/app/addons/documents/__tests__/query-options.test.js
+++ b/app/addons/documents/__tests__/query-options.test.js
@@ -68,7 +68,7 @@ describe('QueryOptions', () => {
     expect(spy.calledOnce).toBe(true);
   });
 
-  it('calls queryOptionsFilterOnlyDdocs if ddocsOnly switches to true on new props', () => {
+  it('calls resetState and queryOptionsFilterOnlyDdocs if ddocsOnly switches to true on new props', () => {
     const spy = sinon.spy();
     const queryOptionsParams = {
       include_docs: false
@@ -76,6 +76,7 @@ describe('QueryOptions', () => {
 
     const wrapper = shallow(<QueryOptions
       ddocsOnly={false}
+      resetState={spy}
       queryOptionsFilterOnlyDdocs={spy}
       queryOptionsExecute={() => {}}
       resetPagination={() => {}}
@@ -89,7 +90,7 @@ describe('QueryOptions', () => {
     wrapper.instance().componentWillReceiveProps({
       ddocsOnly: true
     });
-    expect(spy.calledOnce).toBe(true);
+    expect(spy.calledTwice).toBe(true);
   });
 
   it('calls resetState if ddocsOnly switches to false on new props', () => {

--- a/app/addons/documents/index-results/components/queryoptions/QueryOptions.js
+++ b/app/addons/documents/index-results/components/queryoptions/QueryOptions.js
@@ -42,6 +42,7 @@ export default class QueryOptions extends React.Component {
     } = this.props;
 
     if (!ddocsOnly && nextProps.ddocsOnly) {
+      resetState();
       queryOptionsFilterOnlyDdocs();
     } else if (ddocsOnly && !nextProps.ddocsOnly) {
       resetState();


### PR DESCRIPTION
## Overview

This PR fixes a bug where fauxton would display no results when switching to the Design Docs filter within _all_docs.  This bug occurred when the user had previously paginated forward several pages within _all_docs, adversely affected this filtered view.

## Testing recommendations

1. View the Design Docs filter of _all_docs.  Ensure that the results are correct.
2. Switch to _all_docs and paginate forward enough times where the "skip" parameter is now greater than the number of total design documents in the database.
3. Switch back to the Design Docs filter.  Ensure the results are correct.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
