### PR TITLE
Set safeUrlName to always encode a name

### DIFF
--- a/app/core/tests/utilsSpec.js
+++ b/app/core/tests/utilsSpec.js
@@ -48,11 +48,6 @@ describe('Utils', function () {
 
   describe('safeURLName', function () {
 
-    it('is idempotent', function () {
-      assert.equal('foo-bar%2Fbaz', utils.safeURLName(utils.safeURLName('foo-bar/baz')));
-      assert.equal('foo-bar%2Bbaz', utils.safeURLName(utils.safeURLName('foo-bar+baz')));
-    });
-
     it('encodes special chars', function () {
       assert.equal('foo-bar%2Fbaz', utils.safeURLName('foo-bar/baz'));
     });

--- a/app/core/tests/utilsSpec.js
+++ b/app/core/tests/utilsSpec.js
@@ -51,6 +51,10 @@ describe('Utils', function () {
     it('encodes special chars', function () {
       assert.equal('foo-bar%2Fbaz', utils.safeURLName('foo-bar/baz'));
     });
+
+    it('encodes an encoded doc', function () {
+      assert.equal('foo-bar%252Fbaz', utils.safeURLName('foo-bar%2Fbaz'));
+    });
   });
 
   describe('isSystemDatabase', function () {

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -67,7 +67,8 @@ const utils = {
   safeURLName: function (name = "") {
     // These special caracters are allowed by couch: _, $, (, ), +, -, and /
     // From them only $ + and / are to be escaped in a URI component.
-    return (/[$+/]/g.test(name)) ? encodeURIComponent(name) : name;
+    // return (/[$+/]/g.test(name)) ? encodeURIComponent(name) : name;
+    return encodeURIComponent(name);
   },
 
   getDocTypeFromId: function (id) {


### PR DESCRIPTION
Sometimes a document can be double encoded before saved into CouchDB. We need to support that use case. That means we must always encode the name given to `safeUrlName`.
