### PR TITLE
Only use update and stable query params when set

### DIFF
--- a/app/addons/documents/__tests__/reducers.test.js
+++ b/app/addons/documents/__tests__/reducers.test.js
@@ -482,5 +482,51 @@ describe('Docs Reducers', () => {
         group_level: 2
       });
     });
+
+    it('only adds update when set to non-default value in the queryOptionsPanel', () => {
+      const action = {
+        type: ActionTypes.INDEX_RESULTS_REDUX_NEW_QUERY_OPTIONS,
+        options: {
+          update: 'lazy'
+        }
+      };
+
+      const newStateLazy = Reducers.default(initialState, action);
+      expect(Reducers.getQueryOptionsParams(newStateLazy)).toEqual({
+        update: 'lazy'
+      });
+
+      action.options.update = 'false';
+      const newStateFalse = Reducers.default(initialState, action);
+      expect(Reducers.getQueryOptionsParams(newStateFalse)).toEqual({
+        update: 'false'
+      });
+
+      action.options.update = 'true';
+      const newStateTrue = Reducers.default(initialState, action);
+      expect(Reducers.getQueryOptionsParams(newStateTrue)).toEqual({
+        update: undefined
+      });
+    });
+
+    it('only adds stable when set to non-default value in the queryOptionsPanel', () => {
+      const action = {
+        type: ActionTypes.INDEX_RESULTS_REDUX_NEW_QUERY_OPTIONS,
+        options: {
+          stable: true
+        }
+      };
+
+      const newStateTrue = Reducers.default(initialState, action);
+      expect(Reducers.getQueryOptionsParams(newStateTrue)).toEqual({
+        stable: true
+      });
+
+      action.options.stable = false;
+      const newStateFalse = Reducers.default(initialState, action);
+      expect(Reducers.getQueryOptionsParams(newStateFalse)).toEqual({
+        stable: undefined
+      });
+    });
   });
 });

--- a/app/addons/documents/index-results/reducers.js
+++ b/app/addons/documents/index-results/reducers.js
@@ -322,12 +322,21 @@ export const getQueryOptionsParams = (state) => {
     }
   }
 
+  // Only add UPDATE and STABLE parameters when different than
+  // their respective default values. This prevent errors in
+  // older CouchDB versions that don't support these parameters.
   if (queryOptionsPanel.update !== undefined) {
-    params.update = queryOptionsPanel.update;
+    // Default value is 'true'
+    if (queryOptionsPanel.update !== 'true') {
+      params.update = queryOptionsPanel.update;
+    }
   }
 
   if (typeof queryOptionsPanel.stable === 'boolean') {
-    params.stable = queryOptionsPanel.stable;
+    // Default value is false
+    if (queryOptionsPanel.stable === true) {
+      params.stable = queryOptionsPanel.stable;
+    }
   }
 
   return params;


### PR DESCRIPTION
## Overview

Document list doesn't work with older CouchDB versions that don't support the `update` and `stable` parameters because Fauxton always adds the parameters as part of the GET requests. 

The proposed fix is to only send these params when they're set in the Query Options panel to a value other than their default.

## Testing recommendations

- Go to the All Documents list
- Using the network tab in the browser's devtools, check the `update` and `stable` parameters are no longer being sent.
- Open the Query Options panel. Change the values of `update` and `stable` parameters.
- Check the params are now added to the GET requests

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
