### PR TITLE
Partitioned dbs partition key selector

### DIFF
--- a/app/addons/databases/actions.js
+++ b/app/addons/databases/actions.js
@@ -199,12 +199,14 @@ export default {
   },
 
   setPartitionedDatabasesAvailable(available) {
-    FauxtonAPI.dispatch({
+    const action = {
       type: ActionTypes.DATABASES_PARTITIONED_DB_AVAILABLE,
       options: {
         available
       }
-    });
+    };
+    FauxtonAPI.dispatch(action);
+    FauxtonAPI.reduxDispatch(action);
   },
 
   checkPartitionedQueriesIsAvailable() {

--- a/app/addons/databases/reducers.js
+++ b/app/addons/databases/reducers.js
@@ -1,0 +1,27 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import ActionTypes from './actiontypes';
+const initialState = {
+  partitionedDatabasesAvailable: false
+};
+export default function databases(state = initialState, action) {
+  switch (action.type) {
+    case ActionTypes.DATABASES_PARTITIONED_DB_AVAILABLE:
+      return {
+        ...state,
+        partitionedDatabasesAvailable: action.options.available
+      };
+    default:
+      return state;
+  }
+}

--- a/app/addons/documents/assets/less/documents.less
+++ b/app/addons/documents/assets/less/documents.less
@@ -22,6 +22,7 @@
 @import "header.less";
 @import "revision-browser.less";
 @import "header-docs-left.less";
+@import "partition-key.less";
 
 
 button.beautify {

--- a/app/addons/documents/assets/less/partition-key.less
+++ b/app/addons/documents/assets/less/partition-key.less
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+@import "../../../../../assets/less/variables.less";
+
+.partition-selector {
+  display: flex;
+  align-items: center;
+  padding: 0;
+  min-height: 30px;
+}
+
+// 
+//   line-height: 16px;
+//   padding: 6px 10px 10px 0px;
+//   white-space: nowrap;
+//   overflow: hidden;
+//   text-overflow: ellipsis;
+
+.partition-selector__switch {
+  background-color: transparent;
+  border: none;
+  color: #666;
+  font-size: 1rem;
+  .fonticon-filter {
+    font-size: 1.25rem;
+    padding-right: 6px;
+  }
+  &:hover {
+    color: @hoverHighlight;
+  }
+}
+
+.partition-selector__switch--active {
+  color: @brandHighlight;
+  padding-right: 0px;
+}
+
+.partition-selector__key {
+  flex: 1;
+  color: #666;
+}
+
+.partition-selector__key--active {
+  color: @brandHighlight;
+}
+
+.partition-selector__global {
+  color: #666;
+}

--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -17,6 +17,7 @@ import Documents from "./routes";
 import reducers from "./index-results/reducers";
 import mangoReducers from "./mango/mango.reducers";
 import sidebarReducers from "./sidebar/reducers";
+import partitionKeyReducers from "./partition-key/reducers";
 import revisionBrowserReducers from './rev-browser/reducers';
 import "./assets/less/documents.less";
 
@@ -24,7 +25,8 @@ FauxtonAPI.addReducers({
   indexResults: reducers,
   mangoQuery: mangoReducers,
   sidebar: sidebarReducers,
-  revisionBrowser: revisionBrowserReducers
+  revisionBrowser: revisionBrowserReducers,
+  partitionKey: partitionKeyReducers
 });
 
 function getQueryParam (query) {
@@ -46,6 +48,12 @@ FauxtonAPI.registerUrls('allDocs', {
   apiurl: function (id, query) {
     /** XXX DEPRECATED: use allDocsSanitized **/
     return Helpers.getApiUrl('/' + id + '/_all_docs' + getQueryParam(query));
+  }
+});
+
+FauxtonAPI.registerUrls('partitioned_allDocs', {
+  app: function (databaseName, partitionKey, query) {
+    return 'database/' + databaseName + '/_partition/' + partitionKey + '/_all_docs' + getQueryParam(query);
   }
 });
 
@@ -121,6 +129,18 @@ FauxtonAPI.registerUrls('view', {
 
   fragment: function (database, designDoc, viewName) {
     return 'database/' + database + designDoc + '/_view/' + viewName;
+  }
+});
+
+FauxtonAPI.registerUrls('partitioned_view', {
+  server: function (database, partitionKey, designDoc, viewName) {
+    return Helpers.getServerUrl('/' + database + '/_partition/' + partitionKey + '/_design/' + designDoc + '/_view/' + viewName);
+  },
+  app: function (database, partitionKey, designDoc) {
+    return 'database/' + database + '/_partition/' + partitionKey + '/_design/' + designDoc + '/_view/';
+  },
+  apiurl: function (database, partitionKey, designDoc, viewName) {
+    return Helpers.getApiUrl('/' + database + '/_partition/' + partitionKey + '/_design/' + designDoc + '/_view/' + viewName);
   }
 });
 

--- a/app/addons/documents/layouts.js
+++ b/app/addons/documents/layouts.js
@@ -24,6 +24,7 @@ import IndexResultsContainer from './index-results/containers/IndexResultsContai
 import PaginationContainer from './index-results/containers/PaginationContainer';
 import ApiBarContainer from './index-results/containers/ApiBarContainer';
 import { queryAllDocs, queryMapReduceView } from './index-results/api';
+import PartitionKeySelectorContainer from './partition-key/container';
 import Constants from './constants';
 import Helpers from './helpers';
 
@@ -39,8 +40,21 @@ export const TabsSidebarHeader = ({
   fetchUrl,
   ddocsOnly,
   queryDocs,
-  selectedNavItem
+  selectedNavItem,
+  showPartitionKeySelector,
+  partitionKey,
+  onPartitionKeySelected,
+  onGlobalModeSelected,
+  globalMode
 }) => {
+  const partKeySelector = (<PartitionKeySelectorContainer
+    databaseName={dbName}
+    partitionKey={partitionKey}
+    onPartitionKeySelected={onPartitionKeySelected}
+    onGlobalModeSelected={onGlobalModeSelected}
+    globalMode={globalMode}/>
+  );
+
   return (
     <header className="two-panel-header">
       <div className="flex-layout flex-row">
@@ -51,6 +65,9 @@ export const TabsSidebarHeader = ({
           />
         </div>
         <div className="right-header-wrapper flex-layout flex-row flex-body">
+          <div style={{flex:1, padding: '18px 6px 12px 12px'}}>
+            {showPartitionKeySelector ? partKeySelector : null}
+          </div>
           <div id="right-header" className="flex-fill">
             <RightAllDocsHeader
               hideQueryOptions={hideQueryOptions}
@@ -81,11 +98,17 @@ TabsSidebarHeader.propTypes = {
   hideJumpToDoc: PropTypes.bool,
   database: PropTypes.object.isRequired,
   queryDocs: PropTypes.func,
-  selectedNavItem: PropTypes.object
+  selectedNavItem: PropTypes.object,
+  showPartitionKeySelector: PropTypes.bool,
+  partitionKey: PropTypes.string,
+  onPartitionKeySelected: PropTypes.func.isRequired,
+  onGlobalModeSelected: PropTypes.bool,
+  globalMode: PropTypes.bool
 };
 
 TabsSidebarHeader.defaultProps = {
-  hideHeaderBar: false
+  hideHeaderBar: false,
+  showPartitionKeySelector: false
 };
 
 export const TabsSidebarContent = ({
@@ -138,7 +161,11 @@ export const DocsTabsSidebarLayout = ({
   fetchUrl,
   ddocsOnly,
   deleteEnabled = true,
-  selectedNavItem
+  selectedNavItem,
+  partitionKey,
+  onPartitionKeySelected,
+  onGlobalModeSelected,
+  globalMode
 }) => {
   let queryDocs = (params) => { return queryAllDocs(fetchUrl, params); };
   if (Helpers.isViewSelected(selectedNavItem)) {
@@ -167,6 +194,11 @@ export const DocsTabsSidebarLayout = ({
         ddocsOnly={ddocsOnly}
         queryDocs={queryDocs}
         selectedNavItem={selectedNavItem}
+        showPartitionKeySelector={!ddocsOnly}
+        partitionKey={partitionKey}
+        onPartitionKeySelected={onPartitionKeySelected}
+        onGlobalModeSelected={onGlobalModeSelected}
+        globalMode={globalMode}
       />
       <TabsSidebarContent
         lowerContent={lowerContent}

--- a/app/addons/documents/partition-key/PartitionKeySelector.js
+++ b/app/addons/documents/partition-key/PartitionKeySelector.js
@@ -1,0 +1,138 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import PropTypes from 'prop-types';
+import React from "react";
+import ReactDOM from "react-dom";
+
+
+export default class PartitionKeySelector extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      editorValue: '',
+      editMode: false
+    };
+    this.onModeSwitchClick = this.onModeSwitchClick.bind(this);
+    this.onBlur = this.onBlur.bind(this);
+    this.startEdit = this.startEdit.bind(this);
+    this.onKeyPress = this.onKeyPress.bind(this);
+    this.onChange = this.onChange.bind(this);
+    this.props.checkDbPartitioned(this.props.databaseName);
+  }
+
+  onModeSwitchClick(e) {
+    if (e && e.preventDefault) {
+      e.preventDefault();
+    }
+    if (!this.props.globalMode && this.props.onGlobalModeSelected) {
+      this.props.onGlobalModeSelected();
+    } else if (this.props.partitionKey) {
+      this.props.onPartitionKeySelected(this.state.editorValue);
+    } else {
+      this.startEdit();
+    }
+  }
+
+  startEdit() {
+    this.setState({editMode: true, editorValue: this.props.partitionKey});
+    setTimeout(() => this.textInput.focus());
+  }
+
+  onBlur(e) {
+    if (e && e.preventDefault) {
+      e.preventDefault();
+    }
+    this.setState({editMode: false});
+  }
+
+  onKeyPress(e) {
+    if (e.key === 'Enter') {
+      this.setState({
+        editMode: false
+      });
+      this.props.onPartitionKeySelected(this.state.editorValue);
+    }
+  }
+
+  isPartitionSelected() {
+    return !this.state.global && (this.props.partitionKey.trim().length > 0);
+  }
+
+  onChange(e) {
+    this.setState({editorValue: e.target.value});
+  }
+
+  globalHeader() {
+    return (
+      <button onClick={this.onModeSwitchClick} title="Partition Key Selector" className="button partition-selector__switch">
+        <i className="fonticon-filter"></i>
+        No partition selected
+      </button>
+    );
+  }
+
+  partitionHeader() {
+    const editor = (
+      <input type="text"
+        style={{padding:2, fontSize:16, margin: 0, display: this.state.editMode ? 'block' : 'none'}}
+        onKeyPress={this.onKeyPress}
+        onChange={this.onChange}
+        onBlur={this.onBlur}
+        value={this.state.editorValue}
+        ref={(input) => { this.textInput = input; }} />
+    );
+    let partName = 'Click to select a partition';
+    let className = 'partition-selector__key';
+    if (this.props.partitionKey !== '') {
+      partName = this.props.partitionKey;
+      className += ' partition-selector__key--active';
+    }
+    return (
+      <React.Fragment>
+        <button onClick={this.onModeSwitchClick} title="Partition Key Selector" className="button partition-selector__switch button partition-selector__switch--active">
+          <i className="fonticon-filter"></i>
+        </button>
+        <div className={className}>
+          <span onClick={this.startEdit} style={{display: this.state.editMode ? 'none' : 'block'}}>{partName}</span>
+          {editor}
+        </div>
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    if (!this.props.selectorVisible) {
+      return null;
+    }
+    const global = this.props.globalMode && !this.state.editMode;
+    return (
+      <div className="partition-selector" >
+        {global ? this.globalHeader() : this.partitionHeader()}
+      </div>
+    );
+  }
+}
+
+PartitionKeySelector.defaultProps = {
+  partitionKey: '',
+  globalMode: true
+};
+
+PartitionKeySelector.propTypes = {
+  partitionKey: PropTypes.string.isRequired,
+  checkDbPartitioned: PropTypes.func.isRequired,
+  onPartitionKeySelected: PropTypes.func.isRequired,
+  onGlobalModeSelected: PropTypes.func,
+  globalMode: PropTypes.bool
+};

--- a/app/addons/documents/partition-key/actions.js
+++ b/app/addons/documents/partition-key/actions.js
@@ -1,0 +1,29 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import * as API from './api';
+import ActionTypes from './actiontypes';
+
+export const checkDbPartitioned = (databaseName) => (dispatch) => {
+  //Reset visibility to false
+  dispatch({
+    type: ActionTypes.PARTITON_KEY_HIDE_SELECTOR
+  });
+
+  API.fetchDatabaseInfo(databaseName).then(dbInfo => {
+    if (dbInfo.props && dbInfo.props.partitioned === true) {
+      dispatch({
+        type: ActionTypes.PARTITON_KEY_SHOW_SELECTOR
+      });
+    }
+  });
+};

--- a/app/addons/documents/partition-key/actiontypes.js
+++ b/app/addons/documents/partition-key/actiontypes.js
@@ -1,0 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+export default {
+  PARTITON_KEY_SHOW_SELECTOR: 'PARTITON_KEY_SHOW_SELECTOR',
+  PARTITON_KEY_HIDE_SELECTOR: 'PARTITON_KEY_HIDE_SELECTOR'
+};

--- a/app/addons/documents/partition-key/api.js
+++ b/app/addons/documents/partition-key/api.js
@@ -1,0 +1,20 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import '@webcomponents/url';
+import {get} from '../../../core/ajax';
+import Helpers from "../../../helpers";
+
+export const fetchDatabaseInfo = (databaseName) => {
+  const url = Helpers.getServerUrl("/" + encodeURIComponent(databaseName));
+  return get(url);
+};

--- a/app/addons/documents/partition-key/container.js
+++ b/app/addons/documents/partition-key/container.js
@@ -1,0 +1,49 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import PartitionKeySelector from './PartitionKeySelector';
+import { checkDbPartitioned } from './actions';
+
+const mapStateToProps = ({ partitionKey }, ownProps) => {
+  return {
+    selectorVisible: partitionKey.selectorVisible,
+    databaseName: ownProps.databaseName,
+    partitionKey: ownProps.partitionKey,
+    onPartitionKeySelected: ownProps.onPartitionKeySelected,
+    globalMode: ownProps.globalMode
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    checkDbPartitioned: (databaseName) => {
+      dispatch(checkDbPartitioned(databaseName));
+    }
+  };
+};
+
+const PartitionKeySelectorContainer = connect (
+  mapStateToProps,
+  mapDispatchToProps
+)(PartitionKeySelector);
+
+export default PartitionKeySelectorContainer;
+
+PartitionKeySelectorContainer.propTypes = {
+  databaseName: PropTypes.string.isRequired,
+  partitionKey: PropTypes.string.isRequired,
+  onPartitionKeySelected: PropTypes.func.isRequired,
+  onGlobalModeSelected: PropTypes.func.isRequired,
+  globalMode: PropTypes.bool
+};

--- a/app/addons/documents/partition-key/reducers.js
+++ b/app/addons/documents/partition-key/reducers.js
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import ActionTypes from './actiontypes';
+
+const initialState = {
+  selectorVisible: false
+};
+
+export default function partitionKey(state = initialState, action) {
+  switch (action.type) {
+
+    case ActionTypes.PARTITON_KEY_SHOW_SELECTOR:
+      return {
+        ...state,
+        selectorVisible: true
+      };
+
+    case ActionTypes.PARTITON_KEY_HIDE_SELECTOR:
+      return {
+        ...state,
+        selectorVisible: false
+      };
+
+    default:
+      return state;
+  }
+}

--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -23,8 +23,12 @@ import {DocsTabsSidebarLayout, ViewsTabsSidebarLayout, ChangesSidebarLayout} fro
 
 var DocumentsRouteObject = BaseRoute.extend({
   routes: {
+    "database/:database/_partition/:partitionkey/_all_docs": {
+      route: "partitionedAllDocs",
+      roles: ["fx_loggedIn"]
+    },
     "database/:database/_all_docs(:extra)": {
-      route: "allDocs",
+      route: "globalAllDocs",
       roles: ["fx_loggedIn"]
     },
     "database/:database/_design/:ddoc/_info": {
@@ -70,12 +74,20 @@ var DocumentsRouteObject = BaseRoute.extend({
     />;
   },
 
+  globalAllDocs: function (databaseName, options) {
+    return this.allDocs(databaseName, '', options);
+  },
+
+  partitionedAllDocs: function (databaseName, partitionKey) {
+    return this.allDocs(databaseName, partitionKey);
+  },
+
   /*
   * docParams are the options fauxton uses to fetch from the server
   * urlParams are what are shown in the url and to the user
   * They are not the same when paginating
   */
-  allDocs: function (databaseName, options) {
+  allDocs: function (databaseName, partitionKey, options) {
     const params = this.createParams(options),
           docParams = params.docParams;
 
@@ -98,7 +110,15 @@ var DocumentsRouteObject = BaseRoute.extend({
 
     const endpoint = this.database.allDocs.urlRef("apiurl", {});
     const docURL = FauxtonAPI.constants.DOC_URLS.GENERAL;
-
+    const navigateToPartitionedAllDocs = (partKey) => {
+      const baseUrl = FauxtonAPI.urls('partitioned_allDocs', 'app', encodeURIComponent(databaseName),
+        encodeURIComponent(partKey));
+      FauxtonAPI.navigate('#/' + baseUrl);
+    };
+    const navigateToGlobalAllDocs = () => {
+      const baseUrl = FauxtonAPI.urls('allDocs', 'app', encodeURIComponent(databaseName));
+      FauxtonAPI.navigate('#/' + baseUrl);
+    };
     const dropDownLinks = this.getCrumbs(this.database);
     return <DocsTabsSidebarLayout
       docURL={docURL}
@@ -110,6 +130,10 @@ var DocumentsRouteObject = BaseRoute.extend({
       fetchUrl={url}
       ddocsOnly={onlyShowDdocs}
       selectedNavItem={selectedNavItem}
+      partitionKey={partitionKey}
+      onPartitionKeySelected={navigateToPartitionedAllDocs}
+      onGlobalModeSelected={navigateToGlobalAllDocs}
+      globalMode={partitionKey === ''}
     />;
   },
 

--- a/app/addons/documents/routes-index-editor.js
+++ b/app/addons/documents/routes-index-editor.js
@@ -28,8 +28,12 @@ const IndexEditorAndResults = BaseRoute.extend({
       route: 'createView',
       roles: ['fx_loggedIn']
     },
+    'database/:database/_partition/:partitionkey/_design/:ddoc/_view/:view': {
+      route: 'showPartitionedView',
+      roles: ['fx_loggedIn']
+    },
     'database/:database/_design/:ddoc/_view/:view': {
-      route: 'showView',
+      route: 'showGlobalView',
       roles: ['fx_loggedIn']
     },
     'database/:database/_design/:ddoc/_view/:view/edit': {
@@ -46,8 +50,15 @@ const IndexEditorAndResults = BaseRoute.extend({
     this.addSidebar();
   },
 
-  showView: function (databaseName, ddoc, viewName) {
+  showGlobalView: function (databaseName, ddoc, viewName) {
+    return this.showView(databaseName, '', ddoc, viewName);
+  },
 
+  showPartitionedView: function (databaseName, partitionKey, ddoc, viewName) {
+    return this.showView(databaseName, partitionKey, ddoc, viewName);
+  },
+
+  showView: function (databaseName, partitionKey, ddoc, viewName) {
     viewName = viewName.replace(/\?.*$/, '');
 
     ActionsIndexEditor.clearIndex();
@@ -74,7 +85,11 @@ const IndexEditorAndResults = BaseRoute.extend({
     const endpoint = FauxtonAPI.urls('view', 'apiurl', encodeURIComponent(databaseName),
       encodeURIComponent(ddoc), encodeURIComponent(viewName));
     const docURL = FauxtonAPI.constants.DOC_URLS.GENERAL;
-
+    const navigateToPartitionedView = (partKey) => {
+      const baseUrl = FauxtonAPI.urls('partitioned_view', 'app', encodeURIComponent(databaseName),
+        encodeURIComponent(partKey), encodeURIComponent(ddoc));
+      FauxtonAPI.navigate('#/' + baseUrl + encodeURIComponent(viewName));
+    };
     const dropDownLinks = this.getCrumbs(this.database);
     return <DocsTabsSidebarLayout
       docURL={docURL}
@@ -86,6 +101,9 @@ const IndexEditorAndResults = BaseRoute.extend({
       ddocsOnly={false}
       deleteEnabled={false}
       selectedNavItem={selectedNavItem}
+      partitionKey={partitionKey}
+      onPartitionKeySelected={navigateToPartitionedView}
+      globalMode={partitionKey === ''}
     />;
   },
 

--- a/app/main.js
+++ b/app/main.js
@@ -28,6 +28,12 @@ const store = createStore(
   combineReducers(FauxtonAPI.reducers),
   applyMiddleware(...FauxtonAPI.middlewares)
 );
+FauxtonAPI.reduxDispatch = (action) => {
+  store.dispatch(action);
+};
+FauxtonAPI.reduxState = () => {
+  return store.getState();
+};
 
 app.addons = LoadAddons;
 FauxtonAPI.router = app.router = new FauxtonAPI.Router(app.addons);


### PR DESCRIPTION
## Overview

Second in a series of PRs that will be submitted in support of the new user-defined partitioned databases feature (https://github.com/apache/couchdb/pull/1605).

Summary:
 - Add new PartitionKeySelector component that allows setting a partition key for filtering query results.
 - The selected partition key is represented in the application URL. E.g.: `/#/database/mydb/_partition/part1/_design/ddoc1/_view/new-view`
 - Although the URL is being updated by the Selector, the query results are not affected yet. This will come in a future PR

## Testing recommendations

 - Create a new partitioned database
 - Navigate to 'All Documents'. The Selector should be inactive (gray) and say 'No partition selected'
 - Click the Selector and type the value `part1` then press Enter
 - The URL should change to `/#/database/<DB>/_partition/part1/_all_docs`
 - Click the Selector's (filter) icon to switch back to 'global' mode. The URL should change to back to `/#/database/<DB>/_all_docs`
 - Navigate to a view and repeat the same steps as for 'All Documents'

## Related Pull Requests

https://github.com/apache/couchdb/pull/1605

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
