### PR TITLE
feat: replace shadow-borders with normal borders for more minimal look

### DIFF
--- a/app/addons/fauxton/navigation/components/NavBar.js
+++ b/app/addons/fauxton/navigation/components/NavBar.js
@@ -95,7 +95,6 @@ class NavBar extends Component {
             </div>
           </div>
         </nav>
-        <div id="primary-nav-right-shadow"/>
       </div>
     );
   }

--- a/assets/less/bootstrap/navbar.less
+++ b/assets/less/bootstrap/navbar.less
@@ -25,7 +25,6 @@
   #gradient > .vertical(@navbarBackgroundHighlight, @navbarBackground);
   border: 1px solid @navbarBorder;
   .border-radius(@baseBorderRadius);
-  .box-shadow(0 1px 4px rgba(0,0,0,.065));
 
   // Prevent floats from breaking the navbar
   .clearfix();

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -185,10 +185,8 @@ table.databases {
     min-height: @collapsedNavWidth;
     margin-bottom: auto;
     text-shadow: none;
-    .box-shadow(0px 4px 0px rgba(0,0,0,0.45));
     .border-radius(0);
     border-bottom: 1px solid @brandDark2;
-    box-shadow: 0 4px 0 0 rgba(0, 0, 0, 0.4);
     a, a:hover {
       color: #cecece;
       text-decoration: none;
@@ -346,7 +344,7 @@ table.databases {
    ensures the flexbox height is respected */
   &>div {
     height: 65px;
-    .bottom-shadow-border();
+    .bottom-border();
     position: absolute;
     width: 100%;
     z-index: 2; /* needed because ace's selected row has a z-index of 1 & can't be overridden */

--- a/assets/less/layouts.less
+++ b/assets/less/layouts.less
@@ -156,7 +156,7 @@ body #dashboard.template-with-sidebar {
   }
   #dashboard-content {
     border-left: 1px solid @grayLight;
-    .left-shadow-border();
+    .left-border();
   }
 }
 

--- a/assets/less/mixins.less
+++ b/assets/less/mixins.less
@@ -7,16 +7,16 @@
 }
 
 .customTransition(@prop, @delay, @a, @b, @c, @d){
--webkit-transition: @prop, @delay cubic-bezier(@a, @b, @c, @d); 
-   -moz-transition: @prop, @delay cubic-bezier(@a, @b, @c, @d); 
-    -ms-transition: @prop, @delay cubic-bezier(@a, @b, @c, @d); 
-     -o-transition: @prop, @delay cubic-bezier(@a, @b, @c, @d); 
+-webkit-transition: @prop, @delay cubic-bezier(@a, @b, @c, @d);
+   -moz-transition: @prop, @delay cubic-bezier(@a, @b, @c, @d);
+    -ms-transition: @prop, @delay cubic-bezier(@a, @b, @c, @d);
+     -o-transition: @prop, @delay cubic-bezier(@a, @b, @c, @d);
         transition: @prop, @delay cubic-bezier(@a, @b, @c, @d); /* custom */
 
--webkit-transition-timing-function: cubic-bezier(@a, @b, @c, @d); 
-   -moz-transition-timing-function: cubic-bezier(@a, @b, @c, @d); 
-    -ms-transition-timing-function: cubic-bezier(@a, @b, @c, @d); 
-     -o-transition-timing-function: cubic-bezier(@a, @b, @c, @d); 
+-webkit-transition-timing-function: cubic-bezier(@a, @b, @c, @d);
+   -moz-transition-timing-function: cubic-bezier(@a, @b, @c, @d);
+    -ms-transition-timing-function: cubic-bezier(@a, @b, @c, @d);
+     -o-transition-timing-function: cubic-bezier(@a, @b, @c, @d);
         transition-timing-function: cubic-bezier(@a, @b, @c, @d); /* custom */
 }
 
@@ -28,14 +28,12 @@
   transition: @arguments;
 }
 
-.bottom-shadow-border(@height: 6px) {
+.bottom-border(@height: 6px) {
   border-bottom: 1px solid #999;
-  .box-shadow(0px @height 0 0 rgba(0, 0, 0, 0.1));
 }
 
-.left-shadow-border() {
+.left-border() {
   border-left: 1px solid #999;
-  .box-shadow(-6px 0 rgba(0, 0, 0, 0.1));
 }
 
 .noselect() {

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -50,15 +50,13 @@
   }
 }
 
-.bottom-shadow-border {
+.bottom-border {
   border-bottom: 1px solid #999;
-  .box-shadow(0px 6px 0 0 rgba(0, 0, 0, 0.1));
 }
 
-.bottom-left-shadow-border {
+.bottom-left-border {
   border-bottom: 1px solid #999;
   border-left: 1px solid #999;
-  .box-shadow(-6px 6px 0 0 rgba(0, 0, 0, 0.1));
 }
 
 
@@ -98,7 +96,6 @@
 #sidebar-content {
   width: @sidebarWidth;
   background-color: @secondarySidebar;
-  margin-top: 6px;
   > div.inner {
     display: block;
   }
@@ -136,13 +133,9 @@
   height: @collapsedNavWidth;
 }
 
-.with-sidebar .right-header-wrapper {
-  .box-shadow(-7px 0 rgba(0, 0, 0, 0.1));
-}
-
 .header-wrapper {
-  .bottom-shadow-border();
-  .box-shadow(0 6px 0 0 rgba(0, 0, 0, 0.1));
+  .bottom-border();
+  .box-shadow(0 1px 0 0 rgba(0, 0, 0, 0.1));
   position: absolute;
   left: 0;
   right: 0;
@@ -195,7 +188,7 @@
 
   .with-sidebar & {
     border-left: 1px solid @grayLight;
-    .left-shadow-border();
+    .left-border();
     width: auto;
     padding: 15px;
     bottom: 0px;
@@ -283,11 +276,9 @@
       padding: 0 0 40px;
     }
     border-left: 1px solid #999;
-    .box-shadow(-6px 0 rgba(0, 0, 0, 0.1));
   }
   .right-header-wrapper {
     border-left: 1px solid #999;
-    .box-shadow(-6px 0 rgba(0, 0, 0, 0.1));
     .faux-header__searchboxwrapper {
       display: none;
     }

--- a/assets/less/trays.less
+++ b/assets/less/trays.less
@@ -23,7 +23,6 @@
 }
 
 .tray {
-  .bottom-left-shadow-border;
   display: none;
   position: absolute;
   right: 5px;


### PR DESCRIPTION
## Overview

I know this is probably an annoying or sensible issue for fauxton, but even after a few years i feel that the half transparent huge shadows are outdated feel cluttered and don't really help communicate "professional db admin tool", most importantly they are so big that they are  a 'thing' in regard to brain parsing the interface so add overhead in usability.

This PR just replaces them with more standard borders, I really hope to not offend anyone, and i know these things are easy to result in bikeshedding, because easy things attract people to 'fix'  and hard things are never worked on but i promise i help on hard issues too in the future.

## Testing recommendations

manual test for visual changes

