### PR TITLE
Allow setting the protocol of the couchdb URL for nightwatch tests

### DIFF
--- a/settings.json.default.json
+++ b/settings.json.default.json
@@ -77,6 +77,7 @@
       "fauxton_username": "tester",
       "password": "testerpass",
       "fauxton_port": "8000",
+      "db_protocol": "http",
       "db_host": "localhost",
       "db_port": "5984",
       "custom_commands_path": ["test/nightwatch_tests/custom-commands", "test/nightwatch_tests/custom-commands/auth"],

--- a/tasks/fauxton.js
+++ b/tasks/fauxton.js
@@ -104,6 +104,7 @@ module.exports = function (grunt) {
       launch_url: this.data.settings.nightwatch.launch_url,
       fauxton_host: _getHost(this.data.settings.nightwatch.fauxton_ip),
       fauxton_port: this.data.settings.nightwatch.fauxton_port,
+      db_protocol: this.data.settings.nightwatch.db_protocol,
       db_host: this.data.settings.nightwatch.db_host,
       db_port: this.data.settings.nightwatch.db_port,
       selenium_port: this.data.settings.nightwatch.selenium_port

--- a/test/nightwatch_tests/nightwatch.json.underscore
+++ b/test/nightwatch_tests/nightwatch.json.underscore
@@ -25,7 +25,7 @@
       "fauxton_username": "<%- fauxton_username %>",
       "password": "<%- password %>",
       "launch_url": "http://<%- fauxton_host %>:<%- fauxton_port %>",
-      "db_url": "http://<%- fauxton_username %>:<%- password %>@<%- db_host %>:<%- db_port %>",
+      "db_url": "<%- db_protocol %>://<%- fauxton_username %>:<%- password %>@<%- db_host %>:<%- db_port %>",
       "selenium_host" : "127.0.0.1",
       "selenium_port" : "<%- selenium_port %>",
       "silent" : true,


### PR DESCRIPTION
## Overview

Currently the couchDB URL used by Nightwatch is hardcoded to use HTTP.
This PR adds the new `nightwatch.db_protocol` parameter to `settings.json` to allow changing the default to HTTPS.

## Testing recommendations

Nightwatch tests still pass.
The default used by Travis is still HTTP.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
