### PR TITLE
Use PUT endpoint to clone doc

### DIFF
--- a/app/addons/documents/doc-editor/actions.js
+++ b/app/addons/documents/doc-editor/actions.js
@@ -12,7 +12,6 @@
 
 /* global FormData */
 
-import app from "../../../app";
 import FauxtonAPI from "../../../core/api";
 import ActionTypes from "./actiontypes";
 
@@ -116,14 +115,11 @@ function hideCloneDocModal () {
 }
 
 function cloneDoc (database, doc, newId) {
-  const docId = app.utils.getSafeIdForDoc(newId);
 
   hideCloneDocModal();
 
-  doc.copy(docId).then(() => {
-    doc.set({ _id: docId });
-
-    FauxtonAPI.navigate('/database/' + database.safeID() + '/' + docId, { trigger: true });
+  doc.copy(newId).then(() => {
+    FauxtonAPI.navigate('/database/' + database.safeID() + '/' + encodeURIComponent(newId), { trigger: true });
 
     FauxtonAPI.addNotification({
       msg: 'Document has been duplicated.'

--- a/app/addons/documents/doc-editor/components.js
+++ b/app/addons/documents/doc-editor/components.js
@@ -1,6 +1,3 @@
-import FauxtonAPI from "../../../core/api";
-import app from "../../../app";
-
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy of
 // the License at
@@ -13,9 +10,9 @@ import app from "../../../app";
 // License for the specific language governing permissions and limitations under
 // the License.
 
-
+import FauxtonAPI from "../../../core/api";
+import app from "../../../app";
 import PropTypes from 'prop-types';
-
 import React from "react";
 import { Dropdown, MenuItem } from "react-bootstrap";
 import ReactDOM from "react-dom";

--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -183,11 +183,12 @@ Documents.Doc = FauxtonAPI.Model.extend({
   },
 
   copy: function (copyId) {
-    return $.ajax({
-      type: 'COPY',
-      url: '/' + this.database.safeID() + '/' + this.safeID(),
-      headers: {Destination: copyId}
+    const attrs = Object.assign({}, this.attributes, {_id: copyId});
+    delete attrs._rev;
+    const clonedDoc = new this.constructor(attrs, {
+      database: this.database
     });
+    return clonedDoc.save();
   },
 
   isNewDoc: function () {

--- a/app/addons/documents/tests/nightwatch/cloneDoc.js
+++ b/app/addons/documents/tests/nightwatch/cloneDoc.js
@@ -15,7 +15,7 @@ module.exports = {
   'Clones a document via Editor': function (client) {
     const waitTime = client.globals.maxWaitTime;
     const newDatabaseName = client.globals.testDatabaseName;
-    const newDocumentName = 'clone_doc_doc';
+    const newDocumentName = 'clone_doc/doc';
     const baseUrl = client.globals.test_settings.launch_url;
 
     client

--- a/app/addons/documents/tests/nightwatch/cloneDoc.js
+++ b/app/addons/documents/tests/nightwatch/cloneDoc.js
@@ -15,7 +15,8 @@ module.exports = {
   'Clones a document via Editor': function (client) {
     const waitTime = client.globals.maxWaitTime;
     const newDatabaseName = client.globals.testDatabaseName;
-    const newDocumentName = 'clone_doc/doc';
+    const newDocumentName = 'clone_doc_doc';
+    const clonedDocName = 'cloned/document';
     const baseUrl = client.globals.test_settings.launch_url;
 
     client
@@ -32,13 +33,13 @@ module.exports = {
       .clickWhenVisible('.clone-doc-modal input')
 
       .clearValue('.clone-doc-modal input')
-      .setValue('.clone-doc-modal input', ['ente'])
+      .setValue('.clone-doc-modal input', [clonedDocName])
 
       .clickWhenVisible('.clone-doc-modal button.btn.btn-primary')
       .closeNotification()
 
       .waitForAttribute('.faux-header__breadcrumbs .faux-header__breadcrumbs-element:last-child', 'textContent', function (docContents) {
-        return 'ente' === docContents.trim();
+        return clonedDocName === docContents.trim();
       })
 
       .url(`${baseUrl}'/'${newDatabaseName}/${newDocumentName}`)
@@ -46,7 +47,7 @@ module.exports = {
       .waitForElementNotPresent('.loading-lines', waitTime, false)
       .getText('#editor-container', function (result) {
         const data = result.value;
-        const isCreatedDocumentPresent = data.indexOf('ente') !== -1;
+        const isCreatedDocumentPresent = data.indexOf(clonedDocName) !== -1;
 
         this.verify.ok(
           isCreatedDocumentPresent,


### PR DESCRIPTION
## Overview

The COPY doc api doesn't support cloning docs with ID's that need to be
encoded. So use the PUT command and just create a new doc instead

## Testing recommendations
Clone a document and test that it can clone a document. Ideally clone a document that would need to be encoded e.g `encoded/doc`.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
