### PR TITLE
Validate regex on client side.

### DIFF
--- a/app/addons/documents/mango/__tests__/mango.helper.test.js
+++ b/app/addons/documents/mango/__tests__/mango.helper.test.js
@@ -1,0 +1,74 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import helper from '../mango.helper';
+import {expect} from 'chai';
+
+describe('Mango Helper', () => {
+
+  describe('getSelectorRegex', () => {
+    it('should return no regexes if empty', () => {
+      const selector = {};
+      const regexes = helper.getSelectorRegexes(selector);
+      expect(Object.keys(regexes)).to.have.lengthOf(0);
+    });
+
+    it('should return no regexes on multi level if none are present', () => {
+      const selector = {
+        $and: [
+          {name: 'bobby'},
+          {$or: [{age: 1}, { age: 2}]}
+        ],
+        sexe: 'female'
+      };
+      const regexes = helper.getSelectorRegexes(selector);
+      expect(Object.keys(regexes)).to.have.lengthOf(0);
+    });
+
+    it('should return regex from array sublevel', () => {
+      const selector = {
+        $and: [
+          {
+            $or: [
+              {$name: 'bob'},
+              {$name: {$regex: '^alex'}}
+            ]
+          }
+        ]
+      };
+      const regexes = helper.getSelectorRegexes(selector);
+      expect(Object.keys(regexes)).to.have.lengthOf(1);
+      expect(regexes['$and.0.$or.1.$name']).to.equal('^alex');
+    });
+
+    it('should return regex from object sublevel', () => {
+      const selector = {
+        $and: [{$name: {$regex: '^alex'}}]
+      };
+      const regexes = helper.getSelectorRegexes(selector);
+      expect(Object.keys(regexes)).to.have.lengthOf(1);
+      expect(regexes['$and.0.$name']).to.equal('^alex');
+    });
+
+    it('should return regex from root', () => {
+      const selector  = {
+        $name: {
+          $regex: '^_design'
+        }
+      };
+
+      const regexes = helper.getSelectorRegexes(selector);
+      expect(Object.keys(regexes)).to.have.lengthOf(1);
+      expect(regexes['$name']).to.equal('^_design');
+    });
+  });
+});

--- a/app/addons/documents/mango/components/MangoQueryEditor.js
+++ b/app/addons/documents/mango/components/MangoQueryEditor.js
@@ -142,6 +142,18 @@ export default class MangoQueryEditor extends Component {
     return false;
   }
 
+  getJsonIfValid(json) {
+    try {
+      return JSON.parse(json);
+    } catch (e) {
+      FauxtonAPI.addNotification({
+        msg:  'Please fix the JSON errors and try again. Error: ' + e.message,
+        type: 'error',
+        clear: true
+      });
+    }
+  }
+
   isRegexValid(selector = {}) {
     const regexes = Helper.getSelectorRegexes(selector);
     const errors = _.reduce(regexes, (acc, val) => {
@@ -183,7 +195,10 @@ export default class MangoQueryEditor extends Component {
       return;
     }
 
-    const queryCode = JSON.parse(this.getEditorValue());
+    const queryCode = this.getJsonIfValid(this.getEditorValue());
+    if (queryCode === undefined) {
+      return;
+    }
 
     if (!this.isRegexValid(queryCode.selector)) {
       return;
@@ -202,8 +217,10 @@ export default class MangoQueryEditor extends Component {
       return;
     }
 
-    const queryCode = JSON.parse(this.getEditorValue());
-
+    const queryCode = this.getJsonIfValid(this.getEditorValue());
+    if (queryCode == undefined) {
+      return;
+    }
     if (!this.isRegexValid(queryCode.selector)) {
       return;
     }

--- a/app/addons/documents/mango/mango.api.js
+++ b/app/addons/documents/mango/mango.api.js
@@ -18,7 +18,7 @@ import Constants from '../constants';
 export const fetchQueryExplain = (databaseName, queryCode) => {
   const url = FauxtonAPI.urls('mango', 'explain-server', encodeURIComponent(databaseName));
 
-  return post(url, queryCode, {rawBody: true}).then((json) => {
+  return post(url, queryCode).then((json) => {
     if (json.error) {
       throw new Error('(' + json.error + ') ' + json.reason);
     }

--- a/app/addons/documents/mango/mango.helper.js
+++ b/app/addons/documents/mango/mango.helper.js
@@ -53,8 +53,29 @@ const getIndexContent = (doc) => {
   return JSON.stringify(content, null, ' ');
 };
 
+const getSelectorRegexes = (selector) => {
+  let acc = {};
+  processSelector(selector, '', acc);
+  return acc;
+};
+
+const processSelector = (selector, currentPath, acc = {}) => {
+  const currentValue = currentPath === '' ? selector : _.get(selector, currentPath);
+
+  if (Array.isArray(currentValue) || _.isObject(currentValue)) {
+    _.each(currentValue, (val, key) => {
+      const newPath = currentPath === '' ? key : [currentPath, key].join('.');
+      processSelector(selector, newPath, acc);
+    });
+  } else if (currentPath.endsWith('$regex')) {
+    //Add the regex with the path to $regex as a key
+    acc[currentPath.slice(0, -7)] = currentValue;
+  }
+};
+
 export default {
   getIndexName,
   formatCode,
-  getIndexContent
+  getIndexContent,
+  getSelectorRegexes
 };


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

I added client side validation for the regex. So I extract all the $regex pairs through a recursive function and create them. I catch any errors and show it to the user.

I also added some JSON parsing validation. While testing, I found that the editor was not recognizing invalid patterns such as "\_"  -> The \_ is illegal.


Here's the output when an invalid regex is evaluated:
![image](https://user-images.githubusercontent.com/9197078/46765231-7f7ade00-ccac-11e8-94f8-5351e264616a.png)

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

#1098 

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
