### PR TITLE
Retry docker:up a few times in case of failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,13 @@ git:
 
 before_script:
   - travis_retry ./bin/docker-up-and-check.sh
-  - npm install
-  # - docker logs couchdb
-  # - docker logs selenium
   - curl http://127.0.0.1:5984
+  - npm install
   - npm run stylecheck
   - npm test
   - grunt debugDev
   - DIST=./dist/debug ./bin/fauxton &
   - sleep 30
-  # - docker logs couchdb
-  # - curl http://127.0.0.1:5984
 script:
   - travis_retry ./node_modules/.bin/grunt nightwatch
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ git:
 
 before_script:
   - travis_retry ./bin/docker-up-and-check.sh
-  - curl http://127.0.0.1:5984
   - npm install
+  - curl http://127.0.0.1:5984
   - npm run stylecheck
   - npm test
   - grunt debugDev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,18 @@ git:
   depth: 1
 
 before_script:
-  - npm run docker:up
+  - travis_retry ./bin/docker-up-and-check.sh
   - npm install
-  - docker logs couchdb
-  - docker logs selenium
+  # - docker logs couchdb
+  # - docker logs selenium
   - curl http://127.0.0.1:5984
   - npm run stylecheck
   - npm test
   - grunt debugDev
   - DIST=./dist/debug ./bin/fauxton &
   - sleep 30
-  - docker logs couchdb
-  - curl http://127.0.0.1:5984
+  # - docker logs couchdb
+  # - curl http://127.0.0.1:5984
 script:
   - travis_retry ./node_modules/.bin/grunt nightwatch
 after_script:

--- a/bin/docker-up-and-check.sh
+++ b/bin/docker-up-and-check.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+
+## Sometimes the couchdb docker container won't start correctly, which causes
+## the Travis build to fail and forces users to resubmit their PRs.
+## This script tries to minimize the issue by retrying to start the containers
+## in case of failure.
+
+
+start_containters_and_check() {
+  npm run docker:up
+  if [[ $? != 0 ]]; then exit $?; fi
+
+  # Uses docker logs to check if couchdb server has started
+  NUM_CHECKS=10
+  for ((check=1; check<=$NUM_CHECKS; check++));
+  do
+    echo "Checking if couchdb container has started ($check of $NUM_CHECKS)"
+    logs=$(docker logs couchdb)
+    if [[ $logs == *"Errno socket error"* ]]; then
+      echo "Failed to start couchdb container"
+      echo "=============================="
+      docker logs couchdb
+      echo "=============================="
+      return 1
+    fi
+    if [[ $logs == *"Developers cluster is set up"* ]]; then
+      echo "Docker containers are up"
+      echo "========================"
+      docker logs couchdb
+      echo "========================"
+      return 0
+    fi
+    sleep 6
+  done
+}
+
+stop_containters() {
+  npm run docker:down
+  sleep 2
+}
+
+# Tries to start the containers a few times
+# NUM_TRIES=5
+# for ((i=1; i<=$NUM_TRIES; i++));
+# do
+  # echo "Starting containers... ($i of $NUM_TRIES)"
+  if start_containters_and_check 
+  then
+    exit 0
+  fi
+  stop_containters
+# done
+
+exit 2

--- a/bin/docker-up-and-check.sh
+++ b/bin/docker-up-and-check.sh
@@ -52,16 +52,11 @@ stop_containters() {
   sleep 2
 }
 
-# Tries to start the containers a few times
-# NUM_TRIES=5
-# for ((i=1; i<=$NUM_TRIES; i++));
-# do
-  # echo "Starting containers... ($i of $NUM_TRIES)"
-  if start_containters_and_check 
-  then
-    exit 0
-  fi
-  stop_containters
-# done
 
+if start_containters_and_check 
+then
+  exit 0
+fi
+
+stop_containters
 exit 2


### PR DESCRIPTION
## Overview

Mitigate failures in Travis build by retrying to start up the couchdb container when it doesn't start correctly.

## Testing recommendations



