### PR TITLE
Fix could not bulk delete from table view

### DIFF
--- a/app/addons/documents/__tests__/shared-helpers.test.js
+++ b/app/addons/documents/__tests__/shared-helpers.test.js
@@ -231,6 +231,16 @@ describe('Docs Shared Helpers', () => {
       expect(getDocRev(docView, docType)).toBe(docView.value.rev);
     });
 
+    it('returns document revision for docType "view" and only doc', () => {
+      const docView = {
+        id: "20c76d4ff9851694792654ab3e2ca303",
+        _rev: "1-c59f5770929653147ab939344b84e933"
+      };
+      const docType = Constants.INDEX_RESULTS_DOC_TYPE.VIEW;
+      expect(getDocRev(docView, docType)).toBe(docView._rev);
+    });
+
+
     it('returns document revision for docType "MangoQueryResult"', () => {
       const docMangoResult = {
         _id: "aardvark",

--- a/app/addons/documents/index-results/helpers/shared-helpers.js
+++ b/app/addons/documents/index-results/helpers/shared-helpers.js
@@ -96,7 +96,10 @@ const getDocId = (doc, docType = Constants.INDEX_RESULTS_DOC_TYPE.VIEW) => {
 
 const getDocRev = (doc, docType = Constants.INDEX_RESULTS_DOC_TYPE.VIEW) => {
   if (docType === Constants.INDEX_RESULTS_DOC_TYPE.VIEW) {
-    return doc.value && doc.value.rev;
+    if (doc.value) {
+      return doc.value.rev;
+    }
+    return doc._rev;
   } else if (docType === Constants.INDEX_RESULTS_DOC_TYPE.MANGO_INDEX) {
     return undefined;
   } else if (docType === Constants.INDEX_RESULTS_DOC_TYPE.MANGO_QUERY) {


### PR DESCRIPTION
Fixed an issue where the _rev was not getting added to the doc so table
view could not do bulk deletes



## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
