### PR TITLE
Fix how local creds are checked when creating replications

### DIFF
--- a/app/addons/replication/components/newreplication.js
+++ b/app/addons/replication/components/newreplication.js
@@ -12,7 +12,7 @@
 
 import base64 from 'base-64';
 import React from 'react';
-import app from '../../../app';
+import Helpers from '../../../helpers';
 import {json} from '../../../core/ajax';
 import FauxtonAPI from '../../../core/api';
 import {ReplicationSource} from './source';
@@ -101,7 +101,7 @@ export default class NewReplicationController extends React.Component {
   }
 
   checkCredentials(username, password) {
-    return json(app.host + '/', 'GET', {
+    return json(Helpers.getServerUrl('/'), 'GET', {
       credentials: 'omit',
       headers: {
         'Authorization':'Basic ' + base64.encode(username + ':' + password)


### PR DESCRIPTION
## Overview

When creating/editing replications, the code for credentials check is using `app.host` directly which is not a problem in the dev environment, but it produces errors in the release build.

## Testing recommendations

- Create a new replication using local a database with user/password as either source or target.
- The replication is created successfully

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
