### PR TITLE
Upgrade to Enzyme 3.2

### DIFF
--- a/app/addons/components/__tests__/beautify.test.js
+++ b/app/addons/components/__tests__/beautify.test.js
@@ -31,7 +31,7 @@ describe('Beautify', () => {
   it('should have button to beautify for single line code', () => {
     const badCode = '() => { console.log("hello"); }';
     beautifyEl = mount(<ReactComponents.Beautify code={badCode}/>);
-    assert.ok(beautifyEl.hasClass('beautify'));
+    assert.ok(beautifyEl.find('button').hasClass('beautify'));
   });
 
   it('on click beautifies code', () => {

--- a/app/addons/components/__tests__/zenMode.test.js
+++ b/app/addons/components/__tests__/zenMode.test.js
@@ -36,12 +36,12 @@ describe('Zen Mode', () => {
 
   describe('Toggle theme', () => {
     it('defaults to dark theme', () => {
-      assert.ok(el.hasClass('zen-theme-dark'));
+      assert.ok(el.find('div.zen-theme-dark').exists());
     });
 
     it('switch to light theme on click', () => {
       el.find('.js-toggle-theme').simulate('click');
-      assert.ok(el.hasClass('zen-theme-light'));
+      assert.ok(el.find('div.zen-theme-light').exists());
       // reset
       el.find('.js-toggle-theme').simulate('click');
     });

--- a/app/addons/cors/__tests__/components.test.js
+++ b/app/addons/cors/__tests__/components.test.js
@@ -39,6 +39,7 @@ describe('CORS Components', () => {
         origins={['https://localhost']}
         saveCORS={sinon.stub()}
         showDeleteDomainConfirmation={sinon.stub()}
+        fetchAndLoadCORSOptions={sinon.stub()}
       />);
 
       wrapper.find('.enable-disable .btn').simulate('click');
@@ -55,6 +56,7 @@ describe('CORS Components', () => {
         origins={[]}
         saveCORS={sinon.stub()}
         showDeleteDomainConfirmation={sinon.stub()}
+        fetchAndLoadCORSOptions={sinon.stub()}
       />);
       wrapper.find('.enable-disable .btn').simulate('click');
       assert.ok(spy.notCalled);
@@ -80,12 +82,13 @@ describe('CORS Components', () => {
       const spy = sinon.stub(window, 'confirm');
       spy.returns(false);
 
-      const wrapper = shallow(<Views.CORSScreen
+      const wrapper = mount(<Views.CORSScreen
         corsEnabled={true}
         isAllOrigins={false}
         origins={[]}
         saveCORS={sinon.stub()}
         showDeleteDomainConfirmation={sinon.stub()}
+        fetchAndLoadCORSOptions={sinon.stub()}
       />);
       wrapper.find('input').at(0).simulate('change', { target: { checked: true, value: 'all' } });
       assert.notOk(spy.calledOnce);

--- a/app/addons/documents/__tests__/changes.test.js
+++ b/app/addons/documents/__tests__/changes.test.js
@@ -138,9 +138,9 @@ describe('ChangesController', () => {
 
   beforeEach(() => {
     Actions.initChanges({ databaseName: 'testDatabase' });
+    Actions.updateChanges(changesResponse);
     headerEl  = mount(<Changes.ChangesTabContent />);
     changesEl = mount(<Changes.ChangesController />);
-    Actions.updateChanges(changesResponse);
   });
 
   afterEach(() => {
@@ -149,6 +149,7 @@ describe('ChangesController', () => {
 
 
   it('should list the right number of changes', () => {
+    changesEl.update();
     assert.equal(results.length, changesEl.find('.change-box').length);
   });
 
@@ -162,6 +163,7 @@ describe('ChangesController', () => {
     submitBtn.simulate('submit');
 
     // confirm only the two deleted items shows up and the IDs maps to the deleted rows
+    changesEl.update();
     assert.equal(2, changesEl.find('.change-box').length);
     assert.equal('doc_3', changesEl.find('.js-doc-id').first().text());
     assert.equal('doc_5', changesEl.find('.js-doc-id').at(1).text());
@@ -176,6 +178,7 @@ describe('ChangesController', () => {
     submitBtn.simulate('submit');
 
     // confirm only one item shows up and the ID maps to what we'd expect
+    changesEl.update();
     assert.equal(1, changesEl.find('.change-box').length);
     assert.equal('doc_3', changesEl.find('.js-doc-id').first().text());
   });
@@ -197,6 +200,7 @@ describe('ChangesController', () => {
     submitBtn.simulate('submit');
 
     // confirm only one item shows up and that it's doc_5
+    changesEl.update();
     assert.equal(1, changesEl.find('.change-box').length);
     assert.equal('doc_5', changesEl.find('.js-doc-id').first().text());
   });
@@ -204,6 +208,7 @@ describe('ChangesController', () => {
   it('shows a No Docs Found message if no docs', () => {
     Stores.changesStore.reset();
     Actions.updateChanges({ last_seq: 124, results: [] });
+    changesEl.update();
     assert.ok(/There\sare\sno\sdocument\schanges/.test(changesEl.html()));
   });
 });

--- a/app/addons/documents/__tests__/index-results.test.js
+++ b/app/addons/documents/__tests__/index-results.test.js
@@ -19,7 +19,7 @@ import sinon from 'sinon';
 describe('IndexResults', () => {
   it('calls fetchDocs on mount only when fetchAtStartup is set to true', () => {
     const spy = sinon.spy();
-    const wrapperFetch = shallow(<IndexResults
+    shallow(<IndexResults
       fetchParams={{}}
       selectedDocs={[]}
       queryOptionsParams={{}}
@@ -28,7 +28,6 @@ describe('IndexResults', () => {
       fetchAtStartup={true}
     />);
 
-    wrapperFetch.instance().componentDidMount();
     expect(spy.calledOnce).toBe(true);
 
     spy.reset();
@@ -102,7 +101,7 @@ describe('IndexResults', () => {
       fetchParams={{}}
       selectedDocs={[]}
       queryOptionsParams={{}}
-      fetchAllDocs={() => { }}
+      fetchDocs={() => { }}
       results={[]}
       fetchAtStartup={true}
     />);
@@ -117,7 +116,7 @@ describe('IndexResults', () => {
     }];
     const wrapper = shallow(<IndexResults
       selectedDocs={selectedDocs}
-      fetchAllDocs={() => { }}
+      fetchDocs={() => { }}
       results={[]}
       fetchAtStartup={true}
     />);
@@ -131,7 +130,7 @@ describe('IndexResults', () => {
     }];
     const wrapper = shallow(<IndexResults
       selectedDocs={selectedDocs}
-      fetchAllDocs={() => { }}
+      fetchDocs={() => { }}
       results={[]}
       fetchAtStartup={true}
     />);
@@ -143,7 +142,7 @@ describe('IndexResults', () => {
     const spy = sinon.spy();
     const wrapper = shallow(<IndexResults
       selectedDocs={[]}
-      fetchAllDocs={() => { }}
+      fetchDocs={() => { }}
       results={[]}
       selectDoc={spy}
       fetchAtStartup={true}
@@ -157,7 +156,7 @@ describe('IndexResults', () => {
     const spy = sinon.spy();
     const wrapper = shallow(<IndexResults
       selectedDocs={[]}
-      fetchAllDocs={() => { }}
+      fetchDocs={() => { }}
       results={[]}
       docs={[]}
       allDocumentsSelected={false}

--- a/app/addons/documents/__tests__/results-toolbar.test.js
+++ b/app/addons/documents/__tests__/results-toolbar.test.js
@@ -39,14 +39,14 @@ describe('Results Toolbar', () => {
   it('renders all content when there are results and they are deletable', () => {
     const wrapper = mount(<ResultsToolBar hasResults={true} isListDeletable={true} {...restProps}/>);
     expect(wrapper.find('.bulk-action-component').length).toBe(1);
-    expect(wrapper.find('.two-sides-toggle-button').length).toBe(1);
+    expect(wrapper.find('div.two-sides-toggle-button').length).toBe(1);
     expect(wrapper.find('.document-result-screen__toolbar-create-btn').length).toBe(1);
   });
 
   it('does not render bulk action component when list is not deletable', () => {
     const wrapper = mount(<ResultsToolBar hasResults={true} isListDeletable={false} {...restProps}/>);
     expect(wrapper.find('.bulk-action-component').length).toBe(0);
-    expect(wrapper.find('.two-sides-toggle-button').length).toBe(1);
+    expect(wrapper.find('div.two-sides-toggle-button').length).toBe(1);
     expect(wrapper.find('.document-result-screen__toolbar-create-btn').length).toBe(1);
   });
 });

--- a/app/addons/documents/doc-editor/__tests__/doc-editor.components.test.js
+++ b/app/addons/documents/doc-editor/__tests__/doc-editor.components.test.js
@@ -73,6 +73,7 @@ describe('DocEditorController', () => {
       }
     });
 
+    el.update();
     assert.equal(el.find('.loading-lines').length, 0);
     assert.equal(el.find('.icon-circle-arrow-up').length, 0);
     assert.equal(el.find('.icon-repeat').length, 0);
@@ -102,6 +103,8 @@ describe('DocEditorController', () => {
         doc: doc
       }
     });
+
+    el.update();
     assert.equal(el.find('.view-attachments-section').length, 1);
   });
 
@@ -188,7 +191,7 @@ describe("AttachmentsPanelButton", () => {
 
   it('shows up after loading', () => {
     const el = mount(<Components.AttachmentsPanelButton isLoading={false} doc={doc} />);
-    assert.equal(el.find('.panel-button').length, 1);
+    assert.equal(el.find('button.panel-button').length, 1);
   });
 });
 

--- a/app/addons/documents/index-results/components/results/IndexResults.js
+++ b/app/addons/documents/index-results/components/results/IndexResults.js
@@ -114,5 +114,6 @@ export default class IndexResults extends React.Component {
 }
 
 IndexResults.propTypes = {
-  fetchAtStartup: PropTypes.bool.isRequired
+  fetchAtStartup: PropTypes.bool.isRequired,
+  fetchDocs: PropTypes.func.isRequired
 };

--- a/app/addons/fauxton/navigation/__tests__/navbar-test.js
+++ b/app/addons/fauxton/navigation/__tests__/navbar-test.js
@@ -22,22 +22,24 @@ describe('Navigation Bar', () => {
   };
 
   it('is displayed by default', () => {
-    const NavBar = mount(<NavBarContainer />);
-    expect(NavBar.find('.faux-navbar').length).toBe(1);
+    const navbar = mount(<NavBarContainer />);
+    expect(navbar.find('.faux-navbar').length).toBe(1);
   });
 
   it('is dynamically displayed by isNavBarVisible', () => {
-    const NavBar = mount(<NavBarContainer />);
+    const navbar = mount(<NavBarContainer />);
 
     FauxtonAPI.dispatch({
       type: ActionTypes.NAVBAR_HIDE
     });
-    expect(NavBar.find('.faux-navbar').length).toBe(0);
+    navbar.update();
+    expect(navbar.find('.faux-navbar').length).toBe(0);
 
     FauxtonAPI.dispatch({
       type: ActionTypes.NAVBAR_SHOW
     });
-    expect(NavBar.find('.faux-navbar').length).toBe(1);
+    navbar.update();
+    expect(navbar.find('.faux-navbar').length).toBe(1);
   });
 
   it('can display items with icon badge', () => {
@@ -58,9 +60,9 @@ describe('Navigation Bar', () => {
         icon: "fonticon-database"
       }
     });
-    const NavBar = mount(<NavBarContainer />);
-    expect(NavBar.find('div[data-nav-name="WithoutBadge"] i.faux-navbar__icon-badge').length, 0);
-    expect(NavBar.find('div[data-nav-name="WithBadge"] i.faux-navbar__icon-badge').length, 1);
+    const navbar = mount(<NavBarContainer />);
+    expect(navbar.find('div[data-nav-name="WithoutBadge"] i.faux-navbar__icon-badge').length, 0);
+    expect(navbar.find('div[data-nav-name="WithBadge"] i.faux-navbar__icon-badge').length, 1);
   });
 
 });

--- a/app/addons/fauxton/notifications/__tests__/permanentNotification.test.js
+++ b/app/addons/fauxton/notifications/__tests__/permanentNotification.test.js
@@ -39,12 +39,14 @@ describe('PermanentNotification', () => {
       }
     });
 
+    wrapper.update();
     expect(wrapper.find('.perma-warning__content').html()).toMatch(/Hello World!/);
 
     FauxtonAPI.dispatch({
       type: ActionTypes.HIDE_PERMANENT_NOTIFICATION
     });
 
+    wrapper.update();
     expect(wrapper.find('.perma-warning__content').length).toBe(0);
   });
 });

--- a/app/addons/permissions/__tests__/container-test.js
+++ b/app/addons/permissions/__tests__/container-test.js
@@ -49,6 +49,7 @@ describe('Permissions Container', () => {
       })
     );
 
+    wrapper.update();
     const item = wrapper
       .find('.permissions__admins .permissions__entry');
 

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -19,9 +19,27 @@ window.$ = window.jQuery = require('jquery');
 window._ = require('lodash');
 window.Backbone = require('backbone');
 
+// URL.createObjectURL() and Worker are referenced by brace so we add mock objects to prevent
+// long warning messages from being printed while running the tests.
+if (!window.URL) {
+  window.URL = {};
+}
+if (!window.URL.createObjectURL) {
+  window.URL.createObjectURL = function() {
+    return 'http://localhost';
+  };
+}
+window.Worker = function FakeWorker() {
+  this.postMessage = function () { };
+  this.onmessage = undefined;
+};
+
 Object.defineProperty(window.location, 'origin', {
   writable: true,
   value: 'http://dev:8000'
 });
 
-
+// Setup enzyme's react adapter
+const Enzyme = require('enzyme');
+const EnzymeAdapter = require('enzyme-adapter-react-15');
+Enzyme.configure({ adapter: new EnzymeAdapter() });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "devDependencies": {
     "babel-jest": "^18.0.0",
     "bootstrap": "^3.3.7",
-    "enzyme": "^2.7.1",
+    "enzyme": "^3.2.0",
+    "enzyme-adapter-react-15": "^1.0.5",
     "es5-shim": "4.5.4",
     "fetch-mock": "^5.9.3",
     "jest": "^18.1.0",
@@ -29,7 +30,7 @@
     "react-addons-test-utils": "~15.4.2",
     "redux-devtools": "^3.3.1",
     "redux-mock-store": "^1.2.1",
-    "sinon": "git+https://github.com/sinonjs/sinon.git"
+    "sinon": "^4.1.3"
   },
   "dependencies": {
     "async": "~0.2.6",
@@ -91,12 +92,13 @@
     "prop-types": "^15.6.0",
     "react": "~15.6.2",
     "react-bootstrap": "^0.31.3",
-    "react-dom": "~15.4.1",
+    "react-dom": "~15.6.2",
     "react-motion": "^0.5.0",
     "react-overlays": "^0.7.0",
     "react-range": "0.0.7",
     "react-redux": "^5.0.0",
     "react-select": "1.0.0-rc.2",
+    "react-test-renderer": "^15.6.2",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
     "request": "^2.54.0",


### PR DESCRIPTION
## Overview

Upgrades Enzyme to version 3.2.

This is a pre-requisite for the upgrade to React 16.

## Testing recommendations

Run Jest tests.

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
