### PR TITLE
Show a badge on a tab header

### DIFF
--- a/app/addons/components/__tests__/tabwindowwrapper.test.js
+++ b/app/addons/components/__tests__/tabwindowwrapper.test.js
@@ -47,4 +47,15 @@ describe('TabWindowWrapper', () => {
     const wrapper = mount(<TabWindowWrapper tabs={tabs} selectedTab={"Tab2"}/>);
     expect(wrapper.find('.tab-element-checked .tab-element-content').html()).toMatch(/Tab2/);
   });
+
+  it('shows tab badge', () => {
+    const tabNoBadge = [{name: 'Tab1', component: mock, route: 'tab1'}];
+    const wrapperNoBadge = mount(<TabWindowWrapper tabs={tabNoBadge} selectedTab={"Tab1"}/>);
+    expect(wrapperNoBadge.find('.tab-element-badge').length).toBe(0);
+
+    const tabWithBadge = [{name: 'Tab1', component: mock, route: 'tab1', badgeText: 'new'}];
+    const wrapperWithBadge = mount(<TabWindowWrapper tabs={tabWithBadge} selectedTab={"Tab1"}/>);
+    expect(wrapperWithBadge.find('.tab-element-badge').length).toBe(1);
+    expect(wrapperWithBadge.find('.tab-element-badge').text()).toBe('new');
+  });
 });

--- a/app/addons/components/assets/less/tab-element.less
+++ b/app/addons/components/assets/less/tab-element.less
@@ -56,6 +56,21 @@
     height: 5px;
   }
 
+  .tab-element-badge {
+    display: inline-block;
+    min-width: 10px;
+    padding: 3px 7px;
+    line-height: 1;
+    color: #fff;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    background-color: @linkColorHover;
+    border-radius: 10px;
+    margin-left: 0.25rem;
+    font-size: 0.75rem;
+  }
+
   .tab-element-indicator {
     height: 0px;
     transition: all .25s linear;

--- a/app/addons/components/components/tabelement.js
+++ b/app/addons/components/components/tabelement.js
@@ -15,10 +15,13 @@ import PropTypes from 'prop-types';
 import React from "react";
 import ReactDOM from "react-dom";
 
-export const TabElement = ({selected, text, onChange, iconClass}) => {
+export const TabElement = ({selected, text, onChange, iconClass, badgeText}) => {
 
   const additionalClass = selected ? 'tab-element-checked' : '';
-
+  let badge = null;
+  if (badgeText) {
+    badge = <span className="tab-element-badge">{badgeText}</span>;
+  }
   return (
     <li className={`component-tab-element ${additionalClass}`}>
 
@@ -35,6 +38,7 @@ export const TabElement = ({selected, text, onChange, iconClass}) => {
             onChange={onChange} />
 
           {text}
+          {badge}
         </div>
       </label>
     </li>
@@ -46,6 +50,7 @@ TabElement.propTypes = {
   text: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   iconClass: PropTypes.string,
+  badgeText: PropTypes.string
 };
 
 export const TabElementWrapper = ({children}) => {

--- a/app/addons/components/components/tabwindowwrapper.js
+++ b/app/addons/components/components/tabwindowwrapper.js
@@ -20,6 +20,7 @@ export class TabWindowWrapper extends React.Component {
           key={i}
           selected={tab.name === selectedTab}
           text={tab.name}
+          badgeText={tab.badgeText}
           onChange={() => { FauxtonAPI.navigate(tab.route, {redirect: true}); }}
           iconClass="" />
       );


### PR DESCRIPTION
## Overview

Add ability to show a badge on a tab header.

![image](https://user-images.githubusercontent.com/30349380/32925087-0f6ea9b6-cb0e-11e7-9e7b-fafa9773291a.png)


## Testing recommendations

To see it in action you can replace the code in https://github.com/apache/couchdb-fauxton/blob/master/app/addons/activetasks/components.js#L119 with: 
```
<TabElement
            key={i}
            selected={checked}
            text={radioName}
            onChange={this.onRadioClick}
            badgeText={ i == 1 ? '999' : ''} />
```

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
