### PR TITLE
switch urls to use FauxtonAPI.urls and fix resetState

### DIFF
--- a/app/addons/documents/__tests__/fetch-api.test.js
+++ b/app/addons/documents/__tests__/fetch-api.test.js
@@ -23,6 +23,7 @@ import queryString from 'query-string';
 import sinon from 'sinon';
 import SidebarActions from '../sidebar/actions';
 import FauxtonAPI from '../../../core/api';
+import '../base';
 
 describe('Docs Fetch API', () => {
   describe('mergeParams', () => {
@@ -280,7 +281,8 @@ describe('Docs Fetch API', () => {
           }
         ];
         const databaseName = 'testdb';
-        fetchMock.postOnce(`/${databaseName}/_bulk_docs`, res);
+
+        fetchMock.postOnce(FauxtonAPI.urls('bulk_docs', 'server', databaseName), res);
         return postToBulkDocs(databaseName, payload).then((json) => {
           expect(json).toEqual(res);
         });

--- a/app/addons/documents/__tests__/reducers.test.js
+++ b/app/addons/documents/__tests__/reducers.test.js
@@ -65,6 +65,23 @@ describe('Docs Reducers', () => {
     }
   };
 
+  it('resets selectedDocs on state reset', () => {
+    const action = {
+      type: ActionTypes.INDEX_RESULTS_REDUX_NEW_SELECTED_DOCS,
+      selectedDocs: [{_id: '1'}]
+    };
+
+    const newState = Reducers.default(initialState, action);
+
+    const resetAction = {
+      type: ActionTypes.INDEX_RESULTS_REDUX_RESET_STATE
+    };
+
+    const newState2 = Reducers.default(newState, resetAction);
+    expect(newState2.selectedDocs).toEqual([]);
+
+  });
+
   it('getDocs returns the docs attribute from the state', () => {
     const action = {
       type: ActionTypes.INDEX_RESULTS_REDUX_NEW_RESULTS,

--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -61,7 +61,7 @@ FauxtonAPI.registerUrls('allDocsSanitized', {
 
 FauxtonAPI.registerUrls('bulk_docs', {
   server: function (id, query) {
-    return app.host + '/' + id + '/_bulk_docs' + getQueryParam(query);
+    return app.host + '/' + encodeURIComponent(id) + '/_bulk_docs' + getQueryParam(query);
   },
   app: function (id, query) {
     return 'database/' + id + '/_bulk_docs' + getQueryParam(query);

--- a/app/addons/documents/index-results/apis/fetch.js
+++ b/app/addons/documents/index-results/apis/fetch.js
@@ -104,7 +104,8 @@ export const fetchAllDocs = (fetchUrl, fetchParams, queryOptionsParams) => {
 
 export const queryEndpoint = (fetchUrl, params) => {
   const query = queryString.stringify(params);
-  return fetch(`${fetchUrl}?${query}`, {
+  const url = `${fetchUrl}${fetchUrl.includes('?') ? '&' : '?'}${query}`;
+  return fetch(url, {
     credentials: 'include',
     headers: {
       'Accept': 'application/json; charset=utf-8'
@@ -169,7 +170,8 @@ export const bulkDeleteDocs = (databaseName, fetchUrl, docs, designDocs, fetchPa
 };
 
 export const postToBulkDocs = (databaseName, payload) => {
-  return fetch(`/${databaseName}/_bulk_docs`, {
+  const url = FauxtonAPI.urls('bulk_docs', 'server', databaseName);
+  return fetch(url, {
     method: 'POST',
     credentials: 'include',
     body: JSON.stringify(payload),

--- a/app/addons/documents/index-results/reducers.js
+++ b/app/addons/documents/index-results/reducers.js
@@ -64,6 +64,7 @@ export default function resultsState (state = initialState, action) {
 
     case ActionTypes.INDEX_RESULTS_REDUX_RESET_STATE:
       return Object.assign({}, initialState, {
+        selectedDocs: [],
         fetchParams: {
           limit: getDefaultPerPage() + 1,
           skip: 0

--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -87,7 +87,8 @@ var DocumentsRouteObject = BaseRoute.extend({
           urlParams = params.urlParams,
           docParams = params.docParams;
 
-    const url = `/${encodeURIComponent(databaseName)}/_all_docs`;
+    const url = FauxtonAPI.urls('allDocsSanitized', 'server', databaseName);
+
     // this is used for the header and sidebar
     this.database.buildAllDocs(docParams);
 


### PR DESCRIPTION
Use FauxtonAPI.Urls for some of the new urls in the table view. Fix an issue with the selectedDocs that it wasn't persisting across resets.

## Testing recommendations
All tests passing should prove this works



