### PR TITLE
Remove usage of query-string

### DIFF
--- a/app/addons/documents/__tests__/fetch-actions.test.js
+++ b/app/addons/documents/__tests__/fetch-actions.test.js
@@ -18,7 +18,7 @@ import {
 } from '../index-results/actions/fetch';
 import {queryAllDocs, postToBulkDocs} from '../index-results/api';
 import fetchMock from 'fetch-mock';
-import queryString from 'query-string';
+import app from '../../../app';
 import sinon from 'sinon';
 import SidebarActions from '../sidebar/actions';
 import FauxtonAPI from '../../../core/api';
@@ -208,7 +208,7 @@ describe('Docs Fetch API', () => {
 
     it('queries _all_docs with default params', () => {
       const fetchUrl = '/testdb/_all_docs';
-      const query = queryString.stringify(params);
+      const query = app.utils.queryString(params);
       const url = `${fetchUrl}?${query}`;
       fetchMock.getOnce(url, docs);
 

--- a/app/addons/documents/index-results/api.js
+++ b/app/addons/documents/index-results/api.js
@@ -12,14 +12,14 @@
 
 import 'url-polyfill';
 import 'whatwg-fetch';
-import queryString from 'query-string';
+import app from '../../../app';
 import Constants from '../constants';
 import FauxtonAPI from '../../../core/api';
 
 export const queryAllDocs = (fetchUrl, params) => {
   // Exclude params 'group', 'reduce' and 'group_level' if present since they not allowed for '_all_docs'
   Object.assign(params, {reduce: undefined, group: undefined, group_level: undefined});
-  const query = queryString.stringify(params);
+  const query = app.utils.queryString(params);
   const url = `${fetchUrl}${fetchUrl.includes('?') ? '&' : '?'}${query}`;
   return fetch(url, {
     credentials: 'include',
@@ -50,7 +50,7 @@ export const queryMapReduceView = (fetchUrl, params) => {
     params.group = undefined;
     params.group_level = undefined;
   }
-  const query = queryString.stringify(params);
+  const query = app.utils.queryString(params);
   const url = `${fetchUrl}${fetchUrl.includes('?') ? '&' : '?'}${query}`;
   return fetch(url, {
     credentials: 'include',

--- a/app/addons/documents/index-results/containers/ApiBarContainer.js
+++ b/app/addons/documents/index-results/containers/ApiBarContainer.js
@@ -14,7 +14,7 @@ import { connect } from 'react-redux';
 
 import PropTypes from 'prop-types';
 
-import queryString from 'query-string';
+import app from '../../../../app';
 import { ApiBarWrapper } from '../../../components/layouts';
 import { getQueryOptionsParams } from '../reducers';
 import FauxtonAPI from '../../../../core/api';
@@ -25,7 +25,7 @@ const mapStateToProps = ({indexResults}, {docUrl, endpoint, endpointAddQueryOpti
   }
 
   if (endpoint && endpointAddQueryOptions) {
-    const query = queryString.stringify(getQueryOptionsParams(indexResults));
+    const query = app.utils.queryString(getQueryOptionsParams(indexResults));
     if (query) {
       endpoint = endpoint.indexOf('?') == -1 ? `${endpoint}?${query}` : `${endpoint}&${query}`;
     }

--- a/app/addons/documents/mango/mango.api.js
+++ b/app/addons/documents/mango/mango.api.js
@@ -11,7 +11,6 @@
 // the License.
 
 import 'whatwg-fetch';
-import queryString from 'query-string';
 import app from "../../../app";
 import FauxtonAPI from "../../../core/api";
 import Constants from '../constants';
@@ -60,7 +59,7 @@ export const createIndex = (databaseName, indexCode) => {
 };
 
 export const fetchIndexes = (databaseName, params) => {
-  const query = queryString.stringify(params);
+  const query = app.utils.queryString(params);
   let url = FauxtonAPI.urls('mango', 'index-server', app.utils.safeURLName(databaseName));
   url = `${url}${url.includes('?') ? '&' : '?'}${query}`;
 

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -63,6 +63,18 @@ const utils = {
   },
 
   queryParams: function (obj) {
+    //Simulates jQuery.param()
+    return param(obj);
+  },
+
+  queryString: function (obj) {
+    //Similar to queryParams() but skips object properties
+    //that are undefined
+    Object.keys(obj).forEach((key) => {
+      if (obj[key] === undefined) {
+        delete obj[key];
+      }
+    });
     return param(obj);
   },
 


### PR DESCRIPTION
## Overview

Removed dependency with `query-string` package in favour of the already existing `app.utils.queryParam()` function.

## Testing recommendations

- browse documents
  - change *Documents per page*
  - set *Query Options*
- run Mango query

## GitHub issue number

https://github.com/apache/couchdb-fauxton/issues/1033

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
