### PR TITLE
Updates page title to match current route

### DIFF
--- a/app/core/router.js
+++ b/app/core/router.js
@@ -18,6 +18,7 @@ var beforeUnloads = {};
 
 export default Backbone.Router.extend({
   routes: {},
+  originalPageTitle: window.document.title,
 
   beforeUnload: function (name, fn) {
     beforeUnloads[name] = fn;
@@ -44,6 +45,17 @@ export default Backbone.Router.extend({
 
     if (continueNav) {
       Backbone.Router.prototype.navigate(fragment, options);
+      this.updateWindowTitle(fragment);
+    }
+  },
+
+  updateWindowTitle: function(fragment) {
+    if (fragment.startsWith('#/')) {
+      window.document.title = this.originalPageTitle + ' - ' + fragment.substring(2);
+    } else if (fragment.startsWith('/') || fragment.startsWith('#')) {
+      window.document.title = this.originalPageTitle + ' - ' + fragment.substring(1);
+    } else {
+      window.document.title = this.originalPageTitle + ' - ' + fragment;
     }
   },
 


### PR DESCRIPTION
## Overview

Currently the page title remains the same as you navigate inside Fauxton, which makes it very hard to look at your browser history and go back to a specific page.

Now the title is updated after each page transition.

Before: 
![image](https://user-images.githubusercontent.com/30349380/43018205-de456d68-8c26-11e8-825c-01b75d7efd33.png)

After:
![image](https://user-images.githubusercontent.com/30349380/43018338-58587a96-8c27-11e8-8b3a-359efcafc7ed.png)


## Testing recommendations

- Browse to different pages
- The browser history list should show a different title for each page you visited
- Click on one of the items in your history and check the page title matches the actual page

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
