### PR TITLE
Update React to 15.6.2 (MIT-licensed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "optimist": "^0.6.1",
     "pouchdb-adapter-http": "^6.1.2",
     "pouchdb-core": "^6.1.2",
-    "react": "~15.4.1",
+    "react": "~15.6.2",
     "react-bootstrap": "^0.30.7",
     "react-dom": "~15.4.1",
     "react-motion": "^0.5.0",


### PR DESCRIPTION
A PR against apache/couchdb will need to be filed once this lands,
changing the licensing info for react from BSD+Patents to MIT.

Closes #968
Closes #970
Closes #964
Closes #969
Closes #965
Closes #966
Closes #967