### PR TITLE
Fix View Attachments menu and upload modal in doc editor

### DIFF
--- a/app/addons/documents/doc-editor/actions.js
+++ b/app/addons/documents/doc-editor/actions.js
@@ -173,6 +173,9 @@ function uploadAttachment (params) {
     type: 'PUT',
     data: file,
     contentType: file.type,
+    headers: {
+      Accept: "application/json; charset=utf-8"
+    },
     processData: false,
     xhrFields: {
       withCredentials: true
@@ -214,7 +217,7 @@ function uploadAttachment (params) {
       FauxtonAPI.dispatch({
         type: ActionTypes.FILE_UPLOAD_ERROR,
         options: {
-          error: JSON.parse(resp.responseText).reason
+          error: resp.responseJSON ? resp.responseJSON.reason : 'Error uploading file: (' + resp.statusText + ')'
         }
       });
     }

--- a/app/addons/documents/doc-editor/components.js
+++ b/app/addons/documents/doc-editor/components.js
@@ -17,6 +17,7 @@ import app from "../../../app";
 import PropTypes from 'prop-types';
 
 import React from "react";
+import { Dropdown, MenuItem } from "react-bootstrap";
 import ReactDOM from "react-dom";
 import Actions from "./actions";
 import Stores from "./stores";
@@ -224,12 +225,11 @@ class AttachmentsPanelButton extends React.Component {
     return _.map(this.props.doc.get('_attachments'), function (item, filename) {
       var url = FauxtonAPI.urls('document', 'attachment', db, doc, app.utils.safeURLName(filename));
       return (
-        <li key={filename}>
-          <a href={url} target="_blank" data-bypass="true"> <strong>{filename}</strong>
-            <span className="attachment-delimiter">-</span>
-            <span>{item.content_type}, {Helpers.formatSize(item.length)}</span>
-          </a>
-        </li>
+        <MenuItem key={filename} href={url} target="_blank" data-bypass="true">
+          <strong>{filename}</strong>
+          <span className="attachment-delimiter">-</span>
+          <span>{item.content_type}{item.content_type ? ', ' : ''}{Helpers.formatSize(item.length)}</span>
+        </MenuItem>
       );
     });
   };
@@ -241,15 +241,16 @@ class AttachmentsPanelButton extends React.Component {
 
     return (
       <div className="panel-section view-attachments-section btn-group">
-        <button className="panel-button dropdown-toggle btn" data-bypass="true" data-toggle="dropdown" title="View Attachments"
-          id="view-attachments-menu">
-          <i className="icon icon-paper-clip"></i>
-          <span className="button-text">View Attachments</span>
-          <span className="caret"></span>
-        </button>
-        <ul className="dropdown-menu" role="menu" aria-labelledby="view-attachments-menu">
-          {this.getAttachmentList()}
-        </ul>
+        <Dropdown id="view-attachments-menu">
+          <Dropdown.Toggle noCaret className="panel-button dropdown-toggle btn" data-bypass="true">
+            <i className="icon icon-paper-clip"></i>
+            <span className="button-text">View Attachments</span>
+            <span className="caret"></span>
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            {this.getAttachmentList()}
+          </Dropdown.Menu>
+        </Dropdown>
       </div>
     );
   }
@@ -294,6 +295,18 @@ class UploadModal extends React.Component {
       loadPercentage: store.getUploadLoadPercentage(),
       errorMessage: store.getFileUploadErrorMsg()
     };
+  };
+
+  componentDidMount() {
+    store.on('change', this.onChange, this);
+  }
+
+  componentWillUnmount() {
+    store.off('change', this.onChange);
+  }
+
+  onChange = () => {
+    this.setState(this.getStoreState());
   };
 
   closeModal = (e) => {


### PR DESCRIPTION
## Overview

In the document editor: 
- Fixes "View Attachments" dropdown menu that stopped working after removal of `bootstrap.js` in https://github.com/apache/couchdb-fauxton/pull/994
- Fixes the file upload modal that was not displaying error messages.

## Testing recommendations

- Click on a document to bring up the editor
- Click on 'Upload Attachment'
   - Choose a file that starts with underscore (e.g. '_afile.txt') then click 'Upload Attachment'
   - The modal should show the error message: `Attachment name '_afile.txt' starts with prohibited character '_'`
   - Pick another file then click 'Upload Attachment'
   - Success message is displayed
   - 'View Attachements' is now visible. Click on it and select the file to download it.


