### PR TITLE
url-polyfill name update breaks fauxton build

### DIFF
--- a/app/addons/documents/index-results/api.js
+++ b/app/addons/documents/index-results/api.js
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import 'url-polyfill';
+import '@webcomponents/url';
 import 'whatwg-fetch';
 import app from '../../../app';
 import Constants from '../constants';

--- a/app/addons/replication/api.js
+++ b/app/addons/replication/api.js
@@ -10,7 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import 'url-polyfill';
+import '@webcomponents/url';
 import Constants from './constants';
 import FauxtonAPI from '../../core/api';
 import {get, post, put} from '../../core/ajax';

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,9 @@
       "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
       "dev": true
     },
+    "@webcomponents/url": {
+      "version": "git+https://github.com/webcomponents/URL.git#21758445ee1aaf8df372fb103bf32d30c6c912ab"
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -19805,9 +19808,6 @@
           "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
         }
       }
-    },
-    "url-polyfill": {
-      "version": "git+https://github.com/webcomponents/URL.git#812ca9b2baae653290aceb36362d219cb96c0f35"
     },
     "urls": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "underscore": "~1.4.2",
     "url": "~0.7.9",
     "url-loader": "^0.5.7",
-    "url-polyfill": "git+https://github.com/webcomponents/URL.git",
+    "@webcomponents/url": "git+https://github.com/webcomponents/URL.git",
     "urls": "~0.0.3",
     "uuid": "^3.0.1",
     "visualizeRevTree": "git+https://github.com/neojski/visualizeRevTree.git#gh-pages",


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

After a name change to a fauxton dependency - https://github.com/webcomponents/URL/commit/161f78a312a31fe4edfe336a98a09f13cf2c6c87 - couchdb build fails for fauxton

## Testing recommendations

tested with fauxton 1.1.3

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
