### PR TITLE
Add missing title to Replication page

### DIFF
--- a/app/addons/replication/controller.js
+++ b/app/addons/replication/controller.js
@@ -249,6 +249,8 @@ export default class ReplicationController extends React.Component {
   getCrumbs () {
     if (this.state.tabSection === 'new replication') {
       return [{'name': 'Job Configuration'}];
+    } else {
+      return [{'name': 'Replication'}];
     }
 
     return [];


### PR DESCRIPTION
## Overview

All pages opened using the left nav bar include a title at the top header, except for the Replication page.
To keep the design consistent, the replication page should also display a title.

## Testing recommendations

Click the Replication option on the left nav bar. 
The page includes the title 'Replication' at the top header

