### PR TITLE
Update how Create Document link is created to allow overriding it

### DIFF
--- a/app/addons/documents/components/results-toolbar.js
+++ b/app/addons/documents/components/results-toolbar.js
@@ -13,7 +13,7 @@ import React from 'react';
 import BulkDocumentHeaderController from "../header/header";
 import Stores from "../sidebar/stores";
 import Components from "../../components/react-components";
-import app from '../../../app';
+import Helpers from '../helpers';
 
 const {BulkActionComponent} = Components;
 const store = Stores.sidebarStore;
@@ -55,10 +55,9 @@ export class ResultsToolBar extends React.Component {
 
     let createDocumentLink = null;
     if (database) {
-      const safeDatabaseId = app.utils.safeURLName(database.id);
       createDocumentLink = (
         <div className="document-result-screen__toolbar-flex-container">
-          <a href={`#/database/${safeDatabaseId}/new`} className="btn save document-result-screen__toolbar-create-btn btn-primary">
+          <a href={Helpers.getNewDocUrl(database.id)} className="btn save document-result-screen__toolbar-create-btn btn-primary">
             Create Document
           </a>
         </div>

--- a/app/addons/documents/helpers.js
+++ b/app/addons/documents/helpers.js
@@ -89,10 +89,16 @@ const truncateDoc = (docString, maxRows) => {
   };
 };
 
+const getNewDocUrl = (databaseName) => {
+  const safeDatabaseName = encodeURIComponent(databaseName);
+  return FauxtonAPI.urls('new', 'newDocument', safeDatabaseName);
+};
+
 export default {
   getSeqNum,
   getNewButtonLinks,
   getModifyDatabaseLinks,
+  getNewDocUrl,
   parseJSON,
   truncateDoc
 };

--- a/app/addons/documents/tests/nightwatch/createsDocument.js
+++ b/app/addons/documents/tests/nightwatch/createsDocument.js
@@ -71,7 +71,7 @@ module.exports = {
       .waitForElementPresent('.tableview-checkbox-cell', waitTime, false)
       .clickWhenVisible('.document-result-screen__toolbar-create-btn')
       .waitForElementPresent('#editor-container', waitTime, false)
-      .verify.urlEquals(baseUrl + '/#/database/' + newDatabaseName + '/new')
+      .verify.urlEquals(baseUrl + '/#database/' + newDatabaseName + '/new')
       .waitForElementPresent('.ace_gutter-active-line', waitTime, false)
 
       // confirm the header elements are showing up


### PR DESCRIPTION
## Overview

Changes how the URL for the __Create Document__ button is generated so it can be overriden by a `urls:interceptors` extension.

## Testing recommendations

- Go to _your_database_ > All Documents, then click the __Create Document__ button. Click on __Save Changes__ and verify the document was created.
- Go to _your_database_ > Run a Query with Mango, then click the __Create Document__ button. Click on __Save Changes__ and verify the document was created.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
