### PR TITLE
Fix table mode to show boolean values

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,6 @@
     "react",
     "es2015"
   ],
-  "plugins": ["transform-object-assign", "transform-object-rest-spread", "transform-class-properties"]
+  "plugins": ["transform-object-assign", "transform-object-rest-spread", 
+    "transform-class-properties", "array-includes"]
 }

--- a/app/addons/documents/__tests__/table-row.test.js
+++ b/app/addons/documents/__tests__/table-row.test.js
@@ -1,0 +1,58 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+import FauxtonAPI from "../../../core/api";
+import TableRow from "../index-results/components/results/TableRow";
+import utils from "../../../../test/mocha/testUtils";
+import React from "react";
+import ReactDOM from "react-dom";
+import sinon from "sinon";
+import { shallow } from 'enzyme';
+
+FauxtonAPI.router = new FauxtonAPI.Router([]);
+const { assert } = utils;
+
+describe('Docs Table Row', () => {
+
+  it('all types of value are converted to the appropriate text for display', () => {
+    const elem = {
+      content: {
+        _id: "123",
+        vBool: true,
+        vString: 'abc',
+        vFloat: 123.1234,
+        vInt: 123,
+        vObject: { f1: 1, f2: 'b'},
+      },
+      id: "123"
+    };
+
+    const data = {
+      selectedFields: ['vBool', 'vString', 'vFloat', 'vInt', 'vObject']
+    };
+    const wrapper = shallow(<TableRow
+      onClick={sinon.stub()}
+      docChecked={sinon.stub()}
+      isSelected={sinon.stub()}
+      el={elem}
+      data={data}
+      index={0}
+      docIdentifier={elem.id}
+      isSelected={false}
+    />);
+
+    assert.equal(wrapper.find('td').at(2).text(), JSON.stringify(elem.content.vBool));
+    assert.equal(wrapper.find('td').at(3).text(), elem.content.vString);
+    assert.equal(wrapper.find('td').at(4).text(), JSON.stringify(elem.content.vFloat));
+    assert.equal(wrapper.find('td').at(5).text(), JSON.stringify(elem.content.vInt));
+    assert.equal(wrapper.find('td').at(6).text().replace(/[\s]/g, ''), JSON.stringify(elem.content.vObject));
+  });
+});

--- a/app/addons/documents/index-results/components/results/TableRow.js
+++ b/app/addons/documents/index-results/components/results/TableRow.js
@@ -37,7 +37,8 @@ export default class TableRow extends React.Component {
     const row = this.props.data.selectedFields.map(function (k, i) {
 
       const key = 'tableview-data-cell-' + rowNumber + k + i + el[k];
-      const stringified = typeof el[k] === 'object' ? JSON.stringify(el[k], null, '  ') : el[k];
+      const stringified = ['object', 'boolean'].includes(typeof el[k]) ?
+        JSON.stringify(el[k], null, '  ') : el[k];
 
       return (
         <td key={key} title={stringified} onClick={this.onClick.bind(this)}>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-core": "^6.22.1",
     "babel-eslint": "^8.0.1",
     "babel-loader": "^6.2.9",
+    "babel-plugin-array-includes": "^2.0.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",


### PR DESCRIPTION
## Overview

Fixes display of boolean values in Table mode. 

### Current behavior
Table mode won't display boolean values of top-level fields. E.g.: `{ "_id": "test", "f": false, "t": true }`

### Expected behavior
Table mode displays `true` or `false` for boolean fields. 

## Testing recommendations

 - Create a new doc `{ "_id": "test", "f": false, "t": true }`
 - In the all_docs list, switch to Table mode.
 - Values for `f` and `t` should be displayed

