### PR TITLE
Fix display of String editor when editing a document

### DIFF
--- a/app/addons/components/components/stringeditmodal.js
+++ b/app/addons/components/components/stringeditmodal.js
@@ -36,31 +36,13 @@ export class StringEditModal extends React.Component {
     onSave () { }
   };
 
-  componentDidMount() {
-    if (!this.props.visible) {
-      return;
-    }
-    this.initEditor(this.props.value);
-  }
-
-  componentDidUpdate(prevProps) {
-    if (!this.props.visible) {
-      return;
-    }
-    var val = '';
-    if (!prevProps.visible && this.props.visible) {
-      val = Helpers.parseJSON(this.props.value);
-    }
-
-    this.initEditor(val);
-  }
-
-  initEditor = (val) => {
-    this.editor = ace.edit(this.stringEditor);
+  initAceEditor = (dom_node) => {
+    this.editor = ace.edit(dom_node);
     this.editor.$blockScrolling = Infinity; // suppresses an Ace editor error
     this.editor.setShowPrintMargin(false);
     this.editor.setOption('highlightActiveLine', true);
     this.editor.setTheme('ace/theme/idle_fingers');
+    const val = Helpers.parseJSON(this.props.value);
     this.editor.setValue(val, -1);
   };
 
@@ -81,7 +63,7 @@ export class StringEditModal extends React.Component {
         <Modal.Body>
           <div id="modal-error" className="hide alert alert-error"/>
           <div id="string-editor-wrapper">
-            <div ref={node => this.stringEditor = node} className="doc-code"></div>
+            <div id="string-editor-container" ref={node => this.initAceEditor(node)} className="doc-code"></div>
           </div>
         </Modal.Body>
         <Modal.Footer>

--- a/app/addons/documents/tests/nightwatch/editDocumentWithStringEditor.js
+++ b/app/addons/documents/tests/nightwatch/editDocumentWithStringEditor.js
@@ -1,0 +1,50 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+
+
+module.exports = {
+  'Edit document field using the String Editor' : (client) => {
+    /*jshint multistr: true */
+    const waitTime = client.globals.maxWaitTime,
+          newDatabaseName = client.globals.testDatabaseName,
+          newDocumentName = 'str_editor_document',
+          baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .createDatabase(newDatabaseName)
+      .loginToGUI()
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/new')
+      .waitForElementPresent('#editor-container', waitTime, false)
+      .waitForElementPresent('.ace_gutter-active-line', waitTime, false)
+      // Move editor cursor to _id field
+      .execute('\
+        var editor = ace.edit("doc-editor");\
+        editor.gotoLine(2,4);\
+      ')
+      .clickWhenVisible('button.string-edit')
+      // Check String Editor is displayed
+      .waitForElementPresent('#string-editor-container', waitTime, false)
+      .execute('\
+        var str_editor = ace.edit("string-editor-container");\
+        console.log(str_editor);\
+        str_editor.setValue("' + newDocumentName + '");\
+      ')
+      .clickWhenVisible('#string-edit-save-btn')
+      //Check String editor is no longer visible
+      .waitForElementNotPresent('#string-editor-container', waitTime, false)
+      //Check value has changed in the maind editor
+      .waitForElementPresent('#editor-container', waitTime, false)
+      .assert.containsText('span.ace_string', '"' + newDocumentName + '"')
+      .end();
+  }
+};


### PR DESCRIPTION
## Overview

Fixes display of the String editor when editing a document.

## Testing recommendations

Added a new Nightwatch test to check the String Editor.

To manually test it: 
- Edit or create a new document
- Click on the "_id" field (or any other String field)
- Click the button on the editor's gutter
- The String Editor should show up
- Modify the value and click Modify Text
- The value is changed in the code editor

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
