### PR TITLE
Add search support to code editor

### DIFF
--- a/app/addons/components/components/codeeditor.js
+++ b/app/addons/components/components/codeeditor.js
@@ -13,6 +13,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import FauxtonAPI from "../../../core/api";
 import ace from "brace";
+import "brace/ext/searchbox";
 import {StringEditModal} from './stringeditmodal';
 
 require('brace/mode/javascript');


### PR DESCRIPTION
## Overview

Adds search support to the code editor.

## Testing recommendations

 - Click on a document to open the code editor and press Ctrl+F (Windows/Linux) or Command+F (Mac).
 - You can search for text within the editor using the search dialog

## GitHub issue number

https://github.com/apache/couchdb-fauxton/issues/1100

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
