### PR TITLE
Fix for Mango Query addon when db name has special characters

### DIFF
--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -203,7 +203,7 @@ FauxtonAPI.registerUrls('mango', {
   },
 
   'index-server-bulk-delete': function (db) {
-    return app.host + '/' + encodeURIComponent(db) + '/_index/_bulk_delete';
+    return app.host + '/' + db + '/_index/_bulk_delete';
   },
 
   'query-server': function (db, query) {
@@ -231,11 +231,11 @@ FauxtonAPI.registerUrls('mango', {
   },
 
   'explain-server': function (db) {
-    return app.host + '/' + app.utils.safeURLName(db) + '/_explain';
+    return app.host + '/' + db + '/_explain';
   },
 
   'explain-apiurl': function (db) {
-    return window.location.origin + '/' + app.utils.safeURLName(db) + '/_explain';
+    return window.location.origin + '/' + db + '/_explain';
   }
 });
 

--- a/app/addons/documents/index-results/api.js
+++ b/app/addons/documents/index-results/api.js
@@ -50,7 +50,7 @@ export const postToBulkDocs = (databaseName, payload) => {
 };
 
 export const postToIndexBulkDelete = (databaseName, payload) => {
-  const url = FauxtonAPI.urls('mango', 'index-server-bulk-delete', databaseName);
+  const url = FauxtonAPI.urls('mango', 'index-server-bulk-delete', encodeURIComponent(databaseName));
   return fetch(url, {
     method: 'POST',
     credentials: 'include',

--- a/app/addons/documents/index-results/api.js
+++ b/app/addons/documents/index-results/api.js
@@ -26,10 +26,12 @@ export const queryAllDocs = (fetchUrl, params) => {
     }
   })
   .then(res => res.json())
-  .then(res => {
+  .then(json => {
+    if (json.error) {
+      throw new Error('(' + json.error + ') ' + json.reason);
+    }
     return {
-      //TODO: handle error situation
-      docs: res.error ? [] : res.rows,
+      docs: json.rows,
       docType: Constants.INDEX_RESULTS_DOC_TYPE.VIEW
     };
   });

--- a/app/addons/documents/mango/mango.api.js
+++ b/app/addons/documents/mango/mango.api.js
@@ -17,7 +17,7 @@ import FauxtonAPI from "../../../core/api";
 import Constants from '../constants';
 
 export const fetchQueryExplain = (databaseName, queryCode) => {
-  const url = FauxtonAPI.urls('mango', 'explain-server', databaseName);
+  const url = FauxtonAPI.urls('mango', 'explain-server', encodeURIComponent(databaseName));
 
   return fetch(url, {
     headers: {
@@ -105,7 +105,7 @@ export const mergeFetchParams = (queryCode, fetchParams) => {
 };
 
 export const mangoQueryDocs = (databaseName, queryCode, fetchParams) => {
-  const url = FauxtonAPI.urls('mango', 'query-server', databaseName);
+  const url = FauxtonAPI.urls('mango', 'query-server', encodeURIComponent(databaseName));
   const modifiedQuery = mergeFetchParams(queryCode, fetchParams);
   return fetch(url, {
     headers: {

--- a/app/addons/documents/mangolayout.js
+++ b/app/addons/documents/mangolayout.js
@@ -123,7 +123,7 @@ class MangoLayout extends Component {
     let endpoint = this.props.endpoint;
 
     if (this.props.explainPlan) {
-      endpoint = FauxtonAPI.urls('mango', 'explain-apiurl', database);
+      endpoint = FauxtonAPI.urls('mango', 'explain-apiurl', encodeURIComponent(database));
     }
     let queryFunction = (params) => { return MangoAPI.mangoQueryDocs(databaseName, queryFindCode, params); };
     let docType = Constants.INDEX_RESULTS_DOC_TYPE.MANGO_QUERY;

--- a/app/addons/documents/routes-mango.js
+++ b/app/addons/documents/routes-mango.js
@@ -53,7 +53,7 @@ const MangoIndexEditorAndQueryEditor = FauxtonAPI.RouteObject.extend({
       {name: app.i18n.en_US['mango-title-editor']}
     ];
 
-    const endpoint = FauxtonAPI.urls('mango', 'query-apiurl', this.databaseName);
+    const endpoint = FauxtonAPI.urls('mango', 'query-apiurl', encodeURIComponent(this.databaseName));
 
     return <MangoLayoutContainer
       database={database}
@@ -84,7 +84,7 @@ const MangoIndexEditorAndQueryEditor = FauxtonAPI.RouteObject.extend({
     const url = FauxtonAPI.urls(
       'allDocs', 'app', encodeURIComponent(this.databaseName), '?limit=' + FauxtonAPI.constants.DATABASES.DOCUMENT_LIMIT
     );
-    const endpoint = FauxtonAPI.urls('mango', 'index-apiurl', this.databaseName);
+    const endpoint = FauxtonAPI.urls('mango', 'index-apiurl', encodeURIComponent(this.databaseName));
 
     const crumbs = [
       {name: database, link: url},


### PR DESCRIPTION
## Overview

Fix issues with Mango queries and deletion of indexes when database name contain special characters (e.g. `special/name`)
Also added error handling for `queryAllDocs`

## Testing recommendations

- Create database named `special/name` and create a few documents in it
- Execute a Mango query on this database
- Try to delete one or more docs
- Click on __Manage Indexes__ and create a new index
- Try to delete the new index
