### PR TITLE
Fix devserver on Windows

### DIFF
--- a/devserver.js
+++ b/devserver.js
@@ -31,8 +31,8 @@ const devSetup = function (cb) {
   if (settings.noClean) {
     cmd = 'devSetup';
   }
-  let isOnWindows = process.platform === 'win32';
-  let gruntCmd = isOnWindows ? 'grunt.cmd' : 'grunt';
+  const isOnWindows = process.platform === 'win32';
+  const gruntCmd = isOnWindows ? 'grunt.cmd' : 'grunt';
   const grunt = spawn(gruntCmd, [cmd]);
 
   grunt.stdout.on('data', (data) => {

--- a/devserver.js
+++ b/devserver.js
@@ -31,8 +31,9 @@ const devSetup = function (cb) {
   if (settings.noClean) {
     cmd = 'devSetup';
   }
-
-  const grunt = spawn('grunt', [cmd]);
+  let isOnWindows = process.platform === 'win32';
+  let gruntCmd = isOnWindows ? 'grunt.cmd' : 'grunt';
+  const grunt = spawn(gruntCmd, [cmd]);
 
   grunt.stdout.on('data', (data) => {
     console.log(data.toString());

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "start-debug": "DIST=./dist/debug node ./bin/fauxton",
     "preversion": "node version-check.js && grunt release",
     "test-before-publish": "npm run preversion && npm install . -g",
-    "create:animaldb": "./bin/create-animal-db",
+    "create:animaldb": "node ./bin/create-animal-db",
     "docker:couchdb-up": "docker-compose -f ./docker/dc.selenium.yml up -d couchdb",
     "docker:selenium-up": "docker-compose -f ./docker/dc.selenium.yml up -d selenium",
     "docker:selenium-debug-up": "docker-compose -f ./docker/dc.selenium-debug.yml up -d selenium",


### PR DESCRIPTION
## Overview

We were unable to run: `npm run dev` on Windows.

## Testing recommendations

Run `npm run dev` on a non-windows OS and it should still start the devserser.
Run `npm run dev`on a windows OS and it should successfully start the devserver.

## GitHub issue number

Fixes #960 

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
