### PR TITLE
Fix setup misc bugs

### DIFF
--- a/app/addons/setup/actions.js
+++ b/app/addons/setup/actions.js
@@ -197,9 +197,8 @@ export const addNode = (isOrWasAdminParty, credentials, setupNode, additionalNod
     }
     const addNodeResponse = await post(baseUrl, addNodeData, {raw: true});
 
-
     if (!addNodeResponse.ok) {
-      const json = await enableRemoteNodeResponse.json();
+      const json = await addNodeResponse.json();
       const error = json.reason ? json.reason : json.error;
       return showError(error);
     }

--- a/app/addons/setup/reducers.js
+++ b/app/addons/setup/reducers.js
@@ -56,9 +56,9 @@ export default function setup(state = initialState, action) {
     case SETUP_BIND_ADDRESS_FOR_SINGLE_NODE:
       return updateState(state, 'setupNode.bindAddress', options.value);
     case SETUP_PORT_FOR_SINGLE_NODE:
-      return updateState(state, 'setupNode.port', options.value);
+      return updateStateIfNotNaN(state, 'setupNode.port', parseInt(options.value));
     case SETUP_PORT_ADDITIONAL_NODE:
-      return updateState(state, 'additionalNode.port', parseInt(options.value));
+      return updateStateIfNotNaN(state, 'additionalNode.port', parseInt(options.value));
     case SETUP_BIND_ADDRESS_ADDITIONAL_NODE:
       return updateState(state, 'additionalNode.bindAddress', options.value);
     case SETUP_REMOTE_ADDRESS_ADDITIONAL_NODE:
@@ -71,8 +71,7 @@ export default function setup(state = initialState, action) {
     case SETUP_RESET_ADDITIONAL_NODE:
       return resetAdditionalNode(getStateCopy(state));
     case SETUP_NODE_COUNT:
-      const nodeCount = Math.min(options.value, 3);
-      return updateState(state, 'setupNode.nodeCount', nodeCount);
+      return updateStateIfNotNaN(state, 'setupNode.nodeCount', parseInt(options.value));
     default:
       return state;
   }
@@ -93,6 +92,14 @@ export const getStateCopy = (state) => {
       ...state.additionalNode
     }
   };
+};
+
+export const updateStateIfNotNaN = (state, path, value) => {
+  let stateCopy = getStateCopy(state);
+  if (_.isNaN(value)) {
+    return stateCopy;
+  }
+  return _.set(stateCopy, path, value);
 };
 
 /**


### PR DESCRIPTION
- When entering string instead of numbers, revert change and keep previous value
- Show correct warning when node add fails
- Allow to configure a cluster of more than 3 nodes

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Due to the recent refactor of the setup addon, I introduced few incorrect changes.

- An error on node addition would fail
- User inputs that is not a number would show NaN
- Node count couldn't be greater than 3


<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

1. Try to configure a node that is already configured, you should have an Update conflict error message.

2. When entering letters or negative number in port and nodeCount inputs, it should keep it's previous value.

3. Node count should be able to be greater than 3

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
