### PR TITLE
String Editor fails to open for some kinds of keys

### DIFF
--- a/app/addons/components/__tests__/codeEditor.test.js
+++ b/app/addons/components/__tests__/codeEditor.test.js
@@ -97,4 +97,41 @@ describe('Code Editor', () => {
     });
   });
 
+  describe('parseLineForStringMatch', () => {
+    const initEditor = (code) => {
+      const editor = mount(
+        <ReactComponents.CodeEditor defaultCode={code} />
+      );
+      sinon.stub(editor.instance(), 'getSelectionStart').returns({row: 1});
+      sinon.stub(editor.instance(), 'getSelectionEnd').returns({row: 1});
+      sinon.stub(editor.instance(), 'isRowExpanded').returns(true);
+      return editor;
+    };
+
+    it('returns matches on pretty formatted code', () => {
+      const code = '{\n "field": "my string value" \n}';
+      codeEditorEl = initEditor(code);
+      const matches = codeEditorEl.instance().parseLineForStringMatch();
+      assert.equal('"my string value" ', matches[3]);
+    });
+    it('returns matches when line ends with comma', () => {
+      const code = '{\n "field": "my string value", \n "field2": 123 \n}';
+      codeEditorEl = initEditor(code);
+      const matches = codeEditorEl.instance().parseLineForStringMatch();
+      assert.equal('"my string value", ', matches[3]);
+    });
+    it('returns matches on code with extra spaces', () => {
+      const code = '{\n "field"  \t :  \t "my string value"  \t  ,  \t  \n "field2": 123 \n}';
+      codeEditorEl = initEditor(code);
+      const matches = codeEditorEl.instance().parseLineForStringMatch();
+      assert.equal('"my string value"  \t  ,  \t  ', matches[3]);
+    });
+    it('returns matches on code with special and non-ASCII chars', () => {
+      const code = '{\n "@langua漢字g e" : "my string value",\n "field2": 123 \n}';
+      codeEditorEl = initEditor(code);
+      const matches = codeEditorEl.instance().parseLineForStringMatch();
+      assert.equal('"my string value",', matches[3]);
+    });
+  });
+
 });

--- a/app/addons/components/components/codeeditor.js
+++ b/app/addons/components/components/codeeditor.js
@@ -245,14 +245,13 @@ export class CodeEditor extends React.Component {
   };
 
   parseLineForStringMatch = () => {
-    var selStart = this.getSelectionStart().row;
-    var selEnd   = this.getSelectionEnd().row;
+    const selStart = this.getSelectionStart().row;
+    const selEnd   = this.getSelectionEnd().row;
 
     // one JS(ON) string can't span more than one line - we edit one string, so ensure we don't select several lines
     if (selStart >= 0 && selEnd >= 0 && selStart === selEnd && this.isRowExpanded(selStart)) {
-      var editLine = this.getLine(selStart),
-          editMatch = editLine.match(/^([ \t]*)("[a-zA-Z0-9_-]*["|']: )?(["|'].*",?[ \t]*)$/);
-
+      const editLine = this.getLine(selStart);
+      const editMatch = editLine.match(/^([ \t]*)("[^"]*["][ \t]*:[ \t]*)?(["|'].*"[ \t]*,?[ \t]*)$/);
       if (editMatch) {
         return editMatch;
       }

--- a/app/addons/components/components/codeeditor.js
+++ b/app/addons/components/components/codeeditor.js
@@ -260,13 +260,14 @@ export class CodeEditor extends React.Component {
   };
 
   openStringEditModal = () => {
-    var matches = this.parseLineForStringMatch();
-    var string = matches[3];
-    var lastChar = string.length - 1;
+    const matches = this.parseLineForStringMatch();
+    let string = matches[3].trim();
+    // Removes trailing comma and surrouding spaces
     if (string.substring(string.length - 1) === ',') {
-      lastChar = string.length - 2;
+      string = string.substring(0, string.length - 1).trim();
     }
-    string = string.substring(1, lastChar);
+    // Removes surrouding quotes
+    string = string.substring(1, string.length - 1);
 
     this.setState({
       stringEditModalVisible: true,


### PR DESCRIPTION
## Overview

Fauxton "Edit string" dialogue blank for certain kinds of keys (#910)

## Testing recommendations

New unit tests added.
To validate manually, copy and paste the document below and confirm string editor opens for all three fields.
```
{
  "field:one"  :   "grub thob"  ,   
  "langu漢age": "bo-x-ewts",
  "@value": "grub thob"
}
```

## GitHub issue number

Closes https://github.com/apache/couchdb-fauxton/issues/910

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
