### PR TITLE
Feat/sidebar design fixes

### DIFF
--- a/app/addons/documents/assets/less/header-docs-left.less
+++ b/app/addons/documents/assets/less/header-docs-left.less
@@ -58,6 +58,7 @@ button.faux-header__doc-header-dropdown-toggle:focus {
   border: none;
   background-color: transparent;
   border-right: 1px solid #ccc;
+  color: #333;
   width: 40px;
   padding: 11px;
 }

--- a/app/addons/fauxton/assets/less/navigation.less
+++ b/app/addons/fauxton/assets/less/navigation.less
@@ -38,7 +38,7 @@
 
 .faux-navbar__burger {
   background-color: @brandDark2;
-  padding: 19px 0 18px 18px;
+  padding: 19px 0 18px 25px;
 }
 
 .faux-navbar--narrow {
@@ -55,7 +55,7 @@
 
 .faux-navbar__burger__icon {
   color: @navIconColor;
-  font-size: 27px;
+  font-size: 19px;
 }
 
 .faux-navbar__burger__icon--flipped:before{

--- a/app/addons/fauxton/assets/less/navigation.less
+++ b/app/addons/fauxton/assets/less/navigation.less
@@ -201,6 +201,10 @@
   background-size: 40px;
 }
 
+.faux-navbar__spacer {
+  height: 6px;
+}
+
 .faux-navbar__footer {
   display: flex;
   flex-direction: column;

--- a/app/addons/fauxton/navigation/components/Burger.js
+++ b/app/addons/fauxton/navigation/components/Burger.js
@@ -25,8 +25,8 @@ const Burger = ({toggleMenu, isMinimized}) => {
   );
 
   const icon = isMinimized ?
-    'icon-resize-horizontal' :
-    'icon-signin faux-navbar__burger__icon--flipped';
+    'icon-chevron-right' :
+    'icon-chevron-left';
 
   return (
     <div className={burgerClasses} onClick={toggleMenu}>

--- a/app/addons/fauxton/navigation/components/NavBar.js
+++ b/app/addons/fauxton/navigation/components/NavBar.js
@@ -79,6 +79,9 @@ class NavBar extends Component {
             <Burger isMinimized={isMinimized} toggleMenu={this.toggleMenu}/>
             <div className="faux-navbar__links">
               {navLinks}
+
+              <div className="faux-navbar__spacer"></div>
+
               {bottomNavLinks}
             </div>
 

--- a/app/addons/fauxton/navigation/components/NavBar.js
+++ b/app/addons/fauxton/navigation/components/NavBar.js
@@ -76,7 +76,6 @@ class NavBar extends Component {
       <div className={navClasses}>
         <nav>
           <div className="faux-navbar__linkcontainer">
-            <Burger isMinimized={isMinimized} toggleMenu={this.toggleMenu}/>
             <div className="faux-navbar__links">
               {navLinks}
 
@@ -84,6 +83,8 @@ class NavBar extends Component {
 
               {bottomNavLinks}
             </div>
+
+            <Burger isMinimized={isMinimized} toggleMenu={this.toggleMenu}/>
 
             <div className="faux-navbar__footer">
               <Brand isMinimized={isMinimized} />


### PR DESCRIPTION
## Overview

The sidebar requires too much brain overhead and i tried to improve the usability with common UI design patterns:
 
 - rule of 5s: clusters of items with more than 5 are perceived as "many" and individual items are hard to find. by seperating the menu entries into the top and bottom elements with a little spacer, the brain is releived a bit.
 - order of importance: the top elements of a list are generally more important then lower elements, but the sidebar toggle is still the highest element in the sidebar, even though it has the lowest importance of the entries. also the icons to show and hide the sidebar titles is non standard and hard to understand, and very different between the show and hide states (eg. logout button to hide the sidebar titles.) I tried to adopt as much to the standard way to represent hiding sidebar titles as possible, while having minimal impact on the overall design.


## Testing recommendations

Purely visual changes, please rebuild and manually inspect the design changes.
