### PR TITLE
Fix warnings that appear at runtime and at Jest tests

### DIFF
--- a/app/addons/databases/__tests__/databasepagination.test.js
+++ b/app/addons/databases/__tests__/databasepagination.test.js
@@ -33,7 +33,8 @@ describe('Database Pagination', function () {
     const tempStore = {
       getTotalAmountOfDatabases: () => { return 10; },
       getPage: () => { return 1; },
-      on: () => {}
+      on: () => {},
+      off: () => {}
     };
 
     const pagination = mount(<DatabaseComponents.DatabasePagination store={tempStore} />);

--- a/app/addons/databases/components.js
+++ b/app/addons/databases/components.js
@@ -316,6 +316,9 @@ class DatabasePagination extends React.Component {
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState(this.getStoreState(nextProps));
+    if (this.props.store) {
+      this.props.store.off('change', this.onChange, this);
+    }
     const {store} = nextProps;
     store.on('change', this.onChange, this);
   }

--- a/app/addons/documents/__tests__/main-fields-view.test.js
+++ b/app/addons/documents/__tests__/main-fields-view.test.js
@@ -17,9 +17,16 @@ import MainFieldsView from '../index-results/components/queryoptions/MainFieldsV
 import sinon from 'sinon';
 
 describe('MainFieldsView', () => {
+  const defaultProps = {
+    stable: false,
+    toggleStable: () => {},
+    update: 'true',
+    changeUpdateField: () => {}
+  };
   const docURL = 'http://foo.com';
   it('does not render reduce when showReduce is false', () => {
     const wrapper = mount(<MainFieldsView
+      {...defaultProps}
       includeDocs={false}
       showReduce={false}
       reduce={false}
@@ -32,6 +39,7 @@ describe('MainFieldsView', () => {
 
   it('render reduce when showReduce is true but does not render grouplevel when reduce is false', () => {
     const wrapper = mount(<MainFieldsView
+      {...defaultProps}
       includeDocs={false}
       showReduce={true}
       reduce={false}
@@ -46,6 +54,7 @@ describe('MainFieldsView', () => {
   it('calls toggleIncludeDocs onChange', () => {
     const spy = sinon.spy();
     const wrapper = mount(<MainFieldsView
+      {...defaultProps}
       includeDocs={false}
       showReduce={true}
       reduce={false}
@@ -60,6 +69,7 @@ describe('MainFieldsView', () => {
   it('calls groupLevelChange onChange', () => {
     const spy = sinon.spy();
     const wrapper = mount(<MainFieldsView
+      {...defaultProps}
       includeDocs={false}
       showReduce={true}
       reduce={true}
@@ -76,6 +86,7 @@ describe('MainFieldsView', () => {
   it('calls toggleReduce onChange', () => {
     const spy = sinon.spy();
     const wrapper = mount(<MainFieldsView
+      {...defaultProps}
       includeDocs={false}
       showReduce={true}
       reduce={true}
@@ -92,6 +103,7 @@ describe('MainFieldsView', () => {
   it('calls toggleStable', () => {
     const spy = sinon.spy();
     const wrapper = mount(<MainFieldsView
+      {...defaultProps}
       includeDocs={false}
       showReduce={false}
       reduce={false}
@@ -107,6 +119,7 @@ describe('MainFieldsView', () => {
   it('calls changeUpdateField', () => {
     const spy = sinon.spy();
     const wrapper = mount(<MainFieldsView
+      {...defaultProps}
       includeDocs={false}
       showReduce={false}
       reduce={false}

--- a/app/addons/documents/__tests__/query-options.test.js
+++ b/app/addons/documents/__tests__/query-options.test.js
@@ -23,7 +23,11 @@ describe('QueryOptions', () => {
     queryOptionsToggleIncludeDocs: () => {},
     reduce: false,
     contentVisible: true,
-    perPage: 10
+    perPage: 10,
+    queryOptionsToggleStable: () => {},
+    queryOptionsChangeUpdate: () => {},
+    stable: false,
+    update: 'true'
   };
 
   it('calls resetPagination and queryOptionsExecute on submit', () => {

--- a/app/addons/documents/doc-editor/components.js
+++ b/app/addons/documents/doc-editor/components.js
@@ -396,7 +396,7 @@ class CloneDocModal extends React.Component {
         if (res.uuids) {
           this.setState({ uuid: res.uuids[0] });
         }
-      });
+      }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Overview

 - Fixes runtime warning: `Can't call setState (or forceUpdate) on an unmounted component.`
 - Fixes test warnings: `Failed prop type: The prop <name> is marked as required in <component>, but its value is 'undefined'.`

## Testing recommendations

 - Verify if database pagination works correctly since it was the only component updated

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
