### PR TITLE
Show a warning in Fauxton when no Mango index is available

### DIFF
--- a/app/addons/documents/index-results/actions.js
+++ b/app/addons/documents/index-results/actions.js
@@ -45,6 +45,17 @@ export default {
     });
   },
 
+  notifyOfWarnings: function (options) {
+    var msg = options.collection.warning && options.collection.warning();
+    if (msg) {
+      FauxtonAPI.addNotification({
+        msg: msg,
+        clear:  false,
+        type: 'error'
+      });
+    }
+  },
+
   newResultsList: function (options) {
     this.clearResults();
 
@@ -87,6 +98,8 @@ export default {
   },
 
   newMangoResultsList: function (options) {
+    this.notifyOfWarnings(options);
+
     FauxtonAPI.dispatch({
       type: ActionTypes.INDEX_RESULTS_NEW_RESULTS,
       options: options

--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -179,6 +179,7 @@ Documents.MangoDocumentCollection = PagingCollection.extend({
   initialize: function (_attr, options) {
     var defaultLimit = FauxtonAPI.constants.MISC.DEFAULT_PAGE_SIZE;
 
+    this._warning = null;
     this.database = options.database;
     this.params = _.extend({limit: defaultLimit}, options.params);
 
@@ -196,6 +197,10 @@ Documents.MangoDocumentCollection = PagingCollection.extend({
 
   url: function () {
     return this.urlRef.apply(this, arguments);
+  },
+
+  warning: function () {
+    return this._warning;
   },
 
   updateSeq: function () {
@@ -286,6 +291,8 @@ Documents.MangoDocumentCollection = PagingCollection.extend({
     var rows = resp.docs;
 
     this.paging.hasNext = this.paging.hasPrevious = false;
+
+    this._warning = resp.warning;
 
     this.viewMeta = {
       total_rows: resp.total_rows,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Mango allows queries to run without an index by performing a full
database scan. Whilst this is useful in some scenarios, Couch
returns a warning in the response that an index should be created
if performance is important. This warning is now propagated
to Fauxton using the existing alert infrastructure.

## Testing recommendations

In Fauxton, run a Mango query that does not match an available index. You should see an alert at the top of the UI and in the alert sidebar.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
