### PR TITLE
Remove JQuery usage from config addon

### DIFF
--- a/app/addons/config/actions.js
+++ b/app/addons/config/actions.js
@@ -103,10 +103,8 @@ export default {
     var optionModel = new Resources.OptionModel(modelAttrs);
 
     return optionModel.destroy()
-      .then(
-        () => this.optionDeleteSuccess(options),
-        xhr => this.optionDeleteFailure(options, JSON.parse(xhr.responseText).reason)
-      );
+      .then(() => this.optionDeleteSuccess(options))
+      .catch((err) => this.optionDeleteFailure(options, err.message));
   },
 
   optionDeleteSuccess (options) {

--- a/app/addons/config/components.js
+++ b/app/addons/config/components.js
@@ -230,9 +230,13 @@ class ConfigOptionValue extends React.Component {
 }
 
 class ConfigOptionTrash extends React.Component {
-  state = {
-    show: false
-  };
+  constructor (props) {
+    super(props);
+    this.onDelete = this.onDelete.bind(this);
+    this.showModal = this.showModal.bind(this);
+    this.hideModal = this.hideModal.bind(this);
+    this.state = { show: false };
+  }
 
   onDelete = () => {
     this.props.onDelete();
@@ -248,13 +252,12 @@ class ConfigOptionTrash extends React.Component {
 
   render() {
     return (
-      <td className="text-center config-item-trash config-delete-value"
-        onClick={this.showModal.bind(this)}>
-        <i className="icon icon-trash"></i>
+      <td className="text-center config-item-trash config-delete-value">
+        <i className="icon icon-trash" onClick={this.showModal}></i>
         <FauxtonComponents.ConfirmationModal
           text={`Are you sure you want to delete ${this.props.sectionName}/${this.props.optionName}?`}
-          onClose={this.hideModal.bind(this)}
-          onSubmit={this.onDelete.bind(this)}
+          onClose={this.hideModal}
+          onSubmit={this.onDelete}
           visible={this.state.show}/>
       </td>
     );

--- a/app/addons/config/resources.js
+++ b/app/addons/config/resources.js
@@ -31,15 +31,19 @@ Config.OptionModel = Backbone.Model.extend({
   isNew () { return false; },
 
   sync (method, model) {
-    let operation = put;
+    let operation;
     if (method === 'delete') {
-      operation = deleteRequest;
+      operation = deleteRequest(
+        model.url()
+      );
+    } else {
+      operation = put(
+        model.url(),
+        model.get('value')
+      );
     }
 
-    return operation(
-      model.url(),
-      model.get('value')
-    ).then((res) => {
+    return operation.then((res) => {
       if (res.error) {
         throw new Error(res.reason || res.error);
       }

--- a/app/addons/config/resources.js
+++ b/app/addons/config/resources.js
@@ -12,6 +12,7 @@
 
 import app from "../../app";
 import FauxtonAPI from "../../core/api";
+import { deleteRequest, put } from "../../core/ajax";
 
 var Config = FauxtonAPI.addon();
 
@@ -30,20 +31,20 @@ Config.OptionModel = Backbone.Model.extend({
   isNew () { return false; },
 
   sync (method, model) {
-
-    var params = {
-      url: model.url(),
-      contentType: 'application/json',
-      dataType: 'json',
-      data: JSON.stringify(model.get('value'))
-    };
-
+    let operation = put;
     if (method === 'delete') {
-      params.type = 'DELETE';
-    } else {
-      params.type = 'PUT';
+      operation = deleteRequest;
     }
-    return $.ajax(params);
+
+    return operation(
+      model.url(),
+      model.get('value')
+    ).then((res) => {
+      if (res.error) {
+        throw new Error(res.reason || res.error);
+      }
+      return res;
+    });
   }
 });
 


### PR DESCRIPTION
## Overview

 - Remove JQuery usage from config addon
 - Also fixes a bug in the delete confirmation modal where the Cancel and X buttons were not closing the modal. 

## Testing recommendations

- Go to Config page
  - Add a new option
  - Edit the value of the new option
  - Delete the new option

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
