### PR TITLE
Remove usage of JQuery param

### DIFF
--- a/app/addons/auth/api.js
+++ b/app/addons/auth/api.js
@@ -69,7 +69,7 @@ export function getSession() {
 export function login(body) {
   return formEncoded(app.host + "/_session", {
     method: "POST",
-    body: $.param(body)
+    body: app.utils.queryParams(body)
   });
 }
 
@@ -77,7 +77,7 @@ export function logout() {
   loggedInSessionPromise = null;
   return formEncoded(app.host + "/_session", {
     method: "DELETE",
-    body: $.param({ username: "_", password: "_" })
+    body: app.utils.queryParams({ username: "_", password: "_" })
   });
 }
 

--- a/app/addons/databases/actions.js
+++ b/app/addons/databases/actions.js
@@ -182,7 +182,7 @@ export default {
   },
 
   fetchAllDbsWithKey: (id, callback) => {
-    const query = '?' + $.param({
+    const query = '?' + app.utils.queryParams({
       startkey: JSON.stringify(id),
       endkey: JSON.stringify(id + "\u9999"),
       limit: 30

--- a/app/addons/databases/resources.js
+++ b/app/addons/databases/resources.js
@@ -88,7 +88,7 @@ Databases.Changes = FauxtonAPI.Collection.extend({
   url: function (context) {
     var query = "";
     if (this.params) {
-      query = "?" + $.param(this.params);
+      query = "?" + app.utils.queryParams(this.params);
     }
 
     if (!context) { context = 'server';}

--- a/app/addons/documents/changes/actions.js
+++ b/app/addons/documents/changes/actions.js
@@ -58,7 +58,7 @@ export default {
       params.feed = 'longpoll';
     }
 
-    const query = $.param(params);
+    const query = app.utils.queryParams(params);
     const db = app.utils.safeURLName(changesStore.getDatabaseName());
     const endpoint = FauxtonAPI.urls('changes', 'server', db, '?' + query);
     currentRequest = $.getJSON(endpoint);

--- a/app/addons/documents/components/actions.js
+++ b/app/addons/documents/components/actions.js
@@ -10,12 +10,13 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import $ from 'jquery';
+import app from "../../../app";
 import FauxtonAPI from "../../../core/api";
 
 export default {
   fetchAllDocsWithKey: (database) => {
     return (id, callback) => {
-      const query = '?' + $.param({
+      const query = '?' + app.utils.queryParams({
         startkey: JSON.stringify(id),
         endkey: JSON.stringify(id + "\u9999"),
         limit: 30

--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -224,12 +224,12 @@ Documents.AllDocs = PagingCollection.extend({
 
     if (params) {
       if (!_.isEmpty(params)) {
-        query = "?" + $.param(params);
+        query = "?" + app.utils.queryParams(params);
       } else {
         query = '';
       }
     } else if (this.params) {
-      query = "?" + $.param(this.params);
+      query = "?" + app.utils.queryParams(this.params);
     }
     if (_.isUndefined(context)) {
       context = 'server';

--- a/app/core/__tests__/utils.test.js
+++ b/app/core/__tests__/utils.test.js
@@ -74,13 +74,13 @@ describe('Utils', () => {
       assert.isUndefined(utils.localStorageGet('qwerty'));
     });
 
-    it ('Should get value after setting it', () => {
+    it('Should get value after setting it', () => {
       const key = 'key1';
       utils.localStorageSet(key, 1);
       assert.equal(utils.localStorageGet(key), 1);
     });
 
-    it ('Set and retrieve complex object', () => {
+    it('Set and retrieve complex object', () => {
       const key = 'key2',
         obj = {
           one: 1,
@@ -90,7 +90,7 @@ describe('Utils', () => {
       assert.deepEqual(utils.localStorageGet(key), obj);
     });
 
-    it ('stripHTML removes HTML', () => {
+    it('stripHTML removes HTML', () => {
       [
         { html: '<span>okay</span>', text: 'okay' },
         { html: 'test <span>before</span> and after', text: 'test before and after' },
@@ -101,5 +101,18 @@ describe('Utils', () => {
       });
     });
 
+  });
+
+  describe('queryParams', () => {
+    it('builds query string from an object', () => {
+      assert.equal(
+        utils.queryParams({
+          startkey: JSON.stringify('_design/app'),
+          endkey: JSON.stringify('_design/app\u9999'),
+          limit:30
+        }),
+        'startkey=%22_design%2Fapp%22&endkey=%22_design%2Fapp%E9%A6%99%22&limit=30'
+      );
+    });
   });
 });

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -18,8 +18,8 @@
 // "purely functional" helper system.
 
 
-import $ from "jquery";
-import _ from "lodash";
+import _ from 'lodash';
+import param from 'jquery-param-fn';
 
 const utils = {
 
@@ -27,22 +27,22 @@ const utils = {
   getParams: function (queryString) {
     if (queryString) {
       // I think this could be combined into one if
-      if (queryString.substring(0, 1) === "?") {
+      if (queryString.substring(0, 1) === '?') {
         queryString = queryString.substring(1);
       } else if (queryString.indexOf('?') > -1) {
         queryString = queryString.split('?')[1];
       }
     }
-    var hash = window.location.hash.split('?')[1];
+    const hash = window.location.hash.split('?')[1];
     queryString = queryString || hash || window.location.search.substring(1);
-    var match,
-    urlParams = {},
-    pl     = /\+/g,  // Regex for replacing addition symbol with a space
-    search = /([^&=]+)=?([^&]*)/g,
-    decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); },
-    query  = queryString;
+    const urlParams = {},
+      pl = /\+/g,  // Regex for replacing addition symbol with a space
+      search = /([^&=]+)=?([^&]*)/g,
+      decode = function (s) { return decodeURIComponent(s.replace(pl, ' ')); },
+      query = queryString;
 
     if (queryString) {
+      let match;
       while ((match = search.exec(query))) {
         urlParams[decode(match[1])] = decode(match[2]);
       }
@@ -51,24 +51,19 @@ const utils = {
     return urlParams;
   },
 
-  // this takes the current URL and replaces all ?x=x with whatever new params are passed
-  replaceQueryParams: function (params) {
-    var fragment = window.location.hash.replace(/\?.*$/, "");
-    if (!_.isEmpty(params)) {
-      fragment = fragment + "?" + $.param(params);
-    }
-    return fragment;
-  },
-
   removeSpecialCharacters: function (name) {
-    return name.replace(/[^\w\s]/gi, "");
+    return name.replace(/[^\w\s]/gi, '');
   },
 
-  safeURLName: function (name = "") {
+  safeURLName: function (name = '') {
     // These special caracters are allowed by couch: _, $, (, ), +, -, and /
     // From them only $ + and / are to be escaped in a URI component.
     // return (/[$+/]/g.test(name)) ? encodeURIComponent(name) : name;
     return encodeURIComponent(name);
+  },
+
+  queryParams: function (obj) {
+    return param(obj);
   },
 
   getDocTypeFromId: function (id) {
@@ -89,7 +84,7 @@ const utils = {
   // json editor for docs, or into a ddoc specific page.
   getSafeIdForDoc: function (id) {
     if (utils.getDocTypeFromId(id) === 'design doc') {
-      var ddoc = id.replace(/^_design\//, '');
+      const ddoc = id.replace(/^_design\//, '');
       return '_design/' + utils.safeURLName(ddoc);
     }
 
@@ -102,7 +97,7 @@ const utils = {
     if (_.isObject(value) || _.isArray(value)) {
       value = JSON.stringify(value);
     }
-    var success = true;
+    let success = true;
     try {
       window.localStorage.setItem(key, value);
     } catch (e) {
@@ -112,7 +107,7 @@ const utils = {
   },
 
   localStorageGet: function (key) {
-    var data;
+    let data;
     if (_.has(window.localStorage, key)) {
       data = window.localStorage[key];
       try {
@@ -131,7 +126,7 @@ const utils = {
       return str;
     }
 
-    var tmpElement = document.createElement("div");
+    const tmpElement = document.createElement('div');
     tmpElement.innerHTML = str;
     return tmpElement.textContent || tmpElement.innerText;
   }

--- a/assets/js/plugins/cloudant.pagingcollection.js
+++ b/assets/js/plugins/cloudant.pagingcollection.js
@@ -13,8 +13,7 @@
 import _ from 'lodash';
 import $ from 'jquery';
 import Backbone from "backbone";
-
-const $param = $.param;
+import app from '../../../app/app';
 
 //PagingCollection
 //----------------
@@ -134,7 +133,7 @@ export const PagingCollection = Backbone.Collection.extend({
       }
     }, this);
 
-    this.url = url + '?' + $param(params);
+    this.url = url + '?' + app.utils.queryParams(params);
   },
 
   fetch: function () {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "http-proxy": "^1.16.0",
     "imports-loader": "^0.7.0",
     "jquery": "^3.2.1",
+    "jquery-param-fn": "^1.0.0",
     "jsondiffpatch": "^0.1.41",
     "less": "^2.7.2",
     "less-loader": "^4.0.3",


### PR DESCRIPTION
## Overview

Replaces all uses of JQuery's `param()` 

## Testing recommendations

Added several Jest tests to confirm new `queryParams()` utility method behaves
just like JQuery's `param()`.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
