### PR TITLE
Run Nightwatch tests with suiteRetries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - DIST=./dist/debug ./bin/fauxton &
   - sleep 30
 script:
-  - travis_retry ./node_modules/.bin/grunt nightwatch
+  - ./node_modules/.bin/grunt nightwatch_retries
 after_script:
   - npm run docker:down
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -164,6 +164,14 @@ module.exports = function (grunt) {
         options: {
           maxBuffer: 1000 * 1024
         }
+      },
+      start_nightWatch_with_retries: {
+        command: 'node ' + __dirname + '/node_modules/nightwatch/bin/nightwatch' +
+        ' -c ' + __dirname + '/test/nightwatch_tests/nightwatch.json' +
+        ' --suiteRetries 3',
+        options: {
+          maxBuffer: 1000 * 1024
+        }
       }
     },
 
@@ -253,4 +261,6 @@ module.exports = function (grunt) {
    */
   //Start Nightwatch test from terminal, using: $ grunt nightwatch
   grunt.registerTask('nightwatch', ['initNightwatch', 'exec:start_nightWatch']);
+  //Same as above but the Nightwatch runner will retry tests 3 times before failing
+  grunt.registerTask('nightwatch_retries', ['initNightwatch', 'exec:start_nightWatch_with_retries']);
 };

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "dev": "node ./devserver.js",
     "devtests": "webpack-dev-server --config webpack.config.test-dev.js --debug --progress",
     "nightwatch": "grunt nightwatch",
+    "nightwatch_retries": "grunt nightwatch_retries",
     "start": "node ./bin/fauxton",
     "start-debug": "DIST=./dist/debug node ./bin/fauxton",
     "preversion": "node version-check.js && grunt release",


### PR DESCRIPTION
## Overview

Adds the `--suiteRetries 3` option when running Nightwatch tests  on Travis. 

### Motivation
Currently `travis_retry` is used to rerun all Nightwatch tests when one or more tests fail. 
In practice though, the Travis job runs for too long and it's aborted before all retries can finish. 
When using the `--suiteRetries` option, Nightwatch will rerun the failed suite right away, instead of relying on Travis to run all tests again.

Side note: Nightwatch has a `--retries` option to retry individual tests instead of the whole suite. Unfortunately it's not suitable because some tests rely on `before()` and `after()` methods, and it'd be a major effort to review all tests and properly use `beforeEach`/`afterEach` instead.

## Testing recommendations

No changes to code.

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
