### PR TITLE
Fix - Error is shown when enabling CORS 

### DIFF
--- a/app/core/__tests__/ajax.test.js
+++ b/app/core/__tests__/ajax.test.js
@@ -140,4 +140,74 @@ describe('Fauxton Ajax', () => {
         assert.ok(resp.ok);
       });
   });
+
+  describe('POST with falsy values as the body', () => {
+    const successResponse = {
+      status: 200,
+      body: {
+        ok: true
+      }
+    };
+    it('accepts empty string', () => {
+      fetchMock.postOnce('/testing', successResponse);
+      return post('/testing', '')
+        .then(resp =>{
+          assert.ok(resp.ok);
+          assert.ok(fetchMock.lastOptions().body === '""');
+        });
+    });
+
+    it('accepts zero', () => {
+      fetchMock.postOnce('/testing', successResponse);
+      return post('/testing', 0)
+        .then(resp =>{
+          assert.ok(resp.ok);
+          assert.ok(fetchMock.lastOptions().body === '0');
+        });
+    });
+
+    it('accepts false', () => {
+      fetchMock.postOnce('/testing', successResponse);
+      return post('/testing', false)
+        .then(resp =>{
+          assert.ok(resp.ok);
+          assert.ok(fetchMock.lastOptions().body === 'false');
+        });
+    });
+  });
+
+  describe('PUT with falsy values as the body', () => {
+    const successResponse = {
+      status: 200,
+      body: {
+        ok: true
+      }
+    };
+    it('accepts empty string', () => {
+      fetchMock.putOnce('/testing', successResponse);
+      return put('/testing', '')
+        .then(resp =>{
+          assert.ok(resp.ok);
+          assert.ok(fetchMock.lastOptions().body === '""');
+        });
+    });
+
+    it('accepts zero', () => {
+      fetchMock.putOnce('/testing', successResponse);
+      return put('/testing', 0)
+        .then(resp =>{
+          assert.ok(resp.ok);
+          assert.ok(fetchMock.lastOptions().body === '0');
+        });
+    });
+
+    it('accepts false', () => {
+      fetchMock.putOnce('/testing', successResponse);
+      return put('/testing', false)
+        .then(resp =>{
+          assert.ok(resp.ok);
+          assert.ok(fetchMock.lastOptions().body === 'false');
+        });
+    });
+  });
 });

--- a/app/core/ajax.js
+++ b/app/core/ajax.js
@@ -81,7 +81,7 @@ export const deleteRequest = (url, opts = {}) => {
  * @return {Promise} A promise with the request's response
  */
 export const post = (url, body, opts = {}) => {
-  if (body) {
+  if (typeof body !== 'undefined') {
     if (opts.rawBody)
       opts.body = body;
     else
@@ -101,7 +101,7 @@ export const post = (url, body, opts = {}) => {
  * @return {Promise} A promise with the request's response
  */
 export const put = (url, body, opts = {}) => {
-  if (body) {
+  if (typeof body !== 'undefined') {
     if (opts.rawBody)
       opts.body = body;
     else


### PR DESCRIPTION
## Overview

An error message is displayed when enabling CORS. This happens because the PUT `/_config/cors/origins` request is sent with an empty body when it should be an empty string.

## Testing recommendations

- Go to Config > CORS
- Press Enable CORS
- It should display a success message

## GitHub issue number

Fixes #1130 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
