### PR TITLE
Replication page renders even with missing URL

### DIFF
--- a/app/addons/replication/__tests__/common-table.test.js
+++ b/app/addons/replication/__tests__/common-table.test.js
@@ -16,6 +16,7 @@ import {formatUrl} from '../components/common-table';
 const {assert}  = utils;
 
 describe('Common Table Component', () => {
+
   describe("formatUrl", () => {
     it("renders a url with tricky password characters", () => {
       const url = "http://hello:h#$!^@couchdb.com/my-db";
@@ -27,6 +28,10 @@ describe('Common Table Component', () => {
       const url = "http://couchdb.com/my-db";
       const el = shallow(formatUrl(url));
       assert.equal(el.find('a').prop('href'), '#/database/my-db/_all_docs');
+    });
+
+    it('renders a with a default url if no url is supplied', () => {
+      assert.equal(formatUrl(), '');
     });
   });
 });

--- a/app/addons/replication/components/common-table.js
+++ b/app/addons/replication/components/common-table.js
@@ -18,8 +18,15 @@ import {ErrorModal} from './modals';
 import {removeCredentialsFromUrl} from '../api';
 
 export const formatUrl = (url) => {
-  const urlObj = new URL(removeCredentialsFromUrl(url));
-  const encoded = encodeURIComponent(urlObj.pathname.slice(1));
+  let urlObj;
+  let encoded;
+  try {
+    urlObj = new URL(removeCredentialsFromUrl(url));
+    encoded = encodeURIComponent(urlObj.pathname.slice(1));
+  } catch (error) {
+    console.log('error with url', url);
+    return '';
+  }
 
   if (url.indexOf(window.location.hostname) > -1) {
     return (


### PR DESCRIPTION
Handle bad/missing urls by ignoring them in the formatUrl function.
In same cases a replication doc might not have a source or target and this causes the replication dashboard page to crash. We need to handle the missing url and continue to display the page.

