### PR TITLE
Update brace to v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "backbone": "^1.1.0",
     "base-64": "^0.1.0",
     "bluebird": "^3.4.6",
-    "brace": "^0.7.0",
+    "brace": "^0.11.0",
     "chai": "^3.5.0",
     "classnames": "^2.2.5",
     "clean-css": "^4.0.5",


### PR DESCRIPTION
## Overview

Update brace to v0.11.0.
Fixes an annoying issue in the code editor when you type double quotes then a character (e.g. `"avalue`) the editor adds an extra quote it to `""somevalue`. The workaround was to type double quotes then space, so the editor adds the ending quote correctly.
With the latest brace this is no longer needed.

## Testing recommendations

Go to the editor and try the steps described above

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
