### PR TITLE
Throttle fetch requests triggered by key press events

### DIFF
--- a/app/addons/components/components/throttledreacselect.js
+++ b/app/addons/components/components/throttledreacselect.js
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import React from "react";
+import ReactDOM from "react-dom";
+import ReactSelect from "react-select";
+
+export class ThrottledReactSelectAsync extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.lastCall = undefined;
+    const { loadOptions } = props;
+    this.throttledLoadOptions = this.wrapThrottler(loadOptions).bind(this);
+  }
+
+  wrapThrottler(loadOptions) {
+    if (!loadOptions) {
+      return () => {};
+    }
+    return (id, callback) => {
+      if (this.lastCall) {
+        clearTimeout(this.lastCall);
+      }
+      this.lastCall = setTimeout(() => {
+        loadOptions(id, callback);
+      }, 400);
+    };
+  }
+
+  render() {
+    const newProps = {
+      ...this.props,
+      loadOptions: this.throttledLoadOptions
+    };
+    return (
+      <ReactSelect.Async {...newProps} />
+    );
+  }
+}

--- a/app/addons/components/react-components.js
+++ b/app/addons/components/react-components.js
@@ -31,6 +31,7 @@ import {TabElement, TabElementWrapper} from './components/tabelement';
 import {Polling, RefreshBtn} from './components/polling';
 import {Copy} from './components/copy';
 import {TabWindowWrapper} from './components/tabwindowwrapper';
+import {ThrottledReactSelectAsync} from './components/throttledreacselect';
 
 export default {
   BadgeList,
@@ -58,5 +59,6 @@ export default {
   TabElementWrapper,
   RefreshBtn,
   Copy,
-  TabWindowWrapper
+  TabWindowWrapper,
+  ThrottledReactSelectAsync
 };

--- a/app/addons/databases/components.js
+++ b/app/addons/databases/components.js
@@ -23,7 +23,6 @@ import FauxtonComponentsReact from "..//fauxton/components";
 import Stores from "./stores";
 import Actions from "./actions";
 
-import ReactSelect from "react-select";
 import {Tooltip, OverlayTrigger} from 'react-bootstrap';
 
 const databasesStore = Stores.databasesStore;
@@ -272,12 +271,13 @@ class AddDatabaseWidget extends React.Component {
   }
 }
 
+
 const JumpToDatabaseWidget = ({loadOptions}) => {
   return (
     <div data-name="jump-to-db" className="faux-header__searchboxwrapper">
       <div className="faux-header__searchboxcontainer">
 
-        <ReactSelect.Async
+        <Components.ThrottledReactSelectAsync
           placeholder="Database name"
           loadOptions={loadOptions}
           clearable={false}

--- a/app/addons/documents/components/jumptodoc.js
+++ b/app/addons/documents/components/jumptodoc.js
@@ -14,15 +14,15 @@ import FauxtonAPI from "../../../core/api";
 // the License.
 
 import PropTypes from 'prop-types';
-
 import React from "react";
 import ReactDOM from "react-dom";
-import ReactSelect from "react-select";
+import Components from "../../components/react-components";
+
 
 const JumpToDoc = ({database, loadOptions}) => {
   return (
     <div>
-      <ReactSelect.Async
+      <Components.ThrottledReactSelectAsync
         className="jump-to-doc"
         name="jump-to-doc"
         placeholder="Document ID"


### PR DESCRIPTION
## Overview

The search fields at the top fire one fetch request for each key pressed. Besides being a waste of resources, a user could overload the server by simply typing fast enough on these fields. 

This PR changes this behaviour so a fetch is only triggered 400ms after the last character was typed in.

## Testing recommendations

 - Open the network tab in the browser's devtools
 - In the database list page, type a few characters in the Database Name field at the top. 
 - If you typed fast enough (i.e. time between each key press is < 400ms) you should see only one request in the network tab
 - Repeat the steps above for the Document search in the All Documents page


## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
