### PR TITLE
[partitioned dbs] Support partitioned mango queries and creating partitioned indexes

### DIFF
--- a/app/addons/databases/reducers.js
+++ b/app/addons/databases/reducers.js
@@ -13,7 +13,7 @@
 import ActionTypes from './actiontypes';
 const initialState = {
   partitionedDatabasesAvailable: false,
-  isLoadingDbInfo: false,
+  isLoadingDbInfo: true,
   dbInfo: undefined,
   isDbPartitioned: false
 };

--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -222,40 +222,40 @@ FauxtonAPI.registerUrls('mango', {
     return Helpers.getServerUrl('/' + db + '/_index' + query);
   },
 
-  'index-apiurl': function (db, query) {
+  'index-apiurl': function (db, partitionKey, query) {
     if (!query) {
       query = '';
     }
 
-    return Helpers.getApiUrl('/' + db + '/_index' + query);
+    return Helpers.getApiUrl('/' + db + partitionUrlComponent(partitionKey) + '/_index' + query);
   },
 
-  'index-app': function (db, query) {
+  'index-app': function (db, partitionKey, query) {
     if (!query) {
       query = '';
     }
 
-    return 'database/' + db + '/_index' + query;
+    return 'database/' + db + partitionUrlComponent(partitionKey) + '/_index' + query;
   },
 
   'index-server-bulk-delete': function (db) {
     return Helpers.getServerUrl('/' + db + '/_index/_bulk_delete');
   },
 
-  'query-server': function (db, query) {
+  'query-server': function (db, partitionKey, query) {
     if (!query) {
       query = '';
     }
 
-    return Helpers.getServerUrl('/' + db + '/_find' + query);
+    return Helpers.getServerUrl('/' + db + partitionUrlComponent(partitionKey) + '/_find' + query);
   },
 
-  'query-apiurl': function (db, query) {
+  'query-apiurl': function (db, partitionKey, query) {
     if (!query) {
       query = '';
     }
 
-    return Helpers.getApiUrl('/' + db + '/_find' + query);
+    return Helpers.getApiUrl('/' + db + partitionUrlComponent(partitionKey) + '/_find' + query);
   },
 
   'query-app': function (db, partitionKey, query) {
@@ -266,12 +266,12 @@ FauxtonAPI.registerUrls('mango', {
     return 'database/' + db + partitionUrlComponent(partitionKey) + '/_find' + query;
   },
 
-  'explain-server': function (db) {
-    return Helpers.getServerUrl('/' + db + '/_explain');
+  'explain-server': function (db, partitionKey) {
+    return Helpers.getServerUrl('/' + db + partitionUrlComponent(partitionKey) + '/_explain');
   },
 
-  'explain-apiurl': function (db) {
-    return Helpers.getApiUrl('/' + db + '/_explain');
+  'explain-apiurl': function (db, partitionKey) {
+    return Helpers.getApiUrl('/' + db + partitionUrlComponent(partitionKey) + '/_explain');
   }
 });
 

--- a/app/addons/documents/header/header.js
+++ b/app/addons/documents/header/header.js
@@ -41,8 +41,8 @@ export default class BulkDocumentHeaderController extends React.Component {
     }
 
     // Reduce doesn't allow for include_docs=true, so we'll hide the JSON and table modes
-    // since they force include_docs=true when reduce is checked in the query options panel.
-    // Partitioned views don't supprt include_docs=true either.
+    // since they force 'include_docs=true' when reduce is checked in the query options panel.
+    // Partitioned views don't support 'include_docs=true' either.
     const isAllDocsQuery = fetchUrl && fetchUrl.includes('/_all_docs');
     const isMangoQuery = docType === Constants.INDEX_RESULTS_DOC_TYPE.MANGO_QUERY;
     if (isAllDocsQuery || isMangoQuery || (!queryOptionsParams.reduce && !partitionKey)) {

--- a/app/addons/documents/header/header.js
+++ b/app/addons/documents/header/header.js
@@ -29,22 +29,23 @@ export default class BulkDocumentHeaderController extends React.Component {
     } = this.props;
 
     let metadata, json, table;
-    if ((docType === Constants.INDEX_RESULTS_DOC_TYPE.VIEW)) {
+    if (docType === Constants.INDEX_RESULTS_DOC_TYPE.VIEW) {
       metadata = <Button
         className={selectedLayout === Constants.LAYOUT_ORIENTATION.METADATA ? 'active' : ''}
         onClick={this.toggleLayout.bind(this, Constants.LAYOUT_ORIENTATION.METADATA)}
       >
           Metadata
       </Button>;
-    } else if ((docType === Constants.INDEX_RESULTS_DOC_TYPE.MANGO_INDEX)) {
+    } else if (docType === Constants.INDEX_RESULTS_DOC_TYPE.MANGO_INDEX) {
       return null;
     }
 
-    // Reduce doesn't allow for include_docs=true, so we'll prevent JSON and table
-    // views since they force include_docs=true when reduce is checked in the query options panel.
-    // Partitioned queries don't supprt include_docs=true either.
+    // Reduce doesn't allow for include_docs=true, so we'll hide the JSON and table modes
+    // since they force include_docs=true when reduce is checked in the query options panel.
+    // Partitioned views don't supprt include_docs=true either.
     const isAllDocsQuery = fetchUrl && fetchUrl.includes('/_all_docs');
-    if (isAllDocsQuery || (!queryOptionsParams.reduce && !partitionKey)) {
+    const isMangoQuery = docType === Constants.INDEX_RESULTS_DOC_TYPE.MANGO_QUERY;
+    if (isAllDocsQuery || isMangoQuery || (!queryOptionsParams.reduce && !partitionKey)) {
       table = <Button
         className={selectedLayout === Constants.LAYOUT_ORIENTATION.TABLE ? 'active' : ''}
         onClick={this.toggleLayout.bind(this, Constants.LAYOUT_ORIENTATION.TABLE)}

--- a/app/addons/documents/mango/__tests__/mango.api.test.js
+++ b/app/addons/documents/mango/__tests__/mango.api.test.js
@@ -10,34 +10,52 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import sinon from "sinon";
-import utils from "../../../../../test/mocha/testUtils";
-import FauxtonAPI from "../../../../core/api";
-import * as MangoAPI from '../mango.api';
+import fetchMock from 'fetch-mock';
 import Constants from '../../constants';
-
-const fetchMock = require('fetch-mock');
-const assert = utils.assert;
-const restore = utils.restore;
+import * as MangoAPI from '../mango.api';
+import '../../base';
 
 describe('Mango API', () => {
 
   const paginationLimit = 6;
 
-  beforeEach(() => {
-    sinon.stub(FauxtonAPI, 'urls').returns('mock-url');
-  });
-
   afterEach(() => {
-    restore(FauxtonAPI.urls);
+    fetchMock.restore();
   });
 
   describe('mangoQueryDocs', () => {
-    it('returns document type INDEX_RESULTS_DOC_TYPE.MANGO_QUERY', (done) => {
+    it('returns document type INDEX_RESULTS_DOC_TYPE.MANGO_QUERY', () => {
       fetchMock.mock("*", { times: 2 });
-      MangoAPI.mangoQueryDocs('myDB', {}, {}).then((res) => {
-        assert.equal(res.docType, Constants.INDEX_RESULTS_DOC_TYPE.MANGO_QUERY);
-        done();
+      return MangoAPI.mangoQueryDocs('myDB', '', {}, {}).then((res) => {
+        expect(res.docType).toBe(Constants.INDEX_RESULTS_DOC_TYPE.MANGO_QUERY);
+      });
+    });
+  });
+
+  describe('mangoQuery', () => {
+    it('adds partition key to the query URL when one is set', () => {
+      fetchMock.postOnce('./myDB/_partition/part1/_find', {
+        status: 200,
+        body: { ok: true }
+      }).catch({
+        status: 500,
+        body: { ok: false }
+      });
+      return MangoAPI.mangoQuery('myDB', 'part1', {}, {}).then(() => {
+        expect(fetchMock.done()).toBe(true);
+      });
+    });
+
+    it('does not add partition key to the query URL when one is set', () => {
+      fetchMock.postOnce('./myDB/_find', {
+        status: 200,
+        body: { ok: true }
+      }).catch({
+        status: 500,
+        body: { ok: false }
+      });
+      return MangoAPI.mangoQuery('myDB', '', {}, {}).then(() => {
+        expect(fetchMock.done()).toBe(true);
       });
     });
   });
@@ -46,76 +64,75 @@ describe('Mango API', () => {
     it('adjusts the query "skip" field based on pagination fetch params', () => {
       // 1st page and query's skip is zero
       let mergedParams = MangoAPI.mergeFetchParams({skip: 0}, {skip: 0, limit: paginationLimit});
-      assert.equal(mergedParams.skip, 0);
+      expect(mergedParams.skip).toBe(0);
 
       // 1st page and query's skip is non-zero
       mergedParams = MangoAPI.mergeFetchParams({skip: 3}, {skip: 0, limit: paginationLimit});
-      assert.equal(mergedParams.skip, 3);
+      expect(mergedParams.skip).toBe(3);
 
       // non-1st page and query's skip is zero
       mergedParams = MangoAPI.mergeFetchParams({skip: 0}, {skip: 5, limit: paginationLimit});
-      assert.equal(mergedParams.skip, 5);
+      expect(mergedParams.skip).toBe(5);
 
       // non-1st page and query's skip is non-zero
       mergedParams = MangoAPI.mergeFetchParams({skip: 3}, {skip: 5, limit: paginationLimit});
-      assert.equal(mergedParams.skip, 8);
+      expect(mergedParams.skip).toBe(8);
 
     });
 
     it('uses ZERO when query limit is ZERO', () => {
       const mergedParams = MangoAPI.mergeFetchParams({limit: 0}, {skip: 0, limit: paginationLimit});
-      assert.equal(mergedParams.limit, 0);
+      expect(mergedParams.limit).toBe(0);
     });
 
     it('uses pagination limit when query limit is not provided', () => {
       const mergedParams = MangoAPI.mergeFetchParams({}, {skip: 5, limit: paginationLimit});
-      assert.equal(mergedParams.limit, paginationLimit);
+      expect(mergedParams.limit).toBe(paginationLimit);
     });
 
     it('uses pagination limit if query limit has not been reached', () => {
       let mergedParams = MangoAPI.mergeFetchParams({limit: 50}, {skip: 5, limit: paginationLimit});
-      assert.equal(mergedParams.limit, paginationLimit);
+      expect(mergedParams.limit).toBe(paginationLimit);
 
       mergedParams = MangoAPI.mergeFetchParams({limit: 50}, {skip: 15, limit: paginationLimit});
-      assert.equal(mergedParams.limit, paginationLimit);
+      expect(mergedParams.limit).toBe(paginationLimit);
     });
 
     it('respects query limit when value is lower than docs per page', () => {
       const mergedParams = MangoAPI.mergeFetchParams({limit: 3}, {skip: 0, limit: paginationLimit});
-      assert.equal(mergedParams.limit, 3);
+      expect(mergedParams.limit).toBe(3);
     });
 
     it('respects query limit when value is greater than docs per page', () => {
       // Simulates loading of 3rd page
       const mergedParams = MangoAPI.mergeFetchParams({limit: 17}, {skip: 15, limit: paginationLimit});
-      assert.equal(mergedParams.limit, 2);
+      expect(mergedParams.limit).toBe(2);
     });
 
     it('respects query limit when value is a multipe of docs per page', () => {
       // 1st page
       let mergedParams = MangoAPI.mergeFetchParams({limit: 5}, {skip: 0, limit: paginationLimit});
-      assert.equal(mergedParams.limit, 5);
+      expect(mergedParams.limit).toBe(5);
 
       // non-1st page
       mergedParams = MangoAPI.mergeFetchParams({limit: 15}, {skip: 10, limit: paginationLimit});
-      assert.equal(mergedParams.limit, 5);
+      expect(mergedParams.limit).toBe(5);
     });
 
     it('works correctly with both skip and limit query params', () => {
       // Simulates loading of 3rd page
       const mergedParams = MangoAPI.mergeFetchParams({skip:10, limit: 17}, {skip: 15, limit: paginationLimit});
-      assert.equal(mergedParams.limit, 2);
-      assert.equal(mergedParams.skip, 25);
+      expect(mergedParams.limit).toBe(2);
+      expect(mergedParams.skip).toBe(25);
     });
 
   });
 
   describe('fetchIndexes', () => {
-    it('returns document type INDEX_RESULTS_DOC_TYPE.MANGO_INDEX', (done) => {
+    it('returns document type INDEX_RESULTS_DOC_TYPE.MANGO_INDEX', () => {
       fetchMock.once("*", {});
-      MangoAPI.fetchIndexes('myDB', {}).then((res) => {
-        assert.equal(res.docType, Constants.INDEX_RESULTS_DOC_TYPE.MANGO_INDEX);
-        done();
+      return MangoAPI.fetchIndexes('myDB', {}).then((res) => {
+        expect(res.docType).toBe(Constants.INDEX_RESULTS_DOC_TYPE.MANGO_INDEX);
       });
     });
   });

--- a/app/addons/documents/mango/__tests__/mango.components.test.js
+++ b/app/addons/documents/mango/__tests__/mango.components.test.js
@@ -26,7 +26,6 @@ import MangoIndexEditor from '../components/MangoIndexEditor';
 import mangoReducer from '../mango.reducers';
 import '../../base';
 
-const assert = utils.assert;
 const restore = utils.restore;
 const databaseName = 'testdb';
 
@@ -60,10 +59,10 @@ describe('MangoIndexEditorContainer', function () {
     );
 
     const indexEditor = wrapper.find(MangoIndexEditor);
-    assert.ok(indexEditor.exists());
+    expect(indexEditor.exists()).toBe(true);
     if (indexEditor.exists()) {
       const json = JSON.parse(indexEditor.props().queryIndexCode);
-      assert.equal(json.index.fields[0], 'foo');
+      expect(json.index.fields[0]).toBe('foo');
     }
   });
 
@@ -76,10 +75,10 @@ describe('MangoIndexEditorContainer', function () {
       </Provider>
     );
     const indexEditor = wrapper.find(MangoIndexEditor);
-    assert.ok(indexEditor.exists());
+    expect(indexEditor.exists()).toBe(true);
     if (indexEditor.exists()) {
       const json = JSON.parse(indexEditor.props().queryIndexCode);
-      assert.equal(json.index.fields[0], 'foo');
+      expect(json.index.fields[0]).toBe('foo');
     }
   });
 
@@ -190,10 +189,10 @@ describe('MangoQueryEditorContainer', function () {
       </Provider>
     );
     const queryEditor = wrapper.find(MangoQueryEditor);
-    assert.ok(queryEditor.exists());
+    expect(queryEditor.exists()).toBe(true);
     if (queryEditor.exists()) {
       const query = JSON.parse(queryEditor.props().queryFindCode);
-      assert.property(query.selector, '_id');
+      expect(query.selector).toHaveProperty('_id');
     }
   });
 });

--- a/app/addons/documents/mango/components/MangoIndexEditor.js
+++ b/app/addons/documents/mango/components/MangoIndexEditor.js
@@ -80,7 +80,7 @@ export default class MangoIndexEditor extends Component {
       return null;
     }
     return (
-      <label style={{margin: '10px 10px 0px 0px'}}>
+      <label>
         <input
           id="js-partitioned-index"
           type="checkbox"

--- a/app/addons/documents/mango/components/MangoIndexEditor.js
+++ b/app/addons/documents/mango/components/MangoIndexEditor.js
@@ -180,7 +180,10 @@ MangoIndexEditor.propTypes = {
   isDbPartitioned: PropTypes.bool.isRequired,
   saveIndex: PropTypes.func.isRequired,
   queryIndexCode: PropTypes.string.isRequired,
-  partitionKey: PropTypes.string
+  partitionKey: PropTypes.string,
+  loadIndexTemplates: PropTypes.func.isRequired,
+  clearResults: PropTypes.func.isRequired,
+  loadIndexList: PropTypes.func.isRequired
 };
 
 MangoIndexEditor.defaultProps = {

--- a/app/addons/documents/mango/components/MangoIndexEditorContainer.js
+++ b/app/addons/documents/mango/components/MangoIndexEditorContainer.js
@@ -18,13 +18,16 @@ import Helpers from '../mango.helper';
 import Actions from '../mango.actions';
 import * as MangoAPI from '../mango.api';
 
-const mapStateToProps = ({ mangoQuery, indexResults }, ownProps) => {
+const mapStateToProps = ({ mangoQuery, indexResults, databases }, ownProps) => {
   return {
     description: ownProps.description,
     databaseName: ownProps.databaseName,
     queryIndexCode: Helpers.formatCode(mangoQuery.queryIndexCode),
     templates: mangoQuery.queryIndexTemplates,
     fetchParams: indexResults.fetchParams,
+    partitionKey: ownProps.partitionKey,
+    isLoading: databases.isLoadingDbInfo,
+    isDbPartitioned: databases.isDbPartitioned
   };
 };
 

--- a/app/addons/documents/mango/components/MangoQueryEditor.js
+++ b/app/addons/documents/mango/components/MangoQueryEditor.js
@@ -186,6 +186,10 @@ MangoQueryEditor.propTypes = {
   queryFindCode: PropTypes.string.isRequired,
   queryFindCodeChanged: PropTypes.bool,
   databaseName: PropTypes.string.isRequired,
+  partitionKey: PropTypes.string,
   runExplainQuery: PropTypes.func.isRequired,
+  runQuery: PropTypes.func.isRequired,
   manageIndexes: PropTypes.func.isRequired,
+  loadQueryHistory: PropTypes.func.isRequired,
+  clearResults: PropTypes.func.isRequired
 };

--- a/app/addons/documents/mango/components/MangoQueryEditor.js
+++ b/app/addons/documents/mango/components/MangoQueryEditor.js
@@ -145,7 +145,8 @@ export default class MangoQueryEditor extends Component {
 
     this.props.manageIndexes();
 
-    const manageIndexURL = '#' + FauxtonAPI.urls('mango', 'index-app', encodeURIComponent(this.props.databaseName));
+    const manageIndexURL = '#' + FauxtonAPI.urls('mango', 'index-app',
+      encodeURIComponent(this.props.databaseName), encodeURIComponent(this.props.partitionKey));
     FauxtonAPI.navigate(manageIndexURL);
   }
 
@@ -158,6 +159,7 @@ export default class MangoQueryEditor extends Component {
 
     this.props.runExplainQuery({
       databaseName: this.props.databaseName,
+      partitionKey: this.props.partitionKey,
       queryCode: this.getEditorValue()
     });
   }
@@ -171,6 +173,7 @@ export default class MangoQueryEditor extends Component {
     this.props.clearResults();
     this.props.runQuery({
       databaseName: this.props.databaseName,
+      partitionKey: this.props.partitionKey,
       queryCode: JSON.parse(this.getEditorValue()),
       fetchParams: {...this.props.fetchParams, skip: 0}
     });

--- a/app/addons/documents/mango/components/MangoQueryEditorContainer.js
+++ b/app/addons/documents/mango/components/MangoQueryEditorContainer.js
@@ -59,7 +59,8 @@ const mapStateToProps = (state, ownProps) => {
     additionalIndexesText: ownProps.additionalIndexesText,
     fetchParams: indexResults.fetchParams,
     executionStats: indexResults.executionStats,
-    warning: indexResults.warning
+    warning: indexResults.warning,
+    partitionKey: ownProps.partitionKey
   };
 };
 
@@ -74,7 +75,9 @@ const mapDispatchToProps = (dispatch/*, ownProps*/) => {
     },
 
     runQuery: (options) => {
-      const queryDocs = (params) => { return MangoAPI.mangoQueryDocs(options.databaseName, options.queryCode, params); };
+      const queryDocs = (params) => {
+        return MangoAPI.mangoQueryDocs(options.databaseName, options.partitionKey, options.queryCode, params);
+      };
 
       dispatch(Actions.hideQueryExplain());
       dispatch(Actions.newQueryFindCode(options));

--- a/app/addons/documents/mango/mango.actions.js
+++ b/app/addons/documents/mango/mango.actions.js
@@ -105,9 +105,9 @@ export default {
     return 'Reason: ' + ((error && error.message) || 'n/a');
   },
 
-  runExplainQuery: function ({ databaseName, queryCode }) {
+  runExplainQuery: function ({ databaseName, partitionKey, queryCode }) {
     return (dispatch) => {
-      return MangoAPI.fetchQueryExplain(databaseName, queryCode)
+      return MangoAPI.fetchQueryExplain(databaseName, partitionKey, queryCode)
         .then((explainPlan) => {
           dispatch(this.showQueryExplain({ explainPlan }));
         }).catch(() => {

--- a/app/addons/documents/mango/mango.api.js
+++ b/app/addons/documents/mango/mango.api.js
@@ -97,9 +97,9 @@ export const mergeFetchParams = (queryCode, fetchParams) => {
 };
 
 export const mangoQuery = (databaseName, partitionKey, queryCode, fetchParams) => {
-  const url = FauxtonAPI.urls('mango', 'query-server', encodeURIComponent(databaseName), partitionKey);
+  const encodedPartKey = partitionKey ? encodeURIComponent(partitionKey) : '';
+  const url = FauxtonAPI.urls('mango', 'query-server', encodeURIComponent(databaseName), encodedPartKey);
   const modifiedQuery = mergeFetchParams(queryCode, fetchParams);
-
   return post(url, modifiedQuery, {raw: true});
 };
 

--- a/app/addons/documents/mango/mango.api.js
+++ b/app/addons/documents/mango/mango.api.js
@@ -15,8 +15,8 @@ import {post, get} from '../../../core/ajax';
 import FauxtonAPI from "../../../core/api";
 import Constants from '../constants';
 
-export const fetchQueryExplain = (databaseName, queryCode) => {
-  const url = FauxtonAPI.urls('mango', 'explain-server', encodeURIComponent(databaseName));
+export const fetchQueryExplain = (databaseName, partitionKey, queryCode) => {
+  const url = FauxtonAPI.urls('mango', 'explain-server', encodeURIComponent(databaseName), encodeURIComponent(partitionKey));
 
   return post(url, queryCode, {rawBody: true}).then((json) => {
     if (json.error) {
@@ -61,7 +61,7 @@ let supportsExecutionStatsCache = null;
 const supportsExecutionStats = (databaseName) => {
   if (supportsExecutionStatsCache === null) {
     return new FauxtonAPI.Promise((resolve) => {
-      mangoQuery(databaseName, {
+      mangoQuery(databaseName, '', {
         selector: {
           "_id": {"$gt": "a" }
         },
@@ -96,21 +96,21 @@ export const mergeFetchParams = (queryCode, fetchParams) => {
   };
 };
 
-export const mangoQuery = (databaseName, queryCode, fetchParams) => {
-  const url = FauxtonAPI.urls('mango', 'query-server', encodeURIComponent(databaseName));
+export const mangoQuery = (databaseName, partitionKey, queryCode, fetchParams) => {
+  const url = FauxtonAPI.urls('mango', 'query-server', encodeURIComponent(databaseName), partitionKey);
   const modifiedQuery = mergeFetchParams(queryCode, fetchParams);
 
   return post(url, modifiedQuery, {raw: true});
 };
 
-export const mangoQueryDocs = (databaseName, queryCode, fetchParams) => {
+export const mangoQueryDocs = (databaseName, partitionKey, queryCode, fetchParams) => {
   // we can only add the execution_stats field if it is supported by the server
   // otherwise Couch throws an error
   return supportsExecutionStats(databaseName).then((shouldFetchExecutionStats) => {
     if (shouldFetchExecutionStats) {
       queryCode.execution_stats = true;
     }
-    return mangoQuery(databaseName, queryCode, fetchParams)
+    return mangoQuery(databaseName, partitionKey, queryCode, fetchParams)
       .then((res) => res.json())
       .then((json) => {
         if (json.error) {

--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -71,7 +71,7 @@ var DocumentsRouteObject = BaseRoute.extend({
       designDocName: ddoc,
       designDocSection: 'metadata'
     });
-
+    DatabaseActions.fetchSelectedDatabaseInfo(database);
     const dropDownLinks = this.getCrumbs(this.database);
     return <ViewsTabsSidebarLayout
       showEditView={false}
@@ -147,8 +147,9 @@ var DocumentsRouteObject = BaseRoute.extend({
     />;
   },
 
-  changes: function (_, partitionKey) {
+  changes: function (databaseName, partitionKey) {
     const selectedNavItem = new SidebarItemSelection('changes');
+    DatabaseActions.fetchSelectedDatabaseInfo(databaseName);
 
     return <ChangesSidebarLayout
       endpoint={FauxtonAPI.urls('changes', 'apiurl', this.database.id, '')}

--- a/app/addons/documents/routes-index-editor.js
+++ b/app/addons/documents/routes-index-editor.js
@@ -14,6 +14,7 @@ import React from 'react';
 import FauxtonAPI from "../../core/api";
 import BaseRoute from "./shared-routes";
 import ActionsIndexEditor from "./index-editor/actions";
+import DatabaseActions from '../databases/actions';
 import Databases from "../databases/base";
 import SidebarActions from './sidebar/actions';
 import {SidebarItemSelection} from './sidebar/helpers';
@@ -82,6 +83,7 @@ const IndexEditorAndResults = BaseRoute.extend({
       designDocs: this.designDocs,
       designDocId: '_design/' + ddoc
     });
+    DatabaseActions.fetchSelectedDatabaseInfo(databaseName);
 
     const selectedNavItem = new SidebarItemSelection('designDoc', {
       designDocName: ddoc,
@@ -144,6 +146,7 @@ const IndexEditorAndResults = BaseRoute.extend({
       designDocId: designDoc,
       isNewDesignDoc: isNewDesignDoc
     });
+    DatabaseActions.fetchSelectedDatabaseInfo(database);
 
     const selectedNavItem = new SidebarItemSelection('');
     const dropDownLinks = this.getCrumbs(this.database);
@@ -171,6 +174,7 @@ const IndexEditorAndResults = BaseRoute.extend({
       designDocs: this.designDocs,
       designDocId: '_design/' + ddocName
     });
+    DatabaseActions.fetchSelectedDatabaseInfo(databaseName);
 
     const selectedNavItem = new SidebarItemSelection('designDoc', {
       designDocName: ddocName,

--- a/app/addons/documents/routes-mango.js
+++ b/app/addons/documents/routes-mango.js
@@ -56,14 +56,25 @@ const MangoIndexEditorAndQueryEditor = FauxtonAPI.RouteObject.extend({
       'allDocs', 'app', encodeURIComponent(this.databaseName), encodedPartitionKey
     );
 
-    const fetchUrl = '/' + encodeURIComponent(this.databaseName) + '/_find';
+    const partKeyUrlComponent = partitionKey ? `/${encodeURIComponent(partitionKey)}` : '';
+    const fetchUrl = '/' + encodeURIComponent(this.databaseName) + partKeyUrlComponent + '/_find';
 
     const crumbs = [
       {name: database, link: url},
       {name: app.i18n.en_US['mango-title-editor']}
     ];
 
-    const endpoint = FauxtonAPI.urls('mango', 'query-apiurl', encodeURIComponent(this.databaseName));
+    const endpoint = FauxtonAPI.urls('mango', 'query-apiurl', encodeURIComponent(this.databaseName), encodedPartitionKey);
+
+    const navigateToPartitionedView = (partKey) => {
+      const baseUrl = FauxtonAPI.urls('mango', 'query-app', encodeURIComponent(database),
+        encodeURIComponent(partKey));
+      FauxtonAPI.navigate('#/' + baseUrl);
+    };
+    const navigateToGlobalView = () => {
+      const baseUrl = FauxtonAPI.urls('mango', 'query-app', encodeURIComponent(database));
+      FauxtonAPI.navigate('#/' + baseUrl);
+    };
 
     return <MangoLayoutContainer
       database={database}
@@ -71,9 +82,12 @@ const MangoIndexEditorAndQueryEditor = FauxtonAPI.RouteObject.extend({
       docURL={FauxtonAPI.constants.DOC_URLS.MANGO_SEARCH}
       endpoint={endpoint}
       edit={false}
-      partitionKey={partitionKey}
       databaseName={this.databaseName}
       fetchUrl={fetchUrl}
+      partitionKey={partitionKey}
+      onPartitionKeySelected={navigateToPartitionedView}
+      onGlobalModeSelected={navigateToGlobalView}
+      globalMode={partitionKey === ''}
     />;
   },
 
@@ -99,7 +113,7 @@ const MangoIndexEditorAndQueryEditor = FauxtonAPI.RouteObject.extend({
     const url = FauxtonAPI.urls(
       'allDocs', 'app', encodeURIComponent(this.databaseName), encodedPartitionKey
     );
-    const endpoint = FauxtonAPI.urls('mango', 'index-apiurl', encodeURIComponent(this.databaseName));
+    const endpoint = FauxtonAPI.urls('mango', 'index-apiurl', encodeURIComponent(this.databaseName), encodedPartitionKey);
 
     const crumbs = [
       {name: database, link: url},
@@ -113,8 +127,8 @@ const MangoIndexEditorAndQueryEditor = FauxtonAPI.RouteObject.extend({
       endpoint={endpoint}
       edit={true}
       designDocs={designDocs}
-
       databaseName={this.databaseName}
+      partitionKey={partitionKey}
     />;
   }
 });

--- a/app/addons/documents/routes-mango.js
+++ b/app/addons/documents/routes-mango.js
@@ -11,10 +11,11 @@
 // the License.
 
 import React from 'react';
-import app from "../../app";
-import FauxtonAPI from "../../core/api";
-import Databases from "../databases/resources";
-import Documents from "./shared-resources";
+import app from '../../app';
+import FauxtonAPI from '../../core/api';
+import Databases from '../databases/resources';
+import DatabaseActions from '../databases/actions';
+import Documents from './shared-resources';
 import {MangoLayoutContainer} from './mangolayout';
 
 const MangoIndexEditorAndQueryEditor = FauxtonAPI.RouteObject.extend({
@@ -119,6 +120,8 @@ const MangoIndexEditorAndQueryEditor = FauxtonAPI.RouteObject.extend({
       {name: database, link: url},
       {name: app.i18n.en_US['mango-indexeditor-title']}
     ];
+
+    DatabaseActions.fetchSelectedDatabaseInfo(database);
 
     return <MangoLayoutContainer
       showIncludeAllDocs={false}


### PR DESCRIPTION
## Overview

Sixth in a series of PRs that will be submitted in support of the new user-defined partitioned databases feature (apache/couchdb#1605).

Summary:

 - Show results for partitioned mango queries
 - Create partitioned indexes

## Testing recommendations

On a partitioned database: 
- Go to **Run A Query with Mango**
  - Verify the Partition Selector is displayed at the top
- Click on **Run Query**
  - Verify all docs that match are returned
- Set a partition key
  - Verify the results are updated with only those that match the key
- Click on **Explain**
  - Verify the results include the selected partition under `"opts"`

- Click on **manage indexes**
  - Verify the **partitioned** checkbox is displayed and it is checked
- Click on **Create Index**
  - Verify the results include the new index, and the index code includes `"design_opts": { "partitioned": true }`
- Uncheck the **partitioned** checkbox and click on **Create Index**
  - Verify the results include the new index, and the index code includes `"design_opts": { "partitioned": false }`
- Add `partitioned: true` to the index code in the editor, make sure the checkbox is unchecked, then click on **Create Index** 
  - Verify the results include the new index, and the index code includes `"design_opts": { "partitioned": true }` - which means the value in the editor takes precedence over the checkbox.

## Related Pull Requests

apache/couchdb#1605

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
