### PR TITLE
Fixes documents per page issue with mango

### DIFF
--- a/app/addons/documents/doc-editor/tests/doc-editor.componentsSpec.js
+++ b/app/addons/documents/doc-editor/tests/doc-editor.componentsSpec.js
@@ -20,6 +20,7 @@ import ActionTypes from "../actiontypes";
 import Databases from "../../../databases/base";
 import utils from "../../../../../test/mocha/testUtils";
 import TestUtils from "react-addons-test-utils";
+import '../../base';
 
 var assert = utils.assert;
 var docJSON = {

--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -230,6 +230,10 @@ Documents.MangoDocumentCollection = PagingCollection.extend({
   },
 
   getPaginatedQuery: function () {
+    if (!this.query) {
+      return this.query;
+    }
+
     var paginatedQuery = JSON.parse(JSON.stringify(this.query));
 
     if (!this.paging.direction && this.paging.params.limit > 0) {
@@ -254,6 +258,14 @@ Documents.MangoDocumentCollection = PagingCollection.extend({
         promise = FauxtonAPI.Deferred(),
         query = this.getPaginatedQuery();
 
+    //this section can get called when updating page
+    //and the query options might not have been selected yet
+    //so we just return and don't do a fetch
+    if (!query) {
+      promise.resolve();
+      return promise;
+    }
+
     $.ajax({
       type: 'POST',
       url: url,
@@ -261,12 +273,11 @@ Documents.MangoDocumentCollection = PagingCollection.extend({
       dataType: 'json',
       data: JSON.stringify(query),
     })
-    .then(function (res) {
+    .then(res => {
       this.handleResponse(res, promise);
-    }.bind(this))
-    .fail(function (res) {
+    }, res => {
       promise.reject(res.responseJSON);
-    }.bind(this));
+    });
 
     return promise;
   },


### PR DESCRIPTION
This fixes the issue if you try to change the documents per page on the
mango query page before you have done a query it would fail

## Testing recommendations

Click on the query button in a database. Click update documents per page and change the value. Then click `Run Query`. This should all work and return results.

