### PR TITLE
Use relative pathname instead of static pathname for local replication

### DIFF
--- a/app/addons/replication/__tests__/api.tests.js
+++ b/app/addons/replication/__tests__/api.tests.js
@@ -94,7 +94,6 @@ describe('Replication API', () => {
       }, {origin: 'http://dev:6767', pathname:'/db/_utils'});
 
       assert.deepEqual(source.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
-      console.log(source.url);
       assert.ok(/\/db\/my%2Fdb/.test(source.url));
     });
 

--- a/app/addons/replication/__tests__/api.tests.js
+++ b/app/addons/replication/__tests__/api.tests.js
@@ -81,6 +81,23 @@ describe('Replication API', () => {
       assert.ok(/my%2Fdb/.test(source.url));
     });
 
+    it('returns local source with auth info and encoded when use relative url', () => {
+      const localSource = 'my/db';
+      const source = getSource({
+        replicationSource: Constants.REPLICATION_SOURCE.LOCAL,
+        localSource,
+        sourceAuth: {
+          username: 'the-user',
+          password: 'password'
+        },
+        sourceAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
+      }, {origin: 'http://dev:6767', pathname:'/db/_utils'});
+
+      assert.deepEqual(source.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
+      console.log(source.url);
+      assert.ok(/\/db\/my%2Fdb/.test(source.url));
+    });
+
     it('returns remote source url and auth header', () => {
       const source = getSource({
         replicationSource: Constants.REPLICATION_SOURCE.REMOTE,
@@ -179,6 +196,21 @@ describe('Replication API', () => {
         },
         targetAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
       });
+
+      assert.deepEqual(target.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
+      assert.ok(/my-existing%2Fdb/.test(target.url));
+    });
+
+    it('returns existing local database even with relative urls', () => {
+      const target = getTarget({
+        replicationTarget: Constants.REPLICATION_TARGET.EXISTING_LOCAL_DATABASE,
+        localTarget: 'my-existing/db',
+        targetAuth: {
+          username: 'the-user',
+          password: 'password'
+        },
+        targetAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
+      }, {origin:'http://dev:6767', pathname:'/db/_utils'});
 
       assert.deepEqual(target.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
       assert.ok(/my-existing%2Fdb/.test(target.url));

--- a/app/addons/replication/__tests__/helpers.tests.js
+++ b/app/addons/replication/__tests__/helpers.tests.js
@@ -15,11 +15,11 @@ import helpers from '../helpers';
 describe('Replication Helpers - getDatabaseLabel', () => {
 
   it('returns database name for string', () => {
-    const db = 'http://tester:testerpass@127.0.0.1/fancy/db/name';
+    const db = 'http://tester:testerpass@127.0.0.1/db/fancy%2Fdb%2Fname';
 
     const res = helpers.getDatabaseLabel(db);
 
-    expect(res).toBe('fancy/db/name');
+    expect(res).toBe('fancy%2Fdb%2Fname');
   });
 
   it('returns database name for object', () => {

--- a/app/addons/replication/api.js
+++ b/app/addons/replication/api.js
@@ -100,11 +100,14 @@ export const getSource = ({
   sourceAuthType,
   sourceAuth
 },
-{origin} = window.location) => {
+{origin, pathname} = window.location) => {
 
   const source = {};
   if (replicationSource === Constants.REPLICATION_SOURCE.LOCAL) {
-    source.url = encodeFullUrl(`${origin}/${localSource}`);
+    const encodedLocalTarget = encodeURIComponent(localSource);
+
+    const root = Helpers.getRootUrl({origin, pathname});
+    source.url = `${root}${encodedLocalTarget}`;
   } else {
     source.url = encodeFullUrl(removeCredentialsFromUrl(remoteSource));
   }
@@ -121,7 +124,7 @@ export const getTarget = ({
   targetAuth
 },
 //this allows us to mock out window.location for our tests
-{origin} = window.location) => {
+{origin, pathname} = window.location) => {
 
   const target = {};
   if (replicationTarget === Constants.REPLICATION_TARGET.NEW_REMOTE_DATABASE ||
@@ -129,7 +132,8 @@ export const getTarget = ({
     target.url = encodeFullUrl(removeCredentialsFromUrl(remoteTarget));
   } else {
     const encodedLocalTarget = encodeURIComponent(localTarget);
-    target.url = `${origin}/${encodedLocalTarget}`;
+    const root = Helpers.getRootUrl({origin, pathname});
+    target.url = `${root}${encodedLocalTarget}`;
   }
 
   setCredentials(target, targetAuthType, targetAuth);

--- a/app/addons/replication/components/common-table.js
+++ b/app/addons/replication/components/common-table.js
@@ -19,15 +19,13 @@ import {removeCredentialsFromUrl} from '../api';
 import Helpers from '../../../helpers';
 
 const getDbNameFromUrl = (urlObj, root) => {
-  let encoded;
   try {
     const urlWithoutDb = new URL(root);
     const dbName = urlObj.pathname.substring(urlWithoutDb.pathname.length);
-    encoded = encodeURIComponent(dbName);
+    return encodeURIComponent(dbName);
   } catch (e) {
     return '';
   }
-  return encoded;
 };
 
 export const formatUrl = (url) => {

--- a/app/addons/replication/components/common-table.js
+++ b/app/addons/replication/components/common-table.js
@@ -16,22 +16,35 @@ import {Table, Tooltip, OverlayTrigger} from "react-bootstrap";
 import moment from 'moment';
 import {ErrorModal} from './modals';
 import {removeCredentialsFromUrl} from '../api';
+import Helpers from '../../../helpers';
+
+const getDbNameFromUrl = (urlObj, root) => {
+  let encoded;
+  try {
+    const urlWithoutDb = new URL(root);
+    const dbName = urlObj.pathname.substring(urlWithoutDb.pathname.length);
+    encoded = encodeURIComponent(dbName);
+  } catch (e) {
+    return '';
+  }
+  return encoded;
+};
 
 export const formatUrl = (url) => {
   let urlObj;
   let encoded;
   try {
     urlObj = new URL(removeCredentialsFromUrl(url));
-    encoded = encodeURIComponent(urlObj.pathname.slice(1));
   } catch (e) {
     return '';
   }
-
+  const root = Helpers.getRootUrl();
+  encoded = getDbNameFromUrl(urlObj, root);
   if (url.indexOf(window.location.hostname) > -1) {
     return (
       <span>
-        {urlObj.origin + '/'}
-        <a href={`#/database/${encoded}/_all_docs`}>{urlObj.pathname.slice(1)}</a>
+        {root}
+        <a href={`#/database/${encoded}/_all_docs`}>{decodeURIComponent(encoded)}</a>
       </span>
     );
   }

--- a/app/addons/replication/helpers.js
+++ b/app/addons/replication/helpers.js
@@ -14,7 +14,8 @@ import _ from 'underscore';
 
 const getDatabaseLabel = db => {
   const dbString = (_.isString(db)) ? db.trim().replace(/\/$/, '') : db.url;
-  return (new URL(dbString)).pathname.slice(1);
+  const pathName = (new URL(dbString)).pathname.slice(1);
+  return pathName.split("/").pop();
 };
 
 export default {

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -78,6 +78,10 @@ Helpers.getServerUrl = endpointRoute => {
   return app.host + endpointRoute;
 };
 
+Helpers.getRootUrl = ({origin, pathname} = window.location) => {
+  return url.resolve(origin + pathname, app.host);
+};
+
 Helpers.getUUID = function (count = 1) {
   const url = Helpers.getServerUrl(`/_uuids?count=${count}`);
   return get(url);


### PR DESCRIPTION
<!-- Thank you for your contribution!


     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

When creating a replication using the new replication form, we used the window.location.pathname as the database name and the origin as the root url.

Therefore, when we setup CouchDB on a subroute(relative url), local url is broken.
     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

I added a unit test. I also tested manually on an existing Couch configuration and one with a relative url.

Relative url setup:


I used a express pouchdb setup.

1. Create a folder 👍 
2. In that folder create a package.json

```json
{
  "name": "test",
  "version": "1.0.0",
  "description": "",
  "main": "test.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
    "express": "^4.16.3",
    "express-pouchdb": "^4.0.0",
    "morgan": "^1.4.0",
    "pouchdb": "^6.4.3"
  }
}
```

3. Create a test.js

```javascript
var express = require('express')
    , app = express()
    , PouchDB = require('pouchdb')
    , logger = require('morgan')
;

app.use(logger("tiny"));
app.get('/', function (req, res, next) {
    res.send('Welcome Traveler!  <a href="/db/_utils/">Fauxton?</a>');
});
//app.use('/express-pouchdb', require('express-pouchdb')(PouchDB));
app.use('/db', require('express-pouchdb')(PouchDB));
app.listen(3000);
```

4. Install depencies with `npm install`

5. You need to edit `node_modules/express-pouchdb/lib/routes/fauxton.js` and change the exports for:

```javascript
module.exports = function (app) {
  app.get('/_utils/', function (req, res) {
    // We want to force /_utils to /_utils/ as this is the CouchDB behavior
    // https://git.io/vDMOD#L78
    // https://git.io/vDMOQ#L974
    if (req.originalUrl === '/_utils') {
      res.redirect(301, '/_utils/');
    } else {
      res.sendFile(path.normalize(FAUXTON_PATH + '/index.html'));
    }
  });

  app.use('/_utils/', express.static(FAUXTON_PATH));
};
```

6. Make a fauxton release (`grunt release`) and copy the release to `node_modules/pouchdb-fauxton/www`

7. You need to replace in the index.html of the release (`dashboard` -> `./dashboard`)

8. You should be good 💃 

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

#1118 

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
