### PR TITLE
Fix intermittent fail in Nightwatch test

### DIFF
--- a/app/addons/documents/tests/nightwatch/tableView.js
+++ b/app/addons/documents/tests/nightwatch/tableView.js
@@ -31,6 +31,7 @@ module.exports = {
       .clickWhenVisible('.fonticon-table')
 
       .waitForElementVisible('.tableview-checkbox-cell', waitTime, false)
+      .waitForElementVisible('.table', waitTime, false)
       .getText('.table', function (result) {
         var data = result.value;
 
@@ -61,6 +62,7 @@ module.exports = {
       .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
       .assert.containsText('button.active', 'Metadata')
       .waitForElementVisible('.tableview-checkbox-cell', waitTime, false)
+      .waitForElementVisible('.table', waitTime, false)
       .getText('.table', function (result) {
         var data = result.value;
 


### PR DESCRIPTION
## Overview

Add extra check to `tableView.js` nightwatch test to make sure table is visible before checking its contents.

## Testing recommendations

Run nightwatch tests
