### PR TITLE
Update code editor's contents when a new document is loaded

### DIFF
--- a/app/addons/documents/doc-editor/components.js
+++ b/app/addons/documents/doc-editor/components.js
@@ -84,9 +84,11 @@ var DocEditorController = React.createClass({
     store.off('change', this.onChange);
   },
 
-  // whenever a file is uploaded or a doc is cloned update the editor
   componentWillUpdate: function (nextProps, nextState) {
-    if (this.state.numFilesUploaded !== nextState.numFilesUploaded || this.state.doc && this.state.doc.hasChanged()) {
+    // Update the editor whenever a file is uploaded, a doc is cloned, or a new doc is loaded
+    if (this.state.numFilesUploaded !== nextState.numFilesUploaded ||
+        this.state.doc && this.state.doc.hasChanged() ||
+        (this.state.doc && nextState.doc && this.state.doc.id !== nextState.doc.id)) {
       this.getEditor().setValue(JSON.stringify(nextState.doc.attributes, null, '  '));
       this.onSaveComplete();
     }


### PR DESCRIPTION
## Overview

 Code editor is not updated when switching to a different document by typing a new URL directly in the browser's address bar.

## Testing recommendations

- Navigate to some document. The URL in your bar will be `http://blah/_utils/#database/db-name/document-name-1`. You can see the JSON of `document-name-1`
- Change the URL to another document, say, `http://blah/_utils/#database/db-name/document-name-2`. Hit enter.
- The JSON of `document-name-2` should be displayed. The page header displays the new document ID.

## GitHub issue number

Closes #977
