### PR TITLE
Reduce the whitespace around index results

### DIFF
--- a/app/addons/components/assets/less/docs.less
+++ b/app/addons/components/assets/less/docs.less
@@ -33,7 +33,7 @@
       header {
         font-weight: bold;
         position: relative;
-        padding: 20px;
+        padding: 5px 10px;
         background-color: @docHeaderBG;
         border-bottom: 1px solid @docHeaderBorderBottom;
         border-left: 1px solid @docHeaderOtherBorders;
@@ -41,18 +41,23 @@
         border-top: 1px solid @docHeaderOtherBorders;
         .header-doc-id {
           color: @docHeaderDocId;
-          margin-left: 10px;
+          margin-left: 0;
         }
-        .header-keylabel,
+        .header-keylabel {
+          margin-right: 10px;
+        }
+        .header-keylabel:empty
+        {
+          display:none;
+        }
         .fonticon-pencil {
           color: @docHeaderLabels;
         }
         .doc-edit-symbol {
-          top: -3px;
           position: relative;
         }
         .fonticon-pencil {
-          font-size: 20px;
+          font-size: 16px;
         }
         .fonticon-pencil:hover {
           color: @hoverHighlight;
@@ -75,7 +80,7 @@
     }
   }
   .checkbox.inline {
-    padding-top: 32px;
+    padding-top: 17px;
     padding-left: 0;
     label {
       padding-left: 23px; // 7px to the right-border + 16px around


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

There's an awful lot of unused screen when viewing JSON results
(all docs, mango queries, etc). This reduces the margin and padding
to improve information density.

## Testing recommendations

View JSON results in Fauxton - all docs, mango query results, map/reduce results.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
