### PR TITLE
Use monospace fonts for JSON query results

### DIFF
--- a/app/addons/components/assets/less/docs.less
+++ b/app/addons/components/assets/less/docs.less
@@ -29,6 +29,7 @@
         border-bottom: 1px solid @docHeaderBorderBottom;
         border-left: 1px solid @docHeaderOtherBorders;
         border-right: 1px solid @docHeaderOtherBorders;
+        font-family: monospace;
       }
       header {
         font-weight: bold;

--- a/assets/less/prettyprint.less
+++ b/assets/less/prettyprint.less
@@ -13,7 +13,6 @@
 pre.prettyprint {
   background: @defaultText;
   border: none;
-  font-size: 83%;
   line-height: 1.4;
   margin: 0;
   padding: 16px;


### PR DESCRIPTION
## Overview

Use monospace fonts when displaying JSON in query results. This also removes the apparently arbitrary 83% font-sizing applied to pretty-printed JSON which overrides the default size of 13px.

## Testing recommendations

Run some queries in Fauxton.

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
