### PR TITLE
Support editing _local docs

### DIFF
--- a/app/addons/documents/routes-doc-editor.js
+++ b/app/addons/documents/routes-doc-editor.js
@@ -37,10 +37,10 @@ const DocEditorRouteObject = FauxtonAPI.RouteObject.extend({
     'database/:database/:doc/conflicts': 'revisionBrowser',
     'database/:database/:doc/code_editor': 'codeEditor',
     'database/:database/_design/:ddoc': 'showDesignDoc',
+    'database/:database/_local/:doc': 'showLocalDoc',
     'database/:database/:doc': 'codeEditor',
     'database/:database/new': 'codeEditor'
   },
-
 
   revisionBrowser: function (databaseName, docId) {
     const backLink = FauxtonAPI.urls('allDocs', 'app', FauxtonAPI.url.encode(this.database.safeID()));
@@ -86,6 +86,10 @@ const DocEditorRouteObject = FauxtonAPI.RouteObject.extend({
           isNewDoc={docId ? false : true}
         />}
       />;
+  },
+
+  showLocalDoc: function(databaseName, docId) {
+    return this.codeEditor(databaseName, '_local/' + docId);
   },
 
   showDesignDoc: function (database, ddoc) {

--- a/app/addons/documents/tests/nightwatch/createsDocument.js
+++ b/app/addons/documents/tests/nightwatch/createsDocument.js
@@ -58,6 +58,55 @@ module.exports = {
     .end();
   },
 
+    'Creates a _local document' : (client) => {
+    /*jshint multistr: true */
+    const waitTime = client.globals.maxWaitTime,
+          newDatabaseName = client.globals.testDatabaseName,
+          newDocumentName = '_local/create_doc_document',
+          baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .createDatabase(newDatabaseName)
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .clickWhenVisible('#new-all-docs-button a')
+      .clickWhenVisible('#new-all-docs-button a[href="#/database/' + newDatabaseName + '/new"]')
+      .waitForElementPresent('#editor-container', waitTime, false)
+      .verify.urlEquals(baseUrl + '/#/database/' + newDatabaseName + '/new')
+      .waitForElementPresent('.ace_gutter-active-line', waitTime, false)
+
+      // confirm the header elements are showing up
+      .waitForElementVisible('.faux-header__breadcrumbs', waitTime, true)
+      .waitForElementVisible('.faux__jsonlink-link', waitTime, true)
+
+      .execute('\
+        var editor = ace.edit("doc-editor");\
+        editor.gotoLine(2,10);\
+        editor.removeWordRight();\
+        editor.insert("' + newDocumentName + '");\
+      ')
+
+      .clickWhenVisible('#doc-editor-actions-panel .save-doc')
+      .checkForDocumentCreated(newDocumentName)
+      .url(baseUrl + '#/database/' + newDatabaseName + '/' + newDocumentName)
+
+      // Confirm the editor loaded successfully
+      .waitForElementPresent('.ace_gutter-active-line', waitTime, false)
+      .waitForElementVisible('.faux-header__breadcrumbs', waitTime, true)
+      .waitForElementVisible('.faux__jsonlink-link', waitTime, true)
+      .execute(function() {
+        return ace.edit("doc-editor").getValue();
+      }, function (data) {
+        const createdDocIsPresent = data.value.indexOf(newDocumentName) !== -1;
+
+        this.verify.ok(
+          createdDocIsPresent,
+          'Checking if new document shows up in _all_docs.'
+        );
+      })
+    .end();
+  },
+
   'Creates a Document through Create Document toolbar button': (client) => {
     const waitTime = client.globals.maxWaitTime,
           newDatabaseName = client.globals.testDatabaseName,

--- a/app/addons/documents/tests/nightwatch/createsDocument.js
+++ b/app/addons/documents/tests/nightwatch/createsDocument.js
@@ -95,6 +95,7 @@ module.exports = {
       .waitForElementVisible('.faux-header__breadcrumbs', waitTime, true)
       .waitForElementVisible('.faux__jsonlink-link', waitTime, true)
       .execute(function() {
+        /*global ace*/
         return ace.edit("doc-editor").getValue();
       }, function (data) {
         const createdDocIsPresent = data.value.indexOf(newDocumentName) !== -1;


### PR DESCRIPTION
## Overview

Adds support for editing `_local` docs in Fauxton.

## Testing recommendations

To test, create a _local doc and then modify the Fauxton URL to see the edit page:

## GitHub issue number

Fixes apache/couchdb-fauxton#978

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
