### PR TITLE
Encode view attachment URL

### DIFF
--- a/app/addons/documents/doc-editor/__tests__/doc-editor.components.test.js
+++ b/app/addons/documents/doc-editor/__tests__/doc-editor.components.test.js
@@ -34,7 +34,7 @@ const docJSON = {
 };
 
 const docWithAttachmentsJSON = {
-  _id: '_design/test-doc',
+  _id: '_design/test#doc',
   _rev: '12345',
   blah: {
     whatever: {
@@ -42,7 +42,7 @@ const docWithAttachmentsJSON = {
     }
   },
   _attachments: {
-    "one.png": {
+    "one%2F.png": {
       "content-type": "images/png",
       "length": 100
     },
@@ -53,7 +53,7 @@ const docWithAttachmentsJSON = {
   }
 };
 
-const database = new Databases.Model({ id: 'id' });
+const database = new Databases.Model({ id: 'a/special?db' });
 
 
 describe('DocEditorController', () => {
@@ -137,7 +137,7 @@ describe('DocEditorController', () => {
     const $attachmentNode = el.find('.view-attachments-section .dropdown-menu li');
     const attachmentURLactual = $attachmentNode.find('a').first().prop('href');
 
-    assert.equal(attachmentURLactual, '../../id/_design/test-doc/one.png');
+    assert.equal(attachmentURLactual, '../../a%2Fspecial%3Fdb/_design%2Ftest%23doc/one%252F.png');
   });
 
   it.skip('setting deleteDocModal=true in store shows modal', () => {

--- a/app/addons/documents/doc-editor/components.js
+++ b/app/addons/documents/doc-editor/components.js
@@ -11,7 +11,6 @@
 // the License.
 
 import FauxtonAPI from "../../../core/api";
-import app from "../../../app";
 import PropTypes from 'prop-types';
 import React from "react";
 import { Dropdown, MenuItem } from "react-bootstrap";
@@ -216,11 +215,11 @@ class AttachmentsPanelButton extends React.Component {
   };
 
   getAttachmentList = () => {
-    var db = this.props.doc.database.get('id');
-    var doc = this.props.doc.get('_id');
+    const db = encodeURIComponent(this.props.doc.database.get('id'));
+    const doc = encodeURIComponent(this.props.doc.get('_id'));
 
     return _.map(this.props.doc.get('_attachments'), function (item, filename) {
-      var url = FauxtonAPI.urls('document', 'attachment', db, doc, app.utils.safeURLName(filename));
+      const url = FauxtonAPI.urls('document', 'attachment', db, doc, encodeURIComponent(filename));
       return (
         <MenuItem key={filename} href={url} target="_blank" data-bypass="true">
           <strong>{filename}</strong>


### PR DESCRIPTION
## Overview

Encodes the attachment URL so it won't fail when the database, document or attachment name contains special characters. 

## Testing recommendations

 - Create a new document with ID `new/doc?1`
 - Upload an attachment
 - Use the View Attachments menu to download the attachment

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
