### PR TITLE
Use a supported CouchDB docker image for selenium tests

### DIFF
--- a/docker/dc.selenium.yml
+++ b/docker/dc.selenium.yml
@@ -8,7 +8,9 @@ services:
 
   couchdb:
     container_name: couchdb
-    image: couchdbdev/debian-8-dev
-    command: '--with-haproxy -a tester:testerpass -n 1'
+    image: apache/couchdb:latest
+    environment:
+      COUCHDB_USER: tester
+      COUCHDB_PASSWORD: testerpass
     ports:
       - "5984:5984"

--- a/test/nightwatch_tests/helpers/helpers.js
+++ b/test/nightwatch_tests/helpers/helpers.js
@@ -13,16 +13,30 @@
 var nano = require('nano');
 var async = require('async');
 
+
 function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min)) + min;
 }
 
 const dbName = 'fauxton-selenium-tests-' + getRandomInt(1, 20000);
 
+function createDatabase(nano, database) {
+  return new Promise(function (resolve, reject) {
+    nano.db.create(database, function (err) {
+
+      //Tolerate database already existing
+      if (err && err.status_code != 412)
+        reject(err);
+      else
+        resolve();
+    });
+  });
+}
+
 module.exports = {
   asyncHookTimeout: 20000,
   maxWaitTime: 30000,
-  testDatabaseName : dbName,
+  testDatabaseName: dbName,
 
   getNanoInstance: function (dbURL) {
     console.log('DBURL:', dbURL);
@@ -31,7 +45,7 @@ module.exports = {
 
   beforeEach: function (browser, done) {
     var nano = module.exports.getNanoInstance(browser.globals.test_settings.db_url),
-        database = module.exports.testDatabaseName;
+      database = module.exports.testDatabaseName;
 
     console.log('nano setting up database', database);
 
@@ -43,17 +57,26 @@ module.exports = {
       }
       // create a new database
       nano.db.create(database, function (err, body, header) {
-        if (err) {
-          console.log('Error in setting up ' + database, err.message);
+          if (err) {
+            console.log('Error in setting up ' + database, err.message);
+          }
+          const databaseToCreate = ["_users", "_replicator", "_global_changes"];
+          const promises = databaseToCreate.map(db => createDatabase(nano, db));
+
+          Promise.all(promises).then(function () {
+            done();
+          }).catch(function (err) {
+            console.log("Unable to create required databases:" + JSON.stringify(err));
+            done();
+          });
         }
-        done();
-      });
+      );
     });
   },
 
   afterEach: function (browser, done) {
     var nano = module.exports.getNanoInstance(browser.globals.test_settings.db_url),
-        database = module.exports.testDatabaseName;
+      database = module.exports.testDatabaseName;
 
     console.log('nano cleaning up', database);
     nano.db.destroy(database, function (err, header, body) {


### PR DESCRIPTION
This change mirrors https://github.com/pouchdb/pouchdb/pull/6936 which moved PouchDB off of the obsolete `couchdbdev/debian-8-dev` image (which only has CouchDB 2.0.0 in it!)

I haven't tested this, but Travis should do so for me, if I read `.travis.yml` and `bin/docker-up-and-check.sh` and `package.json` correctly.

@garrensmith I know you're looking for an image that tracks CouchDB master, and that's coming, I promise! But before then I want to ensure you're at least tracking our latest public release. I also want to get rid of these unmaintained images that do no one any favours.

Once this lands I will remove the `couchdbdev/debian-8-dev` image from Docker Hub.