### PR TITLE
Remove chai dependency

### DIFF
--- a/app/addons/activetasks/__tests__/components.test.js
+++ b/app/addons/activetasks/__tests__/components.test.js
@@ -42,7 +42,7 @@ describe('Active Tasks -- Components', () => {
           );
 
           tabs.find(`input[value="${text}"]`).simulate('change');
-          assert.ok(spy.calledOnce);
+          expect(spy.calledOnce).toBeTruthy();
         });
       });
 
@@ -55,7 +55,7 @@ describe('Active Tasks -- Components', () => {
           />
         );
         tabs.find('.searchbox').simulate('change', {target: {value: 'searching'}});
-        assert.ok(spy.calledOnce);
+        expect(spy.calledOnce).toBeTruthy();
       });
     });
 
@@ -81,7 +81,7 @@ describe('Active Tasks -- Components', () => {
           );
 
           table.find(`.${text}`).simulate('click');
-          assert.ok(spy.calledOnce);
+          expect(spy.calledOnce).toBeTruthy();
         });
       });
     });

--- a/app/addons/activetasks/__tests__/components.test.js
+++ b/app/addons/activetasks/__tests__/components.test.js
@@ -12,11 +12,8 @@
 import TableHeader from '../components/tableheader';
 import FilterTabs from '../components/filtertabs';
 import React from "react";
-import ReactDOM from "react-dom";
-import utils from "../../../../test/mocha/testUtils";
 import {mount} from 'enzyme';
 import sinon from "sinon";
-const assert = utils.assert;
 
 describe('Active Tasks -- Components', () => {
 

--- a/app/addons/activetasks/__tests__/reducer.test.js
+++ b/app/addons/activetasks/__tests__/reducer.test.js
@@ -32,8 +32,8 @@ describe('Active Tasks -- Stores', () => {
         type: ActionTypes.ACTIVE_TASKS_SWITCH_TAB,
         options: 'all_tasks'
       });
-      assert.ok(state.tasks.length > 0);
-      assert.deepEqual(state.tasks.length, state.filteredTasks.length);
+      expect(state.tasks.length).toBeGreaterThan(0);
+      expect(state.tasks.length).toEqual(state.filteredTasks.length);
     });
 
     it('should filter the table correctly, by radio', () => {
@@ -43,10 +43,10 @@ describe('Active Tasks -- Stores', () => {
       });
 
       //parse table and check that it only contains objects with type: Replication
-      assert.ok(state.filteredTasks.length > 0);
+      expect(state.filteredTasks.length > 0).toBeTruthy();
       state.filteredTasks.forEach(task => {
-        assert.deepEqual(task.type, 'replication');
-        assert.deepEqual(task.type, state.selectedRadio);
+        expect(task.type).toEqual('replication');
+        expect(task.type).toEqual(state.selectedRadio);
       });
     });
 
@@ -62,8 +62,8 @@ describe('Active Tasks -- Stores', () => {
         { user: 'ooo'}
       ];
 
-      assert.equal(fakeFilteredTable[0].user, state.filteredTasks[0].user);
-      assert.equal(fakeFilteredTable[1].user, state.filteredTasks[1].user);
+      expect(fakeFilteredTable[0].user).toBe(state.filteredTasks[0].user);
+      expect(fakeFilteredTable[1].user).toBe(state.filteredTasks[1].user);
     });
   });
 
@@ -74,7 +74,7 @@ describe('Active Tasks -- Stores', () => {
         type: ActionTypes.ACTIVE_TASKS_SWITCH_TAB,
         options: 'all_tasks'
       });
-      assert.ok(state.headerIsAscending);
+      expect(state.headerIsAscending).toBeTruthy();
     });
 
     it('should set header as descending, if same header is selected again', () => {
@@ -82,25 +82,25 @@ describe('Active Tasks -- Stores', () => {
         type: ActionTypes.ACTIVE_TASKS_SORT_BY_COLUMN_HEADER,
         options: 'sameHeader'
       });
-      assert.ok(state.headerIsAscending);
+      expect(state.headerIsAscending).toBeTruthy();
 
       const state2 = reducer(state, {
         type: ActionTypes.ACTIVE_TASKS_SORT_BY_COLUMN_HEADER,
         options: 'sameHeader'
       });
-      assert.notOk(state2.headerIsAscending);
+      expect(state2.headerIsAscending).toBeFalsy();
 
       const state3 = reducer(state2, {
         type: ActionTypes.ACTIVE_TASKS_SORT_BY_COLUMN_HEADER,
         options: 'sameHeader'
       });
-      assert.ok(state3.headerIsAscending);
+      expect(state3.headerIsAscending).toBeTruthy();
 
       const state4 = reducer(state3, {
         type: ActionTypes.ACTIVE_TASKS_SORT_BY_COLUMN_HEADER,
         options: 'differentHeader'
       });
-      assert.ok(state4.headerIsAscending);
+      expect(state4.headerIsAscending).toBeTruthy();
     });
   });
 });

--- a/app/addons/activetasks/__tests__/reducer.test.js
+++ b/app/addons/activetasks/__tests__/reducer.test.js
@@ -9,11 +9,10 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
+
 import reducer from '../reducers';
 import ActionTypes from '../actiontypes';
 import fakedResponse from "./fakeActiveTaskResponse";
-import utils from "../../../../test/mocha/testUtils";
-const assert = utils.assert;
 
 describe('Active Tasks -- Stores', () => {
   let initState;
@@ -50,7 +49,7 @@ describe('Active Tasks -- Stores', () => {
       });
     });
 
-    it.only('should search the table correctly', () => {
+    it('should search the table correctly', () => {
       var searchTerm = 'base';
       const state = reducer(initState, {
         type: ActionTypes.ACTIVE_TASKS_SET_SEARCH_TERM,

--- a/app/addons/auth/__tests__/components.test.js
+++ b/app/addons/auth/__tests__/components.test.js
@@ -37,7 +37,7 @@ describe('Auth -- Components', () => {
     it('should trigger login event when form submitted', () => {
       const loginForm = mount(<LoginForm/>);
       loginForm.find('#login').simulate('submit');
-      assert.ok(stub.calledOnce);
+      expect(stub.calledOnce).toBeTruthy();
     });
 
     it('in case of nothing in state, should pass actual values to Actions.login()', () => {
@@ -51,11 +51,11 @@ describe('Auth -- Components', () => {
         />);
 
       loginForm.find('#login').simulate('submit');
-      assert.ok(stub.calledOnce);
+      expect(stub.calledOnce).toBeTruthy();
 
       // confirm Actions.login() received the values that weren't in the DOM
-      assert.equal(stub.args[0][0], username);
-      assert.equal(stub.args[0][1], password);
+      expect(stub.args[0][0]).toBe(username);
+      expect(stub.args[0][1]).toBe(password);
     });
 
   });
@@ -65,20 +65,20 @@ describe('Auth -- Components', () => {
     it('should update state on password change', () => {
       const changePasswordForm = mount(<ChangePasswordForm />);
       changePasswordForm.find('#password').simulate('change', { target: { value: 'bobsyouruncle' }});
-      assert.deepEqual(changePasswordForm.state('password'), 'bobsyouruncle');
+      expect(changePasswordForm.state('password')).toEqual('bobsyouruncle');
     });
 
     it('should update state on password confirm change', () => {
       const changePasswordForm = mount(<ChangePasswordForm />);
       changePasswordForm.find('#password-confirm').simulate('change', { target: { value: 'hotdiggity' }});
-      assert.deepEqual(changePasswordForm.state('passwordConfirm'), 'hotdiggity');
+      expect(changePasswordForm.state('passwordConfirm')).toEqual('hotdiggity');
     });
 
     it('should call action to submit form', () => {
       const spy = sinon.spy();
       const changePasswordForm = mount(<ChangePasswordForm username={"bobsyouruncle"} changePassword={spy} />);
       changePasswordForm.find('#change-password').simulate('submit');
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
   });
 
@@ -86,13 +86,13 @@ describe('Auth -- Components', () => {
     it('should update username state', () => {
       const createAdminForm = mount(<CreateAdminForm loginAfter={false} />);
       createAdminForm.find('#username').simulate('change',  { target: { value: 'catsmeow' }});
-      assert.deepEqual(createAdminForm.state('username'), 'catsmeow');
+      expect(createAdminForm.state('username')).toEqual('catsmeow');
     });
 
     it('should call action to update password confirm on field change', () => {
       const createAdminForm = mount(<CreateAdminForm loginAfter={false} />);
       createAdminForm.find('#password').simulate('change',  { target: { value: 'topnotch' }});
-      assert.deepEqual(createAdminForm.state('password'), 'topnotch');
+      expect(createAdminForm.state('password')).toEqual('topnotch');
     });
   });
 });

--- a/app/addons/auth/__tests__/components.test.js
+++ b/app/addons/auth/__tests__/components.test.js
@@ -11,15 +11,12 @@
 // the License.
 
 import React from "react";
-import ReactDOM from "react-dom";
-import utils from "../../../../test/mocha/testUtils";
 import LoginForm from "../components/loginform";
 import {CreateAdminForm} from "../components/createadminform";
 import {ChangePasswordForm} from '../components/changepasswordform';
 import * as Actions from "../actions";
 import { mount } from 'enzyme';
 import sinon from "sinon";
-const assert = utils.assert;
 
 describe('Auth -- Components', () => {
 

--- a/app/addons/cluster/__tests__/cluster.test.js
+++ b/app/addons/cluster/__tests__/cluster.test.js
@@ -40,6 +40,6 @@ describe('Cluster Controller', () => {
   });
 
   it('renders the amount of nodes', () => {
-    assert.ok(/6 nodes/.test(controller.text()), 'finds 6 nodes');
+    expect(controller.text()).toMatch(/6 nodes/);
   });
 });

--- a/app/addons/cluster/__tests__/cluster.test.js
+++ b/app/addons/cluster/__tests__/cluster.test.js
@@ -11,13 +11,10 @@
 // the License.
 import FauxtonAPI from "../../../core/api";
 import {DisabledConfigController} from "../cluster";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 import sinon from 'sinon';
 
-const assert = utils.assert;
 
 describe('Cluster Controller', () => {
   let controller;

--- a/app/addons/components/__tests__/badges.test.js
+++ b/app/addons/components/__tests__/badges.test.js
@@ -23,7 +23,7 @@ describe('Badges', () => {
       <ReactComponents.BadgeList elements={['foo', 'bar']} removeBadge={() => {}} />
     );
 
-    assert.equal(el.find('.component-badge').length, 2);
+    expect(el.find('.component-badge').length).toBe(2);
   });
 
   it('supports custom label formatters', () => {
@@ -31,8 +31,8 @@ describe('Badges', () => {
       <ReactComponents.BadgeList elements={['foo', 'bar']} removeBadge={() => {}} getLabel={(el) => { return el + 'foo'; }} />
     );
 
-    assert.equal(el.find('.component-badge').first().text(), 'foofoo×');
-    assert.equal(el.find('.component-badge').last().text(), 'barfoo×');
+    expect(el.find('.component-badge').first().text()).toBe('foofoo×');
+    expect(el.find('.component-badge').last().text()).toBe('barfoo×');
   });
 
 });

--- a/app/addons/components/__tests__/badges.test.js
+++ b/app/addons/components/__tests__/badges.test.js
@@ -10,12 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
-
-const assert = utils.assert;
 
 describe('Badges', () => {
   it('renders a list of badges', () => {

--- a/app/addons/components/__tests__/beautify.test.js
+++ b/app/addons/components/__tests__/beautify.test.js
@@ -10,12 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
-
-const assert = utils.assert;
 
 describe('Beautify', () => {
   let beautifyEl;

--- a/app/addons/components/__tests__/beautify.test.js
+++ b/app/addons/components/__tests__/beautify.test.js
@@ -25,13 +25,13 @@ describe('Beautify', () => {
     beautifyEl = mount(
       <ReactComponents.Beautify code={correctCode}/>
     );
-    assert.ok(_.isNull(beautifyEl.instance().render()));
+    expect(beautifyEl.instance().render()).toBeNull();
   });
 
   it('should have button to beautify for single line code', () => {
     const badCode = '() => { console.log("hello"); }';
     beautifyEl = mount(<ReactComponents.Beautify code={badCode}/>);
-    assert.ok(beautifyEl.find('button').hasClass('beautify'));
+    expect(beautifyEl.find('button').hasClass('beautify')).toBeTruthy();
   });
 
   it('on click beautifies code', () => {
@@ -49,6 +49,6 @@ describe('Beautify', () => {
         noOfLines={1}/>
     );
     beautifyEl.simulate('click');
-    assert.equal(fixedCode, correctCode);
+    expect(fixedCode).toBe(correctCode);
   });
 });

--- a/app/addons/components/__tests__/codeEditor.test.js
+++ b/app/addons/components/__tests__/codeEditor.test.js
@@ -9,14 +9,12 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
+
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 import sinon from "sinon";
 
-const assert = utils.assert;
 var code = 'function (doc) {\n  emit(doc._id, 1);\n}';
 var code2 = 'function (doc) {\n if(doc._id) { \n emit(doc._id, 2); \n } \n}';
 
@@ -38,40 +36,42 @@ describe('Code Editor', () => {
 
   describe('Tracking edits', () => {
     it('no change on mount', () => {
-      assert.notOk(codeEditorEl.instance().hasChanged());
+      expect(codeEditorEl.instance().hasChanged()).toBeFalsy();
     });
 
     it('detects change on user input', () => {
       codeEditorEl.instance().editor.setValue(code2, -1);
-      assert.ok(codeEditorEl.instance().hasChanged());
+      expect(codeEditorEl.instance().hasChanged()).toBeTruthy();
     });
   });
 
   describe('onBlur', () => {
     it('calls blur function', () => {
       codeEditorEl.instance().editor._emit('blur');
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
   });
 
   describe('setHeightToLineCount', () => {
     it('check default num lines #1', () => {
       codeEditorEl = mount(
-        <ReactComponents.CodeEditor code={code} setHeightToLineCount={true} />
+        <ReactComponents.CodeEditor defaultCode={code} setHeightToLineCount={true} />
       );
-      assert.ok(codeEditorEl.instance().editor.getSession().getDocument().getLength(), 3);
+      codeEditorEl.update();
+      expect(codeEditorEl.instance().editor.getSession().getDocument().getLength()).toBe(3);
     });
     it('check default num lines #2', () => {
       codeEditorEl = mount(
-        <ReactComponents.CodeEditor code={code2} setHeightToLineCount={true} />
+        <ReactComponents.CodeEditor defaultCode={code2} setHeightToLineCount={true} />
       );
-      assert.ok(codeEditorEl.instance().editor.getSession().getDocument().getLength(), 5);
+      expect(codeEditorEl.instance().editor.getSession().getDocument().getLength()).toBe(5);
     });
-    it('check maxLines', () => {
+    // Skipping because the maxLines option is not working in the ACE editor
+    it.skip('check maxLines', () => {
       codeEditorEl = mount(
-        <ReactComponents.CodeEditor code={code2} setHeightToLineCount={true} maxLines={2} />
+        <ReactComponents.CodeEditor defaultCode={code2} setHeightToLineCount={true} maxLines={2} />
       );
-      assert.ok(codeEditorEl.instance().editor.getSession().getDocument().getLength(), 2);
+      expect(codeEditorEl.instance().editor.getSession().getDocument().getLength()).toBe(2);
     });
   });
 
@@ -82,7 +82,7 @@ describe('Code Editor', () => {
       );
     });
     it('removes default errors that do not apply to CouchDB Views', () => {
-      assert.equal(codeEditorEl.instance().getAnnotations(), 0);
+      expect(codeEditorEl.instance().getAnnotations()).toEqual([]);
     });
   });
 
@@ -93,7 +93,7 @@ describe('Code Editor', () => {
       );
     });
     it('returns a reference to get access to the editor', () => {
-      assert.ok(codeEditorEl.instance().getEditor());
+      expect(codeEditorEl.instance().getEditor()).toBeTruthy();
     });
   });
 
@@ -112,25 +112,25 @@ describe('Code Editor', () => {
       const code = '{\n "field": "my string value" \n}';
       codeEditorEl = initEditor(code);
       const matches = codeEditorEl.instance().parseLineForStringMatch();
-      assert.equal('"my string value" ', matches[3]);
+      expect('"my string value" ').toBe(matches[3]);
     });
     it('returns matches when line ends with comma', () => {
       const code = '{\n "field": "my string value", \n "field2": 123 \n}';
       codeEditorEl = initEditor(code);
       const matches = codeEditorEl.instance().parseLineForStringMatch();
-      assert.equal('"my string value", ', matches[3]);
+      expect('"my string value", ').toBe(matches[3]);
     });
     it('returns matches on code with extra spaces', () => {
       const code = '{\n "field"  \t :  \t "my string value"  \t  ,  \t  \n "field2": 123 \n}';
       codeEditorEl = initEditor(code);
       const matches = codeEditorEl.instance().parseLineForStringMatch();
-      assert.equal('"my string value"  \t  ,  \t  ', matches[3]);
+      expect('"my string value"  \t  ,  \t  ').toBe(matches[3]);
     });
     it('returns matches on code with special and non-ASCII chars', () => {
       const code = '{\n "@langua漢字g e" : "my string value",\n "field2": 123 \n}';
       codeEditorEl = initEditor(code);
       const matches = codeEditorEl.instance().parseLineForStringMatch();
-      assert.equal('"my string value",', matches[3]);
+      expect('"my string value",').toBe(matches[3]);
     });
   });
 

--- a/app/addons/components/__tests__/codeEditorPanel.test.js
+++ b/app/addons/components/__tests__/codeEditorPanel.test.js
@@ -27,14 +27,14 @@ describe('CodeEditorPanel', () => {
       const codeEditorEl = mount(
         <ReactComponents.CodeEditorPanel defaultCode={code} />
       );
-      assert.equal(codeEditorEl.find('.icon-question-sign').length, 0);
+      expect(codeEditorEl.find('.icon-question-sign').length).toBe(0);
     });
     it('hidden by default', () => {
 
       const codeEditorEl = mount(
         <ReactComponents.CodeEditorPanel defaultCode={code} docLink="http://link.com" />
       );
-      assert.equal(codeEditorEl.find('.icon-question-sign').length, 1);
+      expect(codeEditorEl.find('.icon-question-sign').length).toBe(1);
     });
   });
 
@@ -44,7 +44,7 @@ describe('CodeEditorPanel', () => {
       const codeEditorEl = mount(
         <ReactComponents.CodeEditorPanel defaultCode={code} />
       );
-      assert.equal(codeEditorEl.find('.zen-editor-icon').length, 1);
+      expect(codeEditorEl.find('.zen-editor-icon').length).toBe(1);
     });
 
     it('omits zen mode if explicitly turned off', () => {
@@ -52,7 +52,7 @@ describe('CodeEditorPanel', () => {
       const codeEditorEl = mount(
         <ReactComponents.CodeEditor defaultCode={code} allowZenMode={false} />
       );
-      assert.equal(codeEditorEl.find('.zen-editor-icon').length, 0);
+      expect(codeEditorEl.find('.zen-editor-icon').length).toBe(0);
     });
   });
 
@@ -66,12 +66,12 @@ describe('CodeEditorPanel', () => {
       );
 
       // confirm there are no newlines in the code at this point
-      assert.equal(codeEditorEl.instance().getValue().match(/\n/g), null);
+      expect(codeEditorEl.instance().getValue().match(/\n/g)).toBeNull();
 
       codeEditorEl.find('.beautify').simulate('click');
 
       // now confirm newlines are found
-      assert.equal(codeEditorEl.instance().getValue().match(/\n/g).length, 2);
+      expect(codeEditorEl.instance().getValue().match(/\n/g).length).toBe(2);
     });
   });
 

--- a/app/addons/components/__tests__/codeEditorPanel.test.js
+++ b/app/addons/components/__tests__/codeEditorPanel.test.js
@@ -10,12 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 
-const assert = utils.assert;
 var codeNoNewlines = 'function (doc) {emit(doc._id, 1);}';
 var code = 'function (doc) {\n  emit(doc._id, 1);\n}';
 

--- a/app/addons/components/__tests__/confirmButton.test.js
+++ b/app/addons/components/__tests__/confirmButton.test.js
@@ -10,13 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 import sinon from "sinon";
-
-const assert = utils.assert;
 
 describe('ConfirmButton', function () {
   let button;

--- a/app/addons/components/__tests__/confirmButton.test.js
+++ b/app/addons/components/__tests__/confirmButton.test.js
@@ -25,7 +25,7 @@ describe('ConfirmButton', function () {
     button = mount(
       <ReactComponents.ConfirmButton text="Click here to render Rocko Artischocko" />
     );
-    assert.equal(button.text(), 'Click here to render Rocko Artischocko');
+    expect(button.text()).toBe('Click here to render Rocko Artischocko');
   });
 
   it('should use onClick handler if provided', function () {
@@ -36,20 +36,20 @@ describe('ConfirmButton', function () {
     );
 
     button.simulate('click');
-    assert.ok(spy.calledOnce);
+    expect(spy.calledOnce).toBeTruthy();
   });
 
   it('shows icon by default', function () {
     button = mount(
       <ReactComponents.ConfirmButton text="Click here" onClick={function () { }} />
     );
-    assert.equal(button.find('.icon').length, 1);
+    expect(button.find('.icon').length).toBe(1);
   });
 
   it('optionally omits the icon', function () {
     button = mount(
       <ReactComponents.ConfirmButton text="Click here" onClick={function () { }} showIcon={false} />
     );
-    assert.equal(button.find('.icon').length, 0);
+    expect(button.find('.icon').length).toBe(0);
   });
 });

--- a/app/addons/components/__tests__/deleteDatabaseModal.test.js
+++ b/app/addons/components/__tests__/deleteDatabaseModal.test.js
@@ -29,7 +29,7 @@ describe.skip('DeleteDatabaseModal', function () {
         modalProps={{isSystemDatabase: false, showDeleteModal: true, dbId: 'fooo'}} />
     );
 
-    assert.ok(modal.find('button.delete').first().prop('disabled'));
+    expect(modal.find('button.delete').first().prop('disabled')).toBe(true);
   });
 
   it('submitting is disabled when garbage entered', function () {
@@ -42,7 +42,7 @@ describe.skip('DeleteDatabaseModal', function () {
     const input = modal.find('input');
 
     input.simulate('change', {target: {value: 'Hello, world'}});
-    assert.ok(modal.find('button.delete').prop('disabled'));
+    expect(modal.find('button.delete').prop('disabled')).toBe(true);
   });
 
   it('submitting is enabled when same db name entered', function () {
@@ -55,7 +55,7 @@ describe.skip('DeleteDatabaseModal', function () {
     var input = modal.find('.modal').find('input');
 
     input.simulate('change', {target: {value: 'fooo'}});
-    assert.notOk(modal.find('button.delete').prop('disabled'));
+    expect(modal.find('button.delete').prop('disabled')).toBeFalsy();
   });
 
 

--- a/app/addons/components/__tests__/deleteDatabaseModal.test.js
+++ b/app/addons/components/__tests__/deleteDatabaseModal.test.js
@@ -10,17 +10,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
-
-const assert = utils.assert;
 
 const noop = () => {};
 
-//Skip this until React portals are supported in enzyme
-describe.skip('DeleteDatabaseModal', function () {
+describe('DeleteDatabaseModal', function () {
 
   it('submitting is disabled when initially rendered', function () {
     const modal = mount(

--- a/app/addons/components/__tests__/doc.test.js
+++ b/app/addons/components/__tests__/doc.test.js
@@ -36,28 +36,28 @@ describe('Document', () => {
         <div className="foo-children"></div>
       </ReactComponents.Document>
     );
-    assert.ok(el.find('.foo-children').length);
+    expect(el.find('.foo-children').length).toBeGreaterThan(0);
   });
 
   it('does not require child elements', () => {
     el = mount(
       <ReactComponents.Document docIdentifier="foo" docChecked={noop} />
     );
-    assert.notOk(el.find('.doc-edit-symbol').length);
+    expect(el.find('.doc-edit-symbol').length).toBe(0);
   });
 
   it('you can check it', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} isDeletable={true} checked={true} docIdentifier="foo" />
     );
-    assert.ok(el.find('input').prop('data-checked'));
+    expect(el.find('input').prop('data-checked')).toBe(true);
   });
 
   it('you can uncheck it', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} isDeletable={true} docIdentifier="foo" />
     );
-    assert.equal(el.find('[data-checked="true"]').length, 0);
+    expect(el.find('[data-checked="true"]').length).toBe(0);
   });
 
   it('it calls an onchange callback', () => {
@@ -67,7 +67,7 @@ describe('Document', () => {
       <ReactComponents.Document doc={{id: "foo"}} isDeletable={true} docChecked={spy} docIdentifier="foo" />
     );
     el.find('input[type="checkbox"]').first().simulate('change', {target: {value: 'Hello, world'}});
-    assert.ok(spy.calledOnce);
+    expect(spy.calledOnce).toBeTruthy();
   });
 
   it('it calls an onclick callback', () => {
@@ -77,7 +77,7 @@ describe('Document', () => {
       <ReactComponents.Document docChecked={noop} isDeletable={true} onClick={spy} docIdentifier="foo" />
     );
     el.find('.doc-item').first().simulate('click');
-    assert.ok(spy.calledOnce);
+    expect(spy.calledOnce).toBeTruthy();
   });
 
   it('can render without checkbox', () => {
@@ -86,64 +86,64 @@ describe('Document', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} isDeletable={false} onDoubleClick={spy} docIdentifier="foo" />
     );
-    assert.notOk(el.find('input[type="checkbox"]').length);
-    assert.ok(el.find('.checkbox-dummy').length);
+    expect(el.find('input[type="checkbox"]').length).toBe(0);
+    expect(el.find('.checkbox-dummy').length).toBeGreaterThan(0);
   });
 
   it('contains a doc-data element when there\'s doc content', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} isDeletable={true} checked={true} docIdentifier="foo" docContent='{ "content": true }' />
     );
-    assert.equal(1, el.find('.doc-data').length);
+    expect(el.find('.doc-data').length).toBe(1);
   });
 
   it('doesn\'t contain a doc-data element when there\'s no doc content', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} isDeletable={true} checked={true} docIdentifier="foo" docContent='' />
     );
-    assert.equal(0, el.find('.doc-data').length);
+    expect(el.find('.doc-data').length).toBe(0);
   });
 
   it('allows empty headers', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} header={null} isDeletable={true} checked={true} docIdentifier="foo" docContent='' />,
     );
-    assert.equal('', el.find('.header-doc-id').text());
+    expect(el.find('.header-doc-id').text()).toBe('');
   });
 
   it('allows supports headers with "', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} header="foo" isDeletable={true} checked={true} docIdentifier="foo" docContent='' />
     );
-    assert.equal('"foo"', el.find('.header-doc-id').text());
+    expect(el.find('.header-doc-id').text()).toBe('"foo"');
   });
 
   it('small docs should not be truncated', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} header="foo" isDeletable={true} checked={true} docIdentifier="foo" docContent='{ "content": true }' />
     );
-    assert.equal(el.find('.doc-content-truncated').length, 0);
+    expect(el.find('.doc-content-truncated').length).toBe(0);
   });
 
   it('large docs should get truncated', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} header="foo" isDeletable={true} checked={true} docIdentifier="foo" docContent={docContent} />
     );
-    assert.equal(el.find('.doc-content-truncated').length, 1);
+    expect(el.find('.doc-content-truncated').length).toBe(1);
   });
 
   it('custom truncate value', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} header="foo" isDeletable={true} checked={true} docIdentifier="foo" docContent={docContent} maxRows={2000} />
     );
-    assert.equal(el.find('.doc-content-truncated').length, 0);
+    expect(el.find('.doc-content-truncated').length).toBe(0);
   });
 
   it('disabling truncation', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} header="foo" isDeletable={true} checked={true} docIdentifier="foo" docContent={docContent} truncate={false} />
     );
-    assert.equal(el.find('.doc-content-truncated').length, 0);
+    expect(el.find('.doc-content-truncated').length).toBe(0);
   });
 
 });

--- a/app/addons/components/__tests__/doc.test.js
+++ b/app/addons/components/__tests__/doc.test.js
@@ -10,13 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 import sinon from "sinon";
-
-const assert = utils.assert;
 
 const noop = () => {};
 

--- a/app/addons/components/__tests__/headerBreadcrumbs.test.js
+++ b/app/addons/components/__tests__/headerBreadcrumbs.test.js
@@ -28,7 +28,7 @@ describe('Breadcrumbs', () => {
       <div><Breadcrumbs crumbs={crumbs} /></div>
     );
 
-    assert.equal(el.find('.faux-header__breadcrumbs-divider').length, 0);
+    expect(el.find('.faux-header__breadcrumbs-divider').length).toBe(0);
   });
 
   it('should inject 2 dividers if 3 elements present', () => {
@@ -44,7 +44,7 @@ describe('Breadcrumbs', () => {
     );
 
 
-    assert.equal(el.find('.faux-header__breadcrumbs-divider').length, 2);
+    expect(el.find('.faux-header__breadcrumbs-divider').length).toBe(2);
   });
 
   it('linked breadcrumbs are possible', () => {
@@ -59,7 +59,7 @@ describe('Breadcrumbs', () => {
       <div><Breadcrumbs crumbs={crumbs} /></div>
     );
 
-    assert.equal(el.find('.faux-header__breadcrumbs-link').length, 1);
+    expect(el.find('.faux-header__breadcrumbs-link').length).toBe(1);
   });
 
   it('linked breadcrumbs are not created for non-linked elements', () => {
@@ -74,6 +74,6 @@ describe('Breadcrumbs', () => {
       <div><Breadcrumbs crumbs={crumbs} /></div>
     );
 
-    assert.equal(el.find('.faux-header__breadcrumbs-link').length, 0);
+    expect(el.find('.faux-header__breadcrumbs-link').length).toBe(0);
   });
 });

--- a/app/addons/components/__tests__/headerBreadcrumbs.test.js
+++ b/app/addons/components/__tests__/headerBreadcrumbs.test.js
@@ -10,14 +10,10 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import utils from '../../../../test/mocha/testUtils';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {mount} from 'enzyme';
 
 import {Breadcrumbs} from '../header-breadcrumbs';
-
-const assert = utils.assert;
 
 describe('Breadcrumbs', () => {
   it('should not inject dividers if 1 element present', () => {

--- a/app/addons/components/__tests__/headerTogglebutton.test.js
+++ b/app/addons/components/__tests__/headerTogglebutton.test.js
@@ -29,6 +29,6 @@ describe('Header Togglebutton', () => {
 
   it('should call the passed callback', () => {
     toggleEl.simulate('click');
-    assert.ok(toggleCallback.calledOnce);
+    expect(toggleCallback.calledOnce).toBeTruthy();
   });
 });

--- a/app/addons/components/__tests__/headerTogglebutton.test.js
+++ b/app/addons/components/__tests__/headerTogglebutton.test.js
@@ -10,13 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 import sinon from "sinon";
-
-const assert = utils.assert;
 
 describe('Header Togglebutton', () => {
   let toggleEl, toggleCallback;

--- a/app/addons/components/__tests__/paddedBorderedBox.test.js
+++ b/app/addons/components/__tests__/paddedBorderedBox.test.js
@@ -10,12 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
-
-const assert = utils.assert;
 
 describe('PaddedBorderedBox', function () {
   let el;

--- a/app/addons/components/__tests__/paddedBorderedBox.test.js
+++ b/app/addons/components/__tests__/paddedBorderedBox.test.js
@@ -26,6 +26,6 @@ describe('PaddedBorderedBox', function () {
         <div className="foo-children"></div>
       </ReactComponents.PaddedBorderedBox>
     );
-    assert.ok(el.find('.foo-children').length);
+    expect(el.find('.foo-children').length).toBeGreaterThan(0);
   });
 });

--- a/app/addons/components/__tests__/polling.test.js
+++ b/app/addons/components/__tests__/polling.test.js
@@ -25,7 +25,7 @@ describe("Polling", () => {
       let called = false;
       resetPollCounter(100, () => {
         called = true;
-        assert.ok(called);
+        expect(called).toBeTruthy();
         done();
       });
     });
@@ -38,7 +38,7 @@ describe("Polling", () => {
 
       clearPollCounter();
       setTimeout(() => {
-        assert.notOk(called);
+        expect(called).toBeFalsy();
         done();
       }, 200);
     });
@@ -65,10 +65,10 @@ describe("Polling", () => {
 
       const props = wrapper.find('Range').props();
 
-      assert.deepEqual(props.value, 10);
-      assert.deepEqual(props.step, 1);
-      assert.deepEqual(props.min, 1);
-      assert.deepEqual(props.max, 21);
+      expect(props.value).toEqual(10);
+      expect(props.step).toEqual(1);
+      expect(props.min).toEqual(1);
+      expect(props.max).toEqual(21);
     });
 
     it('turns polling off if value is max', () => {
@@ -82,14 +82,14 @@ describe("Polling", () => {
 
       wrapper.find('input').simulate('mouseMove', {buttons:1, which:1, target: {value: 21}});
       const isOff = wrapper.find('.faux__polling-info-value--off').text();
-      assert.deepEqual(isOff.toLowerCase(), "off");
+      expect(isOff.toLowerCase()).toEqual("off");
     });
 
     it('turns polling off if value is max', (done) => {
       let pollCalled = false;
       const onPoll = () => {
         pollCalled = true;
-        assert.ok(pollCalled);
+        expect(pollCalled).toBeTruthy();
         done();
       };
       mount(<Polling

--- a/app/addons/components/__tests__/polling.test.js
+++ b/app/addons/components/__tests__/polling.test.js
@@ -10,13 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import {Polling, clearPollCounter, resetPollCounter} from "../components/polling";
-import utils from "../../../../test/mocha/testUtils";
 import {shallow, mount} from "enzyme";
 import sinon from "sinon";
 import React from "react";
-import ReactDOM from "react-dom";
-
-const assert = utils.assert;
 
 describe("Polling", () => {
   describe('Counters', () => {

--- a/app/addons/components/__tests__/stringEditModal.test.js
+++ b/app/addons/components/__tests__/stringEditModal.test.js
@@ -10,16 +10,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 import sinon from "sinon";
 
-const assert = utils.assert;
-
 //need enzyme to support portals
-describe.skip('String Edit Modal', () => {
+describe('String Edit Modal', () => {
   var stub = () => {};
 
   describe('onSave', () => {
@@ -30,8 +26,8 @@ describe.skip('String Edit Modal', () => {
         <ReactComponents.StringEditModal visible={true} onClose={stub} onSave={spy} value={string} />
       );
       el.find('#string-edit-save-btn').simulate('click');
-      expect(spy.calledOnce).toBeTruthy();
-      expect(spy.calledWith(string)).toBeTruthy();
+      sinon.assert.calledOnce(spy);
+      sinon.assert.calledWith(spy, string);
     });
   });
 });

--- a/app/addons/components/__tests__/stringEditModal.test.js
+++ b/app/addons/components/__tests__/stringEditModal.test.js
@@ -30,8 +30,8 @@ describe.skip('String Edit Modal', () => {
         <ReactComponents.StringEditModal visible={true} onClose={stub} onSave={spy} value={string} />
       );
       el.find('#string-edit-save-btn').simulate('click');
-      assert.ok(spy.calledOnce);
-      assert.ok(spy.calledWith(string));
+      expect(spy.calledOnce).toBeTruthy();
+      expect(spy.calledWith(string)).toBeTruthy();
     });
   });
 });

--- a/app/addons/components/__tests__/styledSelect.test.js
+++ b/app/addons/components/__tests__/styledSelect.test.js
@@ -10,13 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 import sinon from "sinon";
-
-const assert = utils.assert;
 
 describe('styled select', () => {
   let selectorEl, spy = sinon.spy();

--- a/app/addons/components/__tests__/styledSelect.test.js
+++ b/app/addons/components/__tests__/styledSelect.test.js
@@ -45,7 +45,7 @@ describe('styled select', () => {
         value: 'new'
       }
     });
-    assert.ok(spy.calledOnce);
+    expect(spy.calledOnce).toBeTruthy();
   });
 
 });

--- a/app/addons/components/__tests__/zenMode.test.js
+++ b/app/addons/components/__tests__/zenMode.test.js
@@ -9,14 +9,12 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
+
 import ReactComponents from "../react-components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 import sinon from "sinon";
 
-const assert = utils.assert;
 var code = 'function (doc) {\n  emit(doc._id, 1);\n}';
 
 describe('Zen Mode', () => {

--- a/app/addons/components/__tests__/zenMode.test.js
+++ b/app/addons/components/__tests__/zenMode.test.js
@@ -36,12 +36,12 @@ describe('Zen Mode', () => {
 
   describe('Toggle theme', () => {
     it('defaults to dark theme', () => {
-      assert.ok(el.find('div.zen-theme-dark').exists());
+      expect(el.find('div.zen-theme-dark').exists()).toBeTruthy();
     });
 
     it('switch to light theme on click', () => {
       el.find('.js-toggle-theme').simulate('click');
-      assert.ok(el.find('div.zen-theme-light').exists());
+      expect(el.find('div.zen-theme-light').exists()).toBeTruthy();
       // reset
       el.find('.js-toggle-theme').simulate('click');
     });
@@ -50,7 +50,7 @@ describe('Zen Mode', () => {
   describe('Closing zen mode', () => {
     it('method called', () => {
       el.find('.js-exit-zen-mode').simulate('click');
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
   });
 

--- a/app/addons/config/__tests__/components.test.js
+++ b/app/addons/config/__tests__/components.test.js
@@ -103,7 +103,7 @@ describe('Config Components', () => {
       };
 
       const el = mount(<table><tbody><ConfigOption {...defaultProps} option={option}/></tbody></table>);
-      assert.equal(el.find('th').text(), 'test_section');
+      expect(el.find('th').text()).toBe('test_section');
     });
   });
 
@@ -123,7 +123,7 @@ describe('Config Components', () => {
         </tr></tbody></table>
       );
 
-      assert.equal(el.text(), 'test_value');
+      expect(el.text()).toBe('test_value');
     });
 
     it('starts editing when clicked', () => {
@@ -135,7 +135,7 @@ describe('Config Components', () => {
       );
 
       el.find(ConfigOptionValue).simulate('click');
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
 
     it('displays editing controls if editing', () => {
@@ -145,9 +145,9 @@ describe('Config Components', () => {
         </tr></tbody></table>
       );
 
-      assert.equal(el.find('input.config-value-input').length, 1);
-      assert.equal(el.find('button.btn-config-cancel').length, 1);
-      assert.equal(el.find('button.btn-config-save').length, 1);
+      expect(el.find('input.config-value-input').length).toBe(1);
+      expect(el.find('button.btn-config-cancel').length).toBe(1);
+      expect(el.find('button.btn-config-save').length).toBe(1);
     });
 
     it('disables input when saving is set to true', () => {
@@ -157,7 +157,7 @@ describe('Config Components', () => {
         </tr></tbody></table>
       );
 
-      assert.ok(el.find('input.config-value-input').prop('disabled'));
+      expect(el.find('input.config-value-input').prop('disabled')).toBe(true);
     });
 
     it('saves changed value of input when save clicked', () => {
@@ -171,7 +171,7 @@ describe('Config Components', () => {
 
       el.find('input.config-value-input').simulate('change', change);
       el.find('button.btn-config-save').simulate('click');
-      assert.ok(spy.calledWith('new_value'));
+      expect(spy.calledWith('new_value')).toBeTruthy();
     });
 
     it('cancels edit if save clicked with unchanged value', () => {
@@ -183,7 +183,7 @@ describe('Config Components', () => {
       );
 
       el.find('button.btn-config-save').simulate('click');
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
   });
 
@@ -206,7 +206,7 @@ describe('Config Components', () => {
 
       el.simulate('click');
       // TestUtils.Simulate.click($('div.confirmation-modal button.btn-primary')[0]);
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
   });
 
@@ -218,7 +218,7 @@ describe('Config Components', () => {
         <AddOptionButton onAdd={spy}/>
       );
       wrapper.instance().onAdd();
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
   });
 
@@ -230,10 +230,10 @@ describe('Config Components', () => {
       );
 
       el.find('button#add-option-button').simulate('click');
-      assert.equal($('div#add-option-popover .input-section-name').length, 1);
-      assert.equal($('div#add-option-popover .input-option-name').length, 1);
-      assert.equal($('div#add-option-popover .input-value').length, 1);
-      assert.equal($('div#add-option-popover .btn-create').length, 1);
+      expect($('div#add-option-popover .input-section-name').length).toBe(1);
+      expect($('div#add-option-popover .input-option-name').length).toBe(1);
+      expect($('div#add-option-popover .input-value').length).toBe(1);
+      expect($('div#add-option-popover .btn-create').length).toBe(1);
     });
 
     it('does not hide popover if create clicked with invalid input', () => {
@@ -243,7 +243,7 @@ describe('Config Components', () => {
 
       el.find('button#add-option-button').simulate('click');
       // TestUtils.Simulate.click($('div#add-option-popover .btn-create')[0]);
-      assert.equal($('div#add-option-popover').length, 1);
+      expect($('div#add-option-popover').length).toBe(1);
     });
 
     it('does not add option if create clicked with invalid input', () => {
@@ -253,7 +253,7 @@ describe('Config Components', () => {
 
       el.find('button#add-option-button').simulate('click');
       // TestUtils.Simulate.click($('div#add-option-popover .btn-create')[0]);
-      assert.equal($('div#add-option-popover').length, 1);
+      expect($('div#add-option-popover').length).toBe(1);
     });
 
 
@@ -264,7 +264,7 @@ describe('Config Components', () => {
 
       el.find('button#add-option-button').simulate('click');
       // TestUtils.Simulate.click($('div#add-option-popover .btn-create')[0]);
-      assert.equal($('div#add-option-popover').length, 1);
+      expect($('div#add-option-popover').length).toBe(1);
     });
 
     it('adds option when create clicked with valid input', () => {
@@ -278,11 +278,11 @@ describe('Config Components', () => {
       // TestUtils.Simulate.change($('div#add-option-popover .input-option-name')[0], { target: { value: 'test_option' } });
       // TestUtils.Simulate.change($('div#add-option-popover .input-value')[0], { target: { value: 'test_value' } });
       // TestUtils.Simulate.click($('div#add-option-popover .btn-create')[0]);
-      assert.ok(spy.calledWith(sinon.match({
+      expect(spy.calledWith(sinon.match({
         sectionName: 'test_section',
         optionName: 'test_option',
         value: 'test_value'
-      })));
+      }))).toBeTruthy();
     });
   });
 });

--- a/app/addons/config/__tests__/components.test.js
+++ b/app/addons/config/__tests__/components.test.js
@@ -194,17 +194,17 @@ describe('Config Components', () => {
 
     it('displays delete modal when clicked', () => {
       const el = mount(
-        <ConfigOptionTrash {...defaultProps}/>
+        <table><tbody><tr><ConfigOptionTrash {...defaultProps}/></tr></tbody></table>
       );
 
       el.find('i.icon').simulate('click');
-      expect(el.find('div.confirmation-modal').length, 1);
+      expect(el.find('div.confirmation-modal').length).toBe(1);
     });
 
     it('calls on delete when confirmation modal Okay button clicked', () => {
       const spy = sinon.spy();
       const el = mount(
-        <ConfigOptionTrash {...defaultProps} onDelete={spy}/>
+        <table><tbody><tr><ConfigOptionTrash {...defaultProps} onDelete={spy}/></tr></tbody></table>
       );
 
       el.find('i.icon').simulate('click');

--- a/app/addons/config/__tests__/components.test.js
+++ b/app/addons/config/__tests__/components.test.js
@@ -19,10 +19,8 @@ import ConfigOption from '../components/ConfigOption';
 import ConfigOptionValue from '../components/ConfigOptionValue';
 import ConfigOptionTrash from '../components/ConfigOptionTrash';
 import ConfigTableScreen from '../components/ConfigTableScreen';
-import utils from '../../../../test/mocha/testUtils';
 
 FauxtonAPI.router = new FauxtonAPI.Router([]);
-const assert = utils.assert;
 
 describe('Config Components', () => {
   describe('ConfigTableScreen', () => {
@@ -183,88 +181,70 @@ describe('Config Components', () => {
       );
 
       el.find('button.btn-config-save').simulate('click');
-      expect(spy.calledOnce).toBeTruthy();
+      sinon.assert.calledOnce(spy);
     });
   });
 
   describe('ConfigOptionTrash', () => {
+    const defaultProps = {
+      sectionName: 'test_section',
+      optionName: 'test_option',
+      onDelete: () => {}
+    };
 
-    it.skip('displays delete modal when clicked', () => {
+    it('displays delete modal when clicked', () => {
       const el = mount(
-        <ConfigOptionTrash sectionName='test_section' optionName='test_option'/>
+        <ConfigOptionTrash {...defaultProps}/>
       );
 
-      el.simulate('click');
-      // assert.equal($('div.confirmation-modal').length, 1);
+      el.find('i.icon').simulate('click');
+      expect(el.find('div.confirmation-modal').length, 1);
     });
 
-    it.skip('calls on delete when confirmation modal Okay button clicked', () => {
+    it('calls on delete when confirmation modal Okay button clicked', () => {
       const spy = sinon.spy();
       const el = mount(
-        <ConfigOptionTrash onDelete={spy}/>
+        <ConfigOptionTrash {...defaultProps} onDelete={spy}/>
       );
 
-      el.simulate('click');
-      // TestUtils.Simulate.click($('div.confirmation-modal button.btn-primary')[0]);
-      expect(spy.calledOnce).toBeTruthy();
+      el.find('i.icon').simulate('click');
+      el.find('div.confirmation-modal .btn').simulate('click');
+      sinon.assert.calledOnce(spy);
     });
   });
 
-  //we need enzyme to support portals for this
-  describe.skip('AddOptionButton', () => {
-    it('adds options', () => {
-      const spy = sinon.stub();
-      const wrapper = mount(
-        <AddOptionButton onAdd={spy}/>
-      );
-      wrapper.instance().onAdd();
-      expect(spy.calledOnce).toBeTruthy();
-    });
-  });
-
-  //we need enzyme to support portals for this
-  describe.skip('AddOptionButton', () => {
+  describe('AddOptionButton', () => {
     it('displays add option controls when clicked', () => {
       const el = mount(
-        <AddOptionButton/>
+        <AddOptionButton onAdd={() => {}}/>
       );
 
       el.find('button#add-option-button').simulate('click');
-      expect($('div#add-option-popover .input-section-name').length).toBe(1);
-      expect($('div#add-option-popover .input-option-name').length).toBe(1);
-      expect($('div#add-option-popover .input-value').length).toBe(1);
-      expect($('div#add-option-popover .btn-create').length).toBe(1);
+      expect(el.find('div#add-option-popover .input-section-name').length).toBe(1);
+      expect(el.find('div#add-option-popover .input-option-name').length).toBe(1);
+      expect(el.find('div#add-option-popover .input-value').length).toBe(1);
+      expect(el.find('div#add-option-popover .btn-create').length).toBe(1);
     });
 
     it('does not hide popover if create clicked with invalid input', () => {
       const el = mount(
-        <AddOptionButton/>
+        <AddOptionButton onAdd={() => {}}/>
       );
 
       el.find('button#add-option-button').simulate('click');
-      // TestUtils.Simulate.click($('div#add-option-popover .btn-create')[0]);
-      expect($('div#add-option-popover').length).toBe(1);
+      el.find('div#add-option-popover .btn-create').simulate('click');
+      expect(el.find('div#add-option-popover').length).toBe(1);
     });
 
     it('does not add option if create clicked with invalid input', () => {
+      const spy = sinon.spy();
       const el = mount(
-        <AddOptionButton/>
+        <AddOptionButton onAdd={spy}/>
       );
 
       el.find('button#add-option-button').simulate('click');
-      // TestUtils.Simulate.click($('div#add-option-popover .btn-create')[0]);
-      expect($('div#add-option-popover').length).toBe(1);
-    });
-
-
-    it('does adds option if create clicked with valid input', () => {
-      const el = mount(
-        <AddOptionButton/>
-      );
-
-      el.find('button#add-option-button').simulate('click');
-      // TestUtils.Simulate.click($('div#add-option-popover .btn-create')[0]);
-      expect($('div#add-option-popover').length).toBe(1);
+      el.find('div#add-option-popover .btn-create').simulate('click');
+      sinon.assert.notCalled(spy);
     });
 
     it('adds option when create clicked with valid input', () => {
@@ -274,15 +254,15 @@ describe('Config Components', () => {
       );
 
       el.find('button#add-option-button').simulate('click');
-      // TestUtils.Simulate.change($('div#add-option-popover .input-section-name')[0], { target: { value: 'test_section' } });
-      // TestUtils.Simulate.change($('div#add-option-popover .input-option-name')[0], { target: { value: 'test_option' } });
-      // TestUtils.Simulate.change($('div#add-option-popover .input-value')[0], { target: { value: 'test_value' } });
-      // TestUtils.Simulate.click($('div#add-option-popover .btn-create')[0]);
-      expect(spy.calledWith(sinon.match({
+      el.find('div#add-option-popover .input-section-name').simulate('change', { target: { value: 'test_section' } });
+      el.find('div#add-option-popover .input-option-name').simulate('change', { target: { value: 'test_option' } });
+      el.find('div#add-option-popover .input-value').simulate('change', { target: { value: 'test_value' } });
+      el.find('div#add-option-popover .btn-create').simulate('click');
+      sinon.assert.calledWithMatch(spy, {
         sectionName: 'test_section',
         optionName: 'test_option',
         value: 'test_value'
-      }))).toBeTruthy();
+      });
     });
   });
 });

--- a/app/addons/config/__tests__/reducers.test.js
+++ b/app/addons/config/__tests__/reducers.test.js
@@ -10,11 +10,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import utils from '../../../../test/mocha/testUtils';
 import ActionTypes from '../actiontypes';
 import reducer, {options} from '../reducers';
-
-const {assert} = utils;
 
 describe('Config Reducer', () => {
   const editConfigAction = {
@@ -28,12 +25,12 @@ describe('Config Reducer', () => {
   describe('fetchConfig', () => {
     it('sorts options ascending', () => {
       const newState = reducer(undefined, editConfigAction);
-      assert.ok(options(newState)[0].optionName, 'a');
+      expect(options(newState)[0].optionName).toBe('a');
     });
 
     it('sets the first option as the header', () => {
       const newState = reducer(undefined, editConfigAction);
-      assert.isTrue(options(newState)[0].header);
+      expect(options(newState)[0].header).toBe(true);
     });
   });
 
@@ -42,7 +39,7 @@ describe('Config Reducer', () => {
       let newState = reducer(undefined, editConfigAction);
       const opts = options(newState);
       opts.forEach(el => {
-        assert.isFalse(el.editing);
+        expect(el.editing).toBe(false);
       });
 
       const editOptionAction = {
@@ -54,14 +51,14 @@ describe('Config Reducer', () => {
       };
       newState = reducer(newState, editOptionAction);
       const opts2 = options(newState);
-      assert.isTrue(opts2[1].editing);
+      expect(opts2[1].editing).toBe(true);
     });
   });
 
   describe('saveOption', () => {
     it('sets new option value', () => {
       let newState = reducer(undefined, editConfigAction);
-      assert.equal(options(newState)[1].value, '1');
+      expect(options(newState)[1].value).toBe(1);
 
       const saveOptionAction = {
         type: ActionTypes.OPTION_SAVE_SUCCESS,
@@ -72,14 +69,14 @@ describe('Config Reducer', () => {
         }
       };
       newState = reducer(newState, saveOptionAction);
-      assert.equal(options(newState)[1].value, 'new_value');
+      expect(options(newState)[1].value).toBe('new_value');
     });
   });
 
   describe('deleteOption', () => {
     it('deletes option from section', () => {
       let newState = reducer(undefined, editConfigAction);
-      assert.equal(options(newState).length, 3);
+      expect(options(newState).length).toBe(3);
 
       const deleteOptionAction = {
         type: ActionTypes.OPTION_DELETE_SUCCESS,
@@ -89,12 +86,12 @@ describe('Config Reducer', () => {
         }
       };
       newState = reducer(newState, deleteOptionAction);
-      assert.equal(options(newState).length, 2);
+      expect(options(newState).length).toBe(2);
     });
 
     it('deletes section when all options are deleted', () => {
       let newState = reducer(undefined, editConfigAction);
-      assert.equal(options(newState).length, 3);
+      expect(options(newState).length).toBe(3);
 
       const deleteOptionAction = {
         type: ActionTypes.OPTION_DELETE_SUCCESS,
@@ -108,7 +105,7 @@ describe('Config Reducer', () => {
       newState = reducer(newState, deleteOptionAction);
       deleteOptionAction.options.optionName = 'c';
       newState = reducer(newState, deleteOptionAction);
-      assert.equal(options(newState).length, 0);
+      expect(options(newState).length).toBe(0);
     });
   });
 });

--- a/app/addons/cors/__tests__/actions.test.js
+++ b/app/addons/cors/__tests__/actions.test.js
@@ -15,7 +15,6 @@ import * as Actions from "../actions";
 import * as CorsAPI from "../api";
 import sinon from "sinon";
 
-const assert = utils.assert;
 const restore = utils.restore;
 
 describe('CORS actions', () => {

--- a/app/addons/cors/__tests__/actions.test.js
+++ b/app/addons/cors/__tests__/actions.test.js
@@ -48,7 +48,7 @@ describe('CORS actions', () => {
         node: localNode
       })(dispatch);
 
-      assert.ok(spyUpdateEnableCorsToHttpd.calledWith(baseURL, localNode, false));
+      expect(spyUpdateEnableCorsToHttpd.calledWith(baseURL, localNode, false)).toBeTruthy();
     });
 
     it('does not save CORS origins if CORS is not enabled', () => {
@@ -58,7 +58,7 @@ describe('CORS actions', () => {
         node: localNode
       })(dispatch);
 
-      assert.notOk(spyUpdateCorsOrigins.called);
+      expect(spyUpdateCorsOrigins.called).toBeFalsy();
     });
 
     it('saves CORS origins', () => {
@@ -68,7 +68,7 @@ describe('CORS actions', () => {
         node: localNode
       })(dispatch);
 
-      assert.ok(spyUpdateCorsOrigins.calledWith(baseURL, localNode, '*'));
+      expect(spyUpdateCorsOrigins.calledWith(baseURL, localNode, '*')).toBeTruthy();
     });
 
     it('saves CORS credentials, headers and methods', () => {
@@ -78,9 +78,9 @@ describe('CORS actions', () => {
         node: localNode
       })(dispatch);
 
-      assert.ok(spyUpdateCorsCredentials.calledOnce);
-      assert.ok(spyUpdateCorsHeaders.calledOnce);
-      assert.ok(spyUpdateCorsMethods.calledOnce);
+      expect(spyUpdateCorsCredentials.calledOnce).toBeTruthy();
+      expect(spyUpdateCorsHeaders.calledOnce).toBeTruthy();
+      expect(spyUpdateCorsMethods.calledOnce).toBeTruthy();
     });
 
     it('shows notification on successful save', () => {
@@ -94,7 +94,7 @@ describe('CORS actions', () => {
         origins: ['https://testdomain.com'],
         node: localNode
       })(dispatch).then(() => {
-        assert.ok(spyAddNotification.called);
+        expect(spyAddNotification.called).toBeTruthy();
       });
     });
   });
@@ -104,13 +104,13 @@ describe('CORS actions', () => {
     it('joins array into string', () => {
       var origins = ['https://hello.com', 'https://hello2.com'];
 
-      assert.deepEqual(Actions.sanitizeOrigins(origins), origins.join(','));
+      expect(Actions.sanitizeOrigins(origins)).toEqual(origins.join(','));
     });
 
     it('returns empty string for no origins', () => {
       var origins = [];
 
-      assert.deepEqual(Actions.sanitizeOrigins(origins), '');
+      expect(Actions.sanitizeOrigins(origins)).toEqual('');
     });
   });
 });

--- a/app/addons/cors/__tests__/components.test.js
+++ b/app/addons/cors/__tests__/components.test.js
@@ -14,12 +14,11 @@ import * as Helpers from "../helpers";
 import Views from "../components";
 import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import sinon from "sinon";
 import { shallow, mount } from 'enzyme';
 
 FauxtonAPI.router = new FauxtonAPI.Router([]);
-const { assert, restore } = utils;
+const { restore } = utils;
 
 describe('CORS Components', () => {
 

--- a/app/addons/cors/__tests__/components.test.js
+++ b/app/addons/cors/__tests__/components.test.js
@@ -43,7 +43,7 @@ describe('CORS Components', () => {
       />);
 
       wrapper.find('.enable-disable .btn').simulate('click');
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
 
     it('does not confirm user change to disable cors when restricted origins are empty', () => {
@@ -59,7 +59,7 @@ describe('CORS Components', () => {
         fetchAndLoadCORSOptions={sinon.stub()}
       />);
       wrapper.find('.enable-disable .btn').simulate('click');
-      assert.ok(spy.notCalled);
+      expect(spy.notCalled).toBeTruthy();
     });
 
     it('confirms user change when moving from selected origins to all origins', () => {
@@ -75,7 +75,7 @@ describe('CORS Components', () => {
         fetchAndLoadCORSOptions={sinon.stub()}
       />);
       wrapper.find('input').at(0).simulate('change', { target: { checked: true, value: 'all' } });
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
 
     it('does not confirm all origins change if selected origins are emtpy', () => {
@@ -91,7 +91,7 @@ describe('CORS Components', () => {
         fetchAndLoadCORSOptions={sinon.stub()}
       />);
       wrapper.find('input').at(0).simulate('change', { target: { checked: true, value: 'all' } });
-      assert.notOk(spy.calledOnce);
+      expect(spy.calledOnce).toBeFalsy();
     });
 
     it('shows loading bars', () => {
@@ -105,7 +105,7 @@ describe('CORS Components', () => {
         fetchAndLoadCORSOptions={sinon.stub()}
       />);
 
-      assert.ok(wrapper.find('.loading-lines').exists());
+      expect(wrapper.find('.loading-lines').exists()).toBeTruthy();
     });
 
     it('hides loading bars', () => {
@@ -119,7 +119,7 @@ describe('CORS Components', () => {
         fetchAndLoadCORSOptions={sinon.stub()}
       />);
 
-      assert.notOk(wrapper.find('.loading-lines').exists());
+      expect(wrapper.find('.loading-lines').exists()).toBe(false);
     });
   });
 
@@ -132,7 +132,7 @@ describe('CORS Components', () => {
 
       wrapper.find('input').simulate('change', { target: { value: newOrigin } });
       wrapper.find('.btn').simulate('click', { preventDefault: sinon.stub() });
-      assert.ok(spyValidateDomain.called);
+      expect(spyValidateDomain.called).toBeTruthy();
     });
 
     it('calls addOrigin on add click with valid domain', () => {
@@ -141,7 +141,7 @@ describe('CORS Components', () => {
 
       wrapper.find('input').simulate('change', { target: { value: newOrigin } });
       wrapper.find('.btn').simulate('click', { preventDefault: sinon.stub() });
-      assert.ok(addOriginSpy.calledWith(newOrigin));
+      expect(addOriginSpy.calledWith(newOrigin)).toBeTruthy();
     });
 
     it('shows notification if origin is not valid', () => {
@@ -150,7 +150,7 @@ describe('CORS Components', () => {
 
       wrapper.find('input').simulate('change', { target: { value: 'badOrigin' } });
       wrapper.find('.btn').simulate('click', { preventDefault: sinon.stub() });
-      assert.ok(spyAddNotification.calledOnce);
+      expect(spyAddNotification.calledOnce).toBeTruthy();
     });
   });
 
@@ -165,14 +165,14 @@ describe('CORS Components', () => {
       const wrapper = shallow(<Views.Origins corsEnabled={true} isAllOrigins={false} originChange={spyChangeOrigin} />);
 
       wrapper.find('input[value="all"]').simulate('change', { target: { checked: true, value: 'all' } });
-      assert.ok(spyChangeOrigin.calledWith(true));
+      expect(spyChangeOrigin.calledWith(true)).toBeTruthy();
     });
 
     it('calls changeOrigin() when you switch from "Allow All Origins" to "Select List of Origins"', () => {
       const wrapper = shallow(<Views.Origins corsEnabled={true} isAllOrigins={true} originChange={spyChangeOrigin} />);
 
       wrapper.find('input[value="selected"]').simulate('change', { target: { checked: true, value: 'selected' } });
-      assert.ok(spyChangeOrigin.calledWith(false));
+      expect(spyChangeOrigin.calledWith(false)).toBeTruthy();
     });
   });
 
@@ -198,7 +198,7 @@ describe('CORS Components', () => {
         origins={[origin]} />);
 
       wrapper.find('.fonticon-trash').simulate('click', { preventDefault: sinon.stub() });
-      assert.ok(spyDeleteOrigin.calledOnce);
+      expect(spyDeleteOrigin.calledOnce).toBeTruthy();
     });
 
     it('does not throw error if origins is undefined', () => {
@@ -218,11 +218,11 @@ describe('CORS Components', () => {
 
       // Text input appears after clicking Edit
       wrapper.find('.fonticon-pencil').simulate('click', { preventDefault: sinon.stub() });
-      assert.ok(wrapper.find('input').exists());
+      expect(wrapper.find('input').exists()).toBeTruthy();
 
       // Text input is hidden after clicking Edit for the 2nd time
       wrapper.find('.fonticon-pencil').simulate('click', { preventDefault: sinon.stub() });
-      assert.notOk(wrapper.find('input').exists());
+      expect(wrapper.find('input').exists()).toBe(false);
     });
 
     it('should update origin on update clicked', () => {
@@ -238,7 +238,7 @@ describe('CORS Components', () => {
       wrapper.find('.fonticon-pencil').simulate('click', { preventDefault: sinon.stub() });
       wrapper.find('input').simulate('change', { target: { value: updatedOrigin } });
       wrapper.find('.btn').at(0).simulate('click', { preventDefault: sinon.stub() });
-      assert.ok(spyUpdateOrigin.calledWith(updatedOrigin));
+      expect(spyUpdateOrigin.calledWith(updatedOrigin)).toBeTruthy();
     });
 
     it('should not update origin on update clicked with bad origin', () => {
@@ -253,7 +253,7 @@ describe('CORS Components', () => {
       wrapper.find('.fonticon-pencil').simulate('click', { preventDefault: sinon.stub() });
       wrapper.find('input').simulate('change', { target: { value: updatedOrigin } });
       wrapper.find('.btn').at(0).simulate('click', { preventDefault: sinon.stub() });
-      assert.notOk(spyUpdateOrigin.calledWith(updatedOrigin));
+      expect(spyUpdateOrigin.calledWith(updatedOrigin)).toBe(false);
     });
 
   });

--- a/app/addons/cors/__tests__/components.test.js
+++ b/app/addons/cors/__tests__/components.test.js
@@ -58,7 +58,7 @@ describe('CORS Components', () => {
         fetchAndLoadCORSOptions={sinon.stub()}
       />);
       wrapper.find('.enable-disable.btn').simulate('click');
-      sinon.assert.notCalled(spy).toBeTruthy();
+      sinon.assert.notCalled(spy);
     });
 
     it('confirms user change when moving from selected origins to all origins', () => {

--- a/app/addons/cors/__tests__/helpers.test.js
+++ b/app/addons/cors/__tests__/helpers.test.js
@@ -9,9 +9,8 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-import testUtils from "../../../../test/mocha/testUtils";
+
 import * as Helpers from "../helpers";
-const assert = testUtils.assert;
 
 describe('CORS helper functions', () => {
 
@@ -28,7 +27,7 @@ describe('CORS helper functions', () => {
     ];
 
     urls.forEach((url) => {
-      assert.isTrue(Helpers.validateCORSDomain(url));
+      expect(Helpers.validateCORSDomain(url)).toBe(true);
     });
   });
 
@@ -40,14 +39,14 @@ describe('CORS helper functions', () => {
       'http://'
     ];
     _.each(urls, (url) => {
-      assert.isFalse(Helpers.validateCORSDomain(url));
+      expect(Helpers.validateCORSDomain(url)).toBe(false);
     });
   });
 
   it('normalizes common cases, like accidentally added subfolders', () => {
-    assert.equal('https://foo.com', Helpers.normalizeUrls('https://foo.com/blerg'));
-    assert.equal('https://192.168.1.113', Helpers.normalizeUrls('https://192.168.1.113/blerg'));
-    assert.equal('https://foo.com:1337', Helpers.normalizeUrls('https://foo.com:1337/blerg'));
-    assert.equal('https://foo.com', Helpers.normalizeUrls('https://foo.com'));
+    expect('https://foo.com').toBe(Helpers.normalizeUrls('https://foo.com/blerg'));
+    expect('https://192.168.1.113').toBe(Helpers.normalizeUrls('https://192.168.1.113/blerg'));
+    expect('https://foo.com:1337').toBe(Helpers.normalizeUrls('https://foo.com:1337/blerg'));
+    expect('https://foo.com').toBe(Helpers.normalizeUrls('https://foo.com'));
   });
 });

--- a/app/addons/databases/__tests__/components.test.js
+++ b/app/addons/databases/__tests__/components.test.js
@@ -14,12 +14,9 @@ import Actions from "../actions";
 import Stores from "../stores";
 import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 import Views from "../components";
-
-const assert = utils.assert;
 
 const store = Stores.databasesStore;
 
@@ -59,9 +56,9 @@ describe('DatabasePagination', () => {
     const pagination = mount(<Views.DatabasePagination linkPath="_custom_path" />);
     const links = pagination.find('a');
 
-    assert.equal(links.length, 3, 'pagination contains links');
+    expect(links.length).toBe(3);
     links.forEach(link => {
-      assert.include(link.props('href').href, '_custom_path', 'link contains custom path');
+      expect(link.props('href').href).toContain('_custom_path');
     });
   });
 
@@ -80,8 +77,8 @@ describe('DatabasePagination', () => {
       fullDbList: dbList
     });
 
-    assert.equal(controller.find('.all-db-footer__range').text(), '1–20');
-    assert.equal(controller.find('.all-db-footer__total-db-count').text(), '30');
+    expect(controller.find('.all-db-footer__range').text()).toBe('1–20');
+    expect(controller.find('.all-db-footer__total-db-count').text()).toBe('30');
   });
 
 });
@@ -125,7 +122,7 @@ describe('DatabaseTable', () => {
     var cols = table.find('th');
 
     // (default # of rows is 4)
-    assert.equal(cols.length, 7, 'extra columns show up');
+    expect(cols.length).toBe(7);
 
     FauxtonAPI.unRegisterExtension('DatabaseTable:head');
   });
@@ -152,7 +149,7 @@ describe('DatabaseTable', () => {
     var links = databaseRow.find('td');
 
     // (default # of rows is 4)
-    assert.equal(links.length, 5, 'extra column shows up');
+    expect(links.length).toBe(5);
 
     FauxtonAPI.unRegisterExtension('DatabaseTable:databaseRow');
 
@@ -172,7 +169,7 @@ describe('DatabaseTable', () => {
     var databaseRow = mount(
       <Views.DatabaseTable showDeleteDatabaseModal={{showModal: false}} dbList={list} loading={false} showPartitionedColumn={false}/>
     );
-    assert.equal(databaseRow.find('.database-load-fail').length, 1);
+    expect(databaseRow.find('.database-load-fail').length).toBe(1);
   });
 
   it('shows no error if row marked as loaded', () => {
@@ -189,7 +186,7 @@ describe('DatabaseTable', () => {
       <Views.DatabaseTable showDeleteDatabaseModal={{showModal: false}} dbList={list} loading={false} showPartitionedColumn={false}/>
     );
 
-    assert.equal(databaseRow.find('.database-load-fail').length, 0);
+    expect(databaseRow.find('.database-load-fail').length).toBe(0);
   });
 
   it('shows Partitioned column only when prop is set to true', () => {
@@ -206,13 +203,13 @@ describe('DatabaseTable', () => {
       <Views.DatabaseTable showDeleteDatabaseModal={{showModal: false}} dbList={list} loading={false} showPartitionedColumn={true}/>
     );
     const colHeaders = withPartColumn.find('th');
-    assert.equal(colHeaders.length, 5);
-    assert.equal(colHeaders.get(3).props.children, 'Partitioned');
+    expect(colHeaders.length).toBe(5);
+    expect(colHeaders.get(3).props.children).toBe('Partitioned');
 
     const withoutPartColumn = mount(
       <Views.DatabaseTable showDeleteDatabaseModal={{showModal: false}} dbList={list} loading={false} showPartitionedColumn={false}/>
     );
-    assert.equal(withoutPartColumn.find('th').length, 4);
+    expect(withoutPartColumn.find('th').length).toBe(4);
   });
 
   it('shows correct values in the Partitioned column', () => {
@@ -233,8 +230,8 @@ describe('DatabaseTable', () => {
     );
     const colCells = dbTable.find('td');
     // 2 rows with 5 cells each
-    assert.equal(colCells.length, 10);
-    assert.equal(colCells.get(3).props.children, 'Yes');
-    assert.equal(colCells.get(8).props.children, 'No');
+    expect(colCells.length).toBe(10);
+    expect(colCells.get(3).props.children).toBe('Yes');
+    expect(colCells.get(8).props.children).toBe('No');
   });
 });

--- a/app/addons/databases/__tests__/stores.test.js
+++ b/app/addons/databases/__tests__/stores.test.js
@@ -10,13 +10,10 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import utils from "../../../../test/mocha/testUtils";
 import Stores from "../stores";
 import "../../documents/base";
 
 import DatabaseActions from "../actions";
-
-const assert = utils.assert;
 
 const store = Stores.databasesStore;
 describe('Databases Store', function () {
@@ -36,7 +33,7 @@ describe('Databases Store', function () {
 
       const list = store.getDbList();
 
-      assert.ok(list[0].failed);
+      expect(list[0].failed).toBeTruthy();
     });
 
     it('unions details', () => {
@@ -48,8 +45,8 @@ describe('Databases Store', function () {
 
       const list = store.getDbList();
 
-      assert.equal(list[0].docCount, 5);
-      assert.equal(list[0].docDelCount, 3);
+      expect(list[0].docCount).toBe(5);
+      expect(list[0].docDelCount).toBe(3);
     });
 
     it('determines database availability', () => {
@@ -59,8 +56,8 @@ describe('Databases Store', function () {
         failedDbs: []
       });
 
-      assert(store.doesDatabaseExist('db1'));
-      assert(!store.doesDatabaseExist('db3'));
+      expect(store.doesDatabaseExist('db1')).toBeTruthy();
+      expect(!store.doesDatabaseExist('db3')).toBeTruthy();
     });
 
     it('uses the data_size prop', () => {
@@ -78,7 +75,7 @@ describe('Databases Store', function () {
 
       const dbList = store.getDbList();
 
-      assert.equal(dbList[0].dataSize, '1.3 KB');
+      expect(dbList[0].dataSize).toBe('1.3 KB');
     });
 
   });

--- a/app/addons/documents/__tests__/changes-reducers.test.js
+++ b/app/addons/documents/__tests__/changes-reducers.test.js
@@ -12,13 +12,10 @@
 // the License.
 
 import FauxtonAPI from '../../../core/api';
-import utils from '../../../../test/mocha/testUtils';
 import ActionTypes from '../changes/actiontypes';
 import reducer from '../changes/reducers';
 
 FauxtonAPI.router = new FauxtonAPI.Router([]);
-
-const assert = utils.assert;
 
 describe('Changes Reducer', () => {
 

--- a/app/addons/documents/__tests__/changes-reducers.test.js
+++ b/app/addons/documents/__tests__/changes-reducers.test.js
@@ -38,8 +38,8 @@ describe('Changes Reducer', () => {
     };
     const newState = reducer(undefined, action);
 
-    assert.ok(newState.filters.length === 1);
-    assert.ok(newState.filters[0] === filter);
+    expect(newState.filters.length).toBe(1);
+    expect(newState.filters[0]).toBe(filter);
   });
 
   it('removes filter from state', () => {
@@ -58,8 +58,8 @@ describe('Changes Reducer', () => {
       filter: filter1
     });
 
-    assert.ok(newState.filters.length === 1);
-    assert.ok(newState.filters[0] === filter2);
+    expect(newState.filters.length).toBe(1);
+    expect(newState.filters[0]).toBe(filter2);
   });
 
   it('number of items is capped by maxChangesListed', () => {
@@ -79,13 +79,13 @@ describe('Changes Reducer', () => {
       seqNum,
       changes
     });
-    assert.equal(state.changes.length, changes.length);
-    assert.equal(state.filteredChanges.length, maxChanges);
+    expect(state.changes.length).toBe(changes.length);
+    expect(state.filteredChanges.length).toBe(maxChanges);
   });
 
   it('tracks last sequence number', () => {
     let state = reducer(undefined, {type: 'DO_NOTHING'});
-    assert.equal(state.lastSequenceNum, null);
+    expect(state.lastSequenceNum).toBeNull();
 
     const seqNum = 123;
     state = reducer(state, {
@@ -95,7 +95,7 @@ describe('Changes Reducer', () => {
     });
 
     // confirm it's been stored
-    assert.equal(state.lastSequenceNum, seqNum);
+    expect(state.lastSequenceNum).toBe(seqNum);
   });
 
   it('"true" filter should apply to change deleted status', () => {
@@ -112,9 +112,9 @@ describe('Changes Reducer', () => {
     });
 
     // confirm only the two deleted items are part of filtered results
-    assert.equal(state.filteredChanges.length, 2);
+    expect(state.filteredChanges.length).toBe(2);
     state.filteredChanges.forEach(el => {
-      assert.equal(el.deleted, true);
+      expect(el.deleted).toBe(true);
     });
   });
 
@@ -138,8 +138,8 @@ describe('Changes Reducer', () => {
     });
 
     // confirm only doc_5 matches both filters
-    assert.equal(state.filteredChanges.length, 1);
-    assert.equal(state.filteredChanges[0].id, 'doc_5');
+    expect(state.filteredChanges.length).toBe(1);
+    expect(state.filteredChanges[0].id).toBe('doc_5');
   });
 
 });

--- a/app/addons/documents/__tests__/changes.test.js
+++ b/app/addons/documents/__tests__/changes.test.js
@@ -17,11 +17,8 @@ import ChangeRow from '../changes/components/ChangeRow';
 import ChangesScreen from '../changes/components/ChangesScreen';
 import ChangesTabContent from "../changes/components/ChangesTabContent";
 import {mount} from 'enzyme';
-import utils from "../../../../test/mocha/testUtils";
 import sinon from "sinon";
 import '../base';
-
-const assert = utils.assert;
 
 
 describe('ChangesTabContent', () => {

--- a/app/addons/documents/__tests__/changes.test.js
+++ b/app/addons/documents/__tests__/changes.test.js
@@ -37,7 +37,7 @@ describe('ChangesTabContent', () => {
       filters={['I wandered lonely as a filter', 'A second filter']}
     />);
 
-    assert.equal(2, el.find('.remove-filter').length);
+    expect(el.find('.remove-filter').length).toBe(2);
   });
 
   it('should call addFilter action on click', () => {
@@ -52,7 +52,7 @@ describe('ChangesTabContent', () => {
     addItemField.simulate('change', {target: {value: 'I wandered lonely as a filter'}});
     submitBtn.simulate('submit');
 
-    assert.ok(addFilterStub.calledOnce);
+    expect(addFilterStub.calledOnce).toBeTruthy();
   });
 
   it('should call removeFilter action on click', () => {
@@ -64,7 +64,7 @@ describe('ChangesTabContent', () => {
     />);
     el.find('.remove-filter').simulate('click');
 
-    assert.ok(removeFilterStub.calledOnce);
+    expect(removeFilterStub.calledOnce).toBeTruthy();
   });
 
   it('should not add empty filters', () => {
@@ -79,14 +79,14 @@ describe('ChangesTabContent', () => {
     addItemField.simulate('change', {target: {value: ''}});
     submitBtn.simulate('submit');
 
-    assert.ok(addFilterStub.notCalled);
+    expect(addFilterStub.notCalled).toBeTruthy();
   });
 
   it('should not add badges by default', () => {
     const el = mount(<ChangesTabContent
       {...defaultProps}
     />);
-    assert.equal(0, el.find('.remove-filter').length);
+    expect(el.find('.remove-filter').length).toBe(0);
   });
 
   it('should not add the same filter twice', () => {
@@ -107,7 +107,7 @@ describe('ChangesTabContent', () => {
     addItemField.simulate('change', {target: {value: filter}});
     submitBtn.simulate('submit');
 
-    assert.equal(callCount, 1);
+    expect(callCount).toBe(1);
   });
 });
 
@@ -135,14 +135,14 @@ describe('ChangesScreen', () => {
       changes={changesList}
     />);
 
-    assert.equal(changesList.length, changesEl.find('.change-box').length);
+    expect(changesEl.find('.change-box').length).toBe(changesList.length);
   });
 
   it('shows a No Docs Found message if no docs', () => {
     const changesEl = mount(<ChangesScreen
       {...defaultProps}
     />);
-    assert.ok(/There\sare\sno\sdocument\schanges/.test(changesEl.html()));
+    expect(changesEl.html()).toMatch(/There\sare\sno\sdocument\schanges/);
   });
 
   it('should show a message if the results are truncated', () => {
@@ -151,7 +151,7 @@ describe('ChangesScreen', () => {
       changes={changesList}
       isShowingSubset={true}
     />);
-    assert.equal(1, changesEl.find('.changes-result-limit').length);
+    expect(changesEl.find('.changes-result-limit').length).toBe(1);
   });
 });
 
@@ -168,22 +168,22 @@ describe('ChangeRow', () => {
     const changeRow = mount(<ChangeRow change={change} databaseName="testDatabase" />);
 
     // confirm it's hidden by default
-    assert.equal(0, changeRow.find('.prettyprint').length);
+    expect(changeRow.find('.prettyprint').length).toBe(0);
 
     // confirm clicking it shows the element
     changeRow.find('button.btn').simulate('click');
-    assert.equal(1, changeRow.find('.prettyprint').length);
+    expect(changeRow.find('.prettyprint').length).toBe(1);
   });
 
   it('deleted docs should not be clickable', () => {
     change.deleted = true;
     const changeRow = mount(<ChangeRow change={change} databaseName="testDatabase" />);
-    assert.equal(0, changeRow.find('a.js-doc-link').length);
+    expect(changeRow.find('a.js-doc-link').length).toBe(0);
   });
 
   it('non-deleted docs should be clickable', () => {
     change.deleted = false;
     const changeRow = mount(<ChangeRow change={change} databaseName="testDatabase" />);
-    assert.equal(1, changeRow.find('a.js-doc-link').length);
+    expect(changeRow.find('a.js-doc-link').length).toBe(1);
   });
 });

--- a/app/addons/documents/__tests__/designdocinfo-action.test.js
+++ b/app/addons/documents/__tests__/designdocinfo-action.test.js
@@ -15,7 +15,7 @@ import FauxtonAPI from '../../../core/api';
 import testUtils from '../../../../test/mocha/testUtils';
 import Actions from '../designdocinfo/actions';
 
-const {assert, restore} = testUtils;
+const {restore} = testUtils;
 
 describe('DesignDocInfo Actions', () => {
 

--- a/app/addons/documents/__tests__/designdocinfo-action.test.js
+++ b/app/addons/documents/__tests__/designdocinfo-action.test.js
@@ -41,7 +41,7 @@ describe('DesignDocInfo Actions', () => {
         ddocName: 'test-designdoc-info',
         designDocInfo: fakeDesignDocInfo
       })(dispatch).then(() => {
-        assert.ok(spy.calledOnce);
+        expect(spy.calledOnce).toBeTruthy();
       });
     });
   });

--- a/app/addons/documents/__tests__/helpers.test.js
+++ b/app/addons/documents/__tests__/helpers.test.js
@@ -10,8 +10,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import Helpers from "../helpers";
-import testUtils from "../../../../test/mocha/testUtils";
-var assert = testUtils.assert;
 
 describe('Helpers', () => {
 

--- a/app/addons/documents/__tests__/helpers.test.js
+++ b/app/addons/documents/__tests__/helpers.test.js
@@ -19,7 +19,7 @@ describe('Helpers', () => {
     it('replaces "\\n" with actual newlines', () => {
       var string = 'I am a string\\nwith\\nfour\\nlinebreaks\\nin';
       var result = Helpers.parseJSON(string);
-      assert.equal(result.match(/\n/g).length, 4);
+      expect(result.match(/\n/g).length).toBe(4);
     });
   });
 
@@ -28,18 +28,18 @@ describe('Helpers', () => {
 
     it('does no truncation if maxRows set higher than doc', () => {
       var result = Helpers.truncateDoc(sevenLineDoc, 10);
-      assert.equal(result.isTruncated, false);
-      assert.equal(result.content, result.content);
+      expect(result.isTruncated).toBe(false);
+      expect(result.content).toBe(result.content);
     });
 
     it('truncates by specified line count', () => {
       var result = Helpers.truncateDoc(sevenLineDoc, 5);
-      assert.equal(result.isTruncated, true);
-      assert.equal(result.content, '{\n"line2": 2,\n"line3": 3,\n"line4": 4,\n"line5": 5,');
+      expect(result.isTruncated).toBe(true);
+      expect(result.content).toBe('{\n"line2": 2,\n"line3": 3,\n"line4": 4,\n"line5": 5,');
 
       var result2 = Helpers.truncateDoc(sevenLineDoc, 2);
-      assert.equal(result2.isTruncated, true);
-      assert.equal(result2.content, '{\n"line2": 2,');
+      expect(result2.isTruncated).toBe(true);
+      expect(result2.content).toBe('{\n"line2": 2,');
     });
 
   });

--- a/app/addons/documents/__tests__/resources.test.js
+++ b/app/addons/documents/__tests__/resources.test.js
@@ -30,7 +30,7 @@ describe('Document', () => {
       _rev: '4-3a1b9f4b988b413e9245cd250769da72',
       id: 'foo'
     });
-    assert.equal(res.id, 'foo');
+    expect(res.id).toBe('foo');
   });
 
   it('removes the id, if we create a document and get back an "id" instead of "_id"', () => {
@@ -43,7 +43,7 @@ describe('Document', () => {
       _rev: '4-3a1b9f4b988b413e9245cd250769da72',
       ok: true
     });
-    assert.notOk(res.id);
+    expect(res.id).toBeFalsy();
   });
 
   it('can return the doc url, if id given', () => {
@@ -51,7 +51,7 @@ describe('Document', () => {
       database: {id: 'blerg', safeID: function () { return this.id; }}
     });
 
-    assert.ok(/\/blerg/.test(doc.url('apiurl')));
+    expect(doc.url('apiurl')).toMatch(/\/blerg/);
   });
 
   it('will return the API url to create a new doc, if no doc exists yet', () => {
@@ -59,7 +59,7 @@ describe('Document', () => {
       database: {id: 'blerg', safeID: function () { return this.id; }}
     });
 
-    assert.ok(/\/blerg/.test(doc.url('apiurl')));
+    expect(doc.url('apiurl')).toMatch(/\/blerg/);
   });
 });
 
@@ -79,7 +79,7 @@ describe('AllDocs', () => {
       params: {limit: 20}
     });
 
-    assert.ok(collection.isEditable());
+    expect(collection.isEditable()).toBeTruthy();
   });
 });
 
@@ -108,7 +108,7 @@ describe('QueryParams', () => {
       const params = {'foo': '[1]]'};
       const result = Models.QueryParams.parse(params);
 
-      assert.deepEqual(result, params);
+      expect(result).toEqual(params);
     });
 
     it('parses startkey, endkey', () => {
@@ -118,7 +118,7 @@ describe('QueryParams', () => {
       };
       const result = Models.QueryParams.parse(params);
 
-      assert.deepEqual(result, {
+      expect(result).toEqual({
         'startkey': ['a', 'b'],
         'endkey': ['c', 'd']
       });
@@ -130,7 +130,7 @@ describe('QueryParams', () => {
       };
       const result = Models.QueryParams.parse(params);
 
-      assert.deepEqual(result, {'key': [1, 2]});
+      expect(result).toEqual({'key': [1, 2]});
     });
 
     it('does not modify input', () => {
@@ -139,7 +139,7 @@ describe('QueryParams', () => {
       };
       const clone = _.clone(params);
       Models.QueryParams.parse(params);
-      assert.deepEqual(params, clone);
+      expect(params).toEqual(clone);
     });
   });
 
@@ -148,7 +148,7 @@ describe('QueryParams', () => {
       const params = {'foo': [1, 2, 3]};
       const result = Models.QueryParams.stringify(params);
 
-      assert.deepEqual(result, params);
+      expect(result).toEqual(params);
     });
 
     it('stringifies startkey, endkey', () => {
@@ -159,7 +159,7 @@ describe('QueryParams', () => {
 
       const result = Models.QueryParams.stringify(params);
 
-      assert.deepEqual(result, {
+      expect(result).toEqual({
         'startkey':'["a","b"]',
         'endkey':'["c","d"]'
       });
@@ -169,7 +169,7 @@ describe('QueryParams', () => {
       const params = {'key':['a', 'b']};
       const result = Models.QueryParams.stringify(params);
 
-      assert.deepEqual(result, { 'key': '["a","b"]' });
+      expect(result).toEqual({ 'key': '["a","b"]' });
     });
 
     it('does not modify input', () => {
@@ -177,7 +177,7 @@ describe('QueryParams', () => {
       const clone = _.clone(params);
       Models.QueryParams.stringify(params);
 
-      assert.deepEqual(params, clone);
+      expect(params).toEqual(clone);
     });
 
     it('is symmetrical with parse', () => {
@@ -192,7 +192,7 @@ describe('QueryParams', () => {
       const json = Models.QueryParams.stringify(params);
       const result = Models.QueryParams.parse(json);
 
-      assert.deepEqual(result, clone);
+      expect(result).toEqual(clone);
     });
   });
 });
@@ -237,7 +237,7 @@ describe('Bulk Delete', () => {
       databaseId: databaseId
     });
 
-    assert.equal(collection.length, 3);
+    expect(collection.length).toBe(3);
   });
 
   it('clears the memory if no errors happened', () => {
@@ -247,13 +247,13 @@ describe('Bulk Delete', () => {
     ], resolve, reject);
 
     return promise.then(() => {
-      assert.equal(collection.length, 1);
+      expect(collection.length).toBe(1);
     });
   });
 
   it('triggers a removed event with all ids', (done) => {
     collection.listenToOnce(collection, 'removed', function (ids) {
-      assert.deepEqual(ids, ['Deferred', 'DeskSet']);
+      expect(ids).toEqual(['Deferred', 'DeskSet']);
       done();
     });
 
@@ -266,7 +266,7 @@ describe('Bulk Delete', () => {
   it('triggers a error event with all errored ids', (done) => {
     collection.listenToOnce(collection, 'error', function (ids) {
       done();
-      assert.deepEqual(ids, ['Deferred']);
+      expect(ids).toEqual(['Deferred']);
     });
 
     collection.handleResponse([
@@ -283,9 +283,9 @@ describe('Bulk Delete', () => {
     ], resolve, reject);
 
     return promise.then(() => {
-      assert.ok(collection.get('1'));
-      assert.ok(collection.get('3'));
-      assert.notOk(collection.get('2'));
+      expect(collection.get('1')).toBeTruthy();
+      expect(collection.get('3')).toBeTruthy();
+      expect(collection.get('2')).toBeFalsy();
     });
   });
 
@@ -299,7 +299,7 @@ describe('Bulk Delete', () => {
     ], resolve, reject);
 
     return promise.then(() => {
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
     });
   });
 
@@ -318,7 +318,7 @@ describe('Bulk Delete', () => {
     ], resolve, reject);
 
     return promise.then(() => {
-      assert.ok(spy.calledWith(ids));
+      expect(spy.calledWith(ids)).toBeTruthy();
     });
   });
 
@@ -328,7 +328,7 @@ describe('Bulk Delete', () => {
     ], resolve, reject);
 
     return promise.catch((errors) => {
-      assert.deepEqual(errors, ['1']);
+      expect(errors).toEqual(['1']);
     });
   });
 

--- a/app/addons/documents/__tests__/resources.test.js
+++ b/app/addons/documents/__tests__/resources.test.js
@@ -13,10 +13,8 @@
 import FauxtonAPI from "../../../core/api";
 import Helpers from '../../../helpers';
 import Models from "../resources";
-import testUtils from "../../../../test/mocha/testUtils";
 import "../base";
 import sinon from 'sinon';
-const { assert } = testUtils;
 
 describe('Document', () => {
   let doc;

--- a/app/addons/documents/__tests__/table-row.test.js
+++ b/app/addons/documents/__tests__/table-row.test.js
@@ -16,10 +16,8 @@ import { shallow } from 'enzyme';
 import FauxtonAPI from '../../../core/api';
 import Constants from '../constants';
 import TableRow from '../index-results/components/results/TableRow';
-import utils from '../../../../test/mocha/testUtils';
 
 FauxtonAPI.router = new FauxtonAPI.Router([]);
-const { assert } = utils;
 
 describe('Docs Table Row', () => {
 

--- a/app/addons/documents/__tests__/table-row.test.js
+++ b/app/addons/documents/__tests__/table-row.test.js
@@ -50,11 +50,11 @@ describe('Docs Table Row', () => {
       isSelected={false}
     />);
 
-    assert.equal(wrapper.find('td').at(2).text(), JSON.stringify(elem.content.vBool));
-    assert.equal(wrapper.find('td').at(3).text(), elem.content.vString);
-    assert.equal(wrapper.find('td').at(4).text(), JSON.stringify(elem.content.vFloat));
-    assert.equal(wrapper.find('td').at(5).text(), JSON.stringify(elem.content.vInt));
-    assert.equal(wrapper.find('td').at(6).text().replace(/[\s]/g, ''), JSON.stringify(elem.content.vObject));
+    expect(wrapper.find('td').at(2).text()).toBe(JSON.stringify(elem.content.vBool));
+    expect(wrapper.find('td').at(3).text()).toBe(elem.content.vString);
+    expect(wrapper.find('td').at(4).text()).toBe(JSON.stringify(elem.content.vFloat));
+    expect(wrapper.find('td').at(5).text()).toBe(JSON.stringify(elem.content.vInt));
+    expect(wrapper.find('td').at(6).text().replace(/[\s]/g, '')).toBe(JSON.stringify(elem.content.vObject));
   });
 
   it('shows full text values', () => {

--- a/app/addons/documents/doc-editor/__tests__/doc-editor.components.test.js
+++ b/app/addons/documents/doc-editor/__tests__/doc-editor.components.test.js
@@ -21,7 +21,6 @@ import DocEditorScreen from '../components/DocEditorScreen';
 import DocEditorContainer from '../components/DocEditorContainer';
 import Databases from '../../../databases/base';
 import databasesReducer from '../../../databases/reducers';
-import utils from '../../../../../test/mocha/testUtils';
 import { mount } from 'enzyme';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
@@ -31,7 +30,6 @@ import docEditorReducer from '../reducers';
 import '../../base';
 
 FauxtonAPI.router = new FauxtonAPI.Router([]);
-const assert = utils.assert;
 const docJSON = {
   _id: '_design/test-doc',
   views: {
@@ -97,7 +95,7 @@ describe('DocEditorScreen', () => {
 
   it('loading indicator appears on load', () => {
     const el = mount(<DocEditorScreen {...defaultProps} />);
-    assert.equal(el.find('.loading-lines').length, 1);
+    expect(el.find('.loading-lines').length).toBe(1);
   });
 
   it('new docs do not show the button row', () => {
@@ -109,10 +107,10 @@ describe('DocEditorScreen', () => {
       database={database}
       doc={doc} />);
 
-    assert.equal(el.find('.loading-lines').length, 0);
-    assert.equal(el.find('.icon-circle-arrow-up').length, 0);
-    assert.equal(el.find('.icon-repeat').length, 0);
-    assert.equal(el.find('.icon-trash').length, 0);
+    expect(el.find('.loading-lines').length).toBe(0);
+    expect(el.find('.icon-circle-arrow-up').length).toBe(0);
+    expect(el.find('.icon-repeat').length).toBe(0);
+    expect(el.find('.icon-trash').length).toBe(0);
   });
 
   it('view attachments button does not appear with no attachments', () => {
@@ -124,7 +122,7 @@ describe('DocEditorScreen', () => {
       database={database}
       doc={doc} />);
 
-    assert.equal(el.find('.view-attachments-section').length, 0);
+    expect(el.find('.view-attachments-section').length).toBe(0);
   });
 
   it('view attachments button shows up when the doc has attachments', () => {
@@ -136,7 +134,7 @@ describe('DocEditorScreen', () => {
       database={database}
       doc={doc} />);
 
-    assert.equal(el.find('.view-attachments-section').length, 1);
+    expect(el.find('.view-attachments-section').length).toBe(1);
   });
 
   it('view attachments dropdown contains right number of docs', () => {
@@ -148,7 +146,7 @@ describe('DocEditorScreen', () => {
       database={database}
       doc={doc} />);
 
-    assert.equal(el.find('.view-attachments-section .dropdown-menu li').length, 2);
+    expect(el.find('.view-attachments-section .dropdown-menu li').length).toBe(2);
   });
 
   it('view attachments dropdown contains correct urls', () => {
@@ -163,7 +161,7 @@ describe('DocEditorScreen', () => {
     const $attachmentNode = el.find('.view-attachments-section .dropdown-menu li');
     const attachmentURLactual = $attachmentNode.find('a').first().prop('href');
 
-    assert.equal(attachmentURLactual, './a%2Fspecial%3Fdb/_design%2Ftest%23doc/one%252F.png');
+    expect(attachmentURLactual).toBe('./a%2Fspecial%3Fdb/_design%2Ftest%23doc/one%252F.png');
   });
 
   it('auto-generated ID for new docs starts with colon for partitioned databases', () => {
@@ -226,9 +224,9 @@ describe('DocEditorContainer', () => {
           database={database} />
       </Provider>
     );
-    assert.equal(wrapper.find(DocEditorScreen).prop('isDeleteDocModalVisible'), false);
+    expect(wrapper.find(DocEditorScreen).prop('isDeleteDocModalVisible')).toBe(false);
     wrapper.find('button[title="Delete"]').simulate('click');
-    assert.equal(wrapper.find(DocEditorScreen).prop('isDeleteDocModalVisible'), true);
+    expect(wrapper.find(DocEditorScreen).prop('isDeleteDocModalVisible')).toBe(true);
   });
 
   it('clicking Upload button shows the upload dialog', () => {
@@ -239,9 +237,9 @@ describe('DocEditorContainer', () => {
           database={database} />
       </Provider>
     );
-    assert.equal(wrapper.find(DocEditorScreen).prop('isUploadModalVisible'), false);
+    expect(wrapper.find(DocEditorScreen).prop('isUploadModalVisible')).toBe(false);
     wrapper.find('button[title="Upload Attachment"]').simulate('click');
-    assert.equal(wrapper.find(DocEditorScreen).prop('isUploadModalVisible'), true);
+    expect(wrapper.find(DocEditorScreen).prop('isUploadModalVisible')).toBe(true);
   });
 
   it('clicking Clone button shows the clone doc dialog', () => {
@@ -252,9 +250,9 @@ describe('DocEditorContainer', () => {
           database={database} />
       </Provider>
     );
-    assert.equal(wrapper.find(DocEditorScreen).prop('isCloneDocModalVisible'), false);
+    expect(wrapper.find(DocEditorScreen).prop('isCloneDocModalVisible')).toBe(false);
     wrapper.find('button[title="Clone Document"]').simulate('click');
-    assert.equal(wrapper.find(DocEditorScreen).prop('isCloneDocModalVisible'), true);
+    expect(wrapper.find(DocEditorScreen).prop('isCloneDocModalVisible')).toBe(true);
   });
 
 });
@@ -269,12 +267,12 @@ describe("AttachmentsPanelButton", () => {
 
   it('does not show up when loading', () => {
     const el = mount(<AttachmentsPanelButton isLoading={true} doc={doc} />);
-    assert.equal(el.find('.panel-button').length, 0);
+    expect(el.find('.panel-button').length).toBe(0);
   });
 
   it('shows up after loading', () => {
     const el = mount(<AttachmentsPanelButton isLoading={false} doc={doc} />);
-    assert.equal(el.find('button.panel-button').length, 1);
+    expect(el.find('button.panel-button').length).toBe(1);
   });
 });
 
@@ -299,9 +297,9 @@ describe("Custom Extension Buttons", () => {
       isLoading={false}
       isNewDoc={false}
       database={database} />);
-    assert.isTrue(/Oh\sno\sshe\sdi'n't!/.test(el.html()));
+    expect(/Oh\sno\sshe\sdi'n't!/.test(el.html())).toBe(true);
     // confirm the database name was also included
-    assert.equal(el.find("#testDatabaseName").text(), database.id);
+    expect(el.find("#testDatabaseName").text()).toBe(database.id);
   });
 });
 

--- a/app/addons/documents/doc-editor/__tests__/doc-editor.reducers.test.js
+++ b/app/addons/documents/doc-editor/__tests__/doc-editor.reducers.test.js
@@ -26,13 +26,13 @@ describe('DocEditor Reducer', function () {
   it('defines sensible defaults', function () {
     const newState = reducer(undefined, { type: 'do_nothing'});
 
-    assert.equal(newState.isLoading, true);
-    assert.equal(newState.cloneDocModalVisible, false);
-    assert.equal(newState.deleteDocModalVisible, false);
-    assert.equal(newState.uploadModalVisible, false);
-    assert.equal(newState.numFilesUploaded, 0);
-    assert.equal(newState.uploadInProgress, false);
-    assert.equal(newState.uploadPercentage, 0);
+    expect(newState.isLoading).toBe(true);
+    expect(newState.cloneDocModalVisible).toBe(false);
+    expect(newState.deleteDocModalVisible).toBe(false);
+    expect(newState.uploadModalVisible).toBe(false);
+    expect(newState.numFilesUploaded).toBe(0);
+    expect(newState.uploadInProgress).toBe(false);
+    expect(newState.uploadPercentage).toBe(0);
   });
 
   it('marks loading as complete after doc is loaded', function () {
@@ -40,31 +40,31 @@ describe('DocEditor Reducer', function () {
       type: ActionTypes.DOC_LOADED,
       options: { doc: doc }
     });
-    assert.equal(newState.isLoading, false);
+    expect(newState.isLoading).toBe(false);
   });
 
   it('showCloneDocModal / hideCloneDocModal', function () {
     const newStateShow = reducer(undefined, { type: ActionTypes.SHOW_CLONE_DOC_MODAL });
-    assert.equal(newStateShow.cloneDocModalVisible, true);
+    expect(newStateShow.cloneDocModalVisible).toBe(true);
 
     const newStateHide = reducer(undefined, { type: ActionTypes.HIDE_CLONE_DOC_MODAL });
-    assert.equal(newStateHide.cloneDocModalVisible, false);
+    expect(newStateHide.cloneDocModalVisible).toBe(false);
   });
 
   it('showDeleteDocModal / hideDeleteDocModal', function () {
     const newStateShow = reducer(undefined, { type: ActionTypes.SHOW_DELETE_DOC_CONFIRMATION_MODAL });
-    assert.equal(newStateShow.deleteDocModalVisible, true);
+    expect(newStateShow.deleteDocModalVisible).toBe(true);
 
     const newStateHide = reducer(undefined, { type: ActionTypes.HIDE_DELETE_DOC_CONFIRMATION_MODAL });
-    assert.equal(newStateHide.deleteDocModalVisible, false);
+    expect(newStateHide.deleteDocModalVisible).toBe(false);
   });
 
   it('showUploadModal / hideUploadModal', function () {
     const newStateShow = reducer(undefined, { type: ActionTypes.SHOW_UPLOAD_MODAL });
-    assert.equal(newStateShow.uploadModalVisible, true);
+    expect(newStateShow.uploadModalVisible).toBe(true);
 
     const newStateHide = reducer(undefined, { type: ActionTypes.HIDE_UPLOAD_MODAL });
-    assert.equal(newStateHide.uploadModalVisible, false);
+    expect(newStateHide.uploadModalVisible).toBe(false);
   });
 
 });

--- a/app/addons/documents/doc-editor/__tests__/doc-editor.reducers.test.js
+++ b/app/addons/documents/doc-editor/__tests__/doc-editor.reducers.test.js
@@ -11,14 +11,12 @@
 // the License.
 
 import FauxtonAPI from "../../../../core/api";
-import utils from "../../../../../test/mocha/testUtils";
 import Documents from "../../resources";
 import ActionTypes from "../actiontypes";
 import reducer from "../reducers";
 
 FauxtonAPI.router = new FauxtonAPI.Router([]);
 
-const assert = utils.assert;
 const doc = new Documents.Doc({id: 'foo'}, {database: 'bar'});
 
 describe('DocEditor Reducer', function () {

--- a/app/addons/documents/sidebar/__tests__/sidebar.actions.test.js
+++ b/app/addons/documents/sidebar/__tests__/sidebar.actions.test.js
@@ -58,10 +58,10 @@ describe('Sidebar actions', () => {
 
     Actions.dispatchNewOptions(options);
     process.nextTick(() => {
-      assert.ok(notificationSpy.calledOnce);
-      assert.ok(/not exist/.test(notificationSpy.args[0][0].msg));
-      assert.ok(navigateSpy.calledOnce);
-      assert.deepEqual(navigateSpy.args[0][0], '/');
+      expect(notificationSpy.calledOnce).toBeTruthy();
+      expect(/not exist/.test(notificationSpy.args[0][0].msg)).toBeTruthy();
+      expect(navigateSpy.calledOnce).toBeTruthy();
+      expect(navigateSpy.args[0][0]).toEqual('/');
       done();
     });
   });

--- a/app/addons/documents/sidebar/__tests__/sidebar.actions.test.js
+++ b/app/addons/documents/sidebar/__tests__/sidebar.actions.test.js
@@ -15,7 +15,7 @@ import FauxtonAPI from "../../../../core/api";
 import Actions from '../actions';
 import sinon from 'sinon';
 
-const {restore, assert} = utils;
+const {restore} = utils;
 FauxtonAPI.router = new FauxtonAPI.Router([]);
 
 describe('Sidebar actions', () => {

--- a/app/addons/documents/sidebar/__tests__/sidebar.components.test.js
+++ b/app/addons/documents/sidebar/__tests__/sidebar.components.test.js
@@ -20,7 +20,7 @@ import DesignDoc from '../components/DesignDoc';
 import IndexSection from '../components/IndexSection';
 import MainSidebar from '../components/MainSidebar';
 
-const { assert, restore} = utils;
+const { restore} = utils;
 
 describe('DesignDoc', () => {
   const database = { id: 'test-db' };
@@ -54,8 +54,8 @@ describe('DesignDoc', () => {
       designDocName={'doc-$-#-.1'}
     />);
 
-    assert.include(wrapper.find('a.icon .fonticon-plus-circled').at(1).props()['href'], '/doc-%24-%23-.1');
-    assert.include(wrapper.find('a.toggle-view .accordion-header').props()['href'], '/doc-%24-%23-.1');
+    expect(wrapper.find('a.icon .fonticon-plus-circled').at(1).props()['href']).toContain('/doc-%24-%23-.1');
+    expect(wrapper.find('a.toggle-view .accordion-header').props()['href']).toContain('/doc-%24-%23-.1');
   });
 
   it('check toggle() works when design doc name has special characters', () => {
@@ -71,7 +71,7 @@ describe('DesignDoc', () => {
 
     // NOTE: wrapper.find doesn't work special chars so we use class name instead
     wrapper.find('div.accordion-list-item').simulate('click', {preventDefault: sinon.stub()});
-    assert.ok(toggleStub.calledOnce);
+    expect(toggleStub.calledOnce).toBeTruthy();
   });
 
   //here
@@ -84,7 +84,7 @@ describe('DesignDoc', () => {
     />);
 
     const subOptions = el.find('.accordion-body li');
-    assert.equal(subOptions.length, 1);
+    expect(subOptions.length).toBe(1);
   });
 
   it('confirm design doc sidebar extensions appear', function () {
@@ -105,7 +105,7 @@ describe('DesignDoc', () => {
     />);
 
     const subOptions = el.find('.accordion-body li');
-    assert.equal(subOptions.length, 3); // 1 for "Metadata" row, 1 for Type List row ("search indexes") and one for the index itself
+    expect(subOptions.length).toBe(3); // 1 for "Metadata" row, 1 for Type List row ("search indexes") and one for the index itself
   });
 
   it('confirm design doc sidebar extensions do not appear when they have no content', function () {
@@ -125,7 +125,7 @@ describe('DesignDoc', () => {
     />);
 
     const subOptions = el.find('.accordion-body li');
-    assert.equal(subOptions.length, 1);
+    expect(subOptions.length).toBe(1);
   });
 
   it('confirm doc metadata page is highlighted if selected', function () {
@@ -140,7 +140,7 @@ describe('DesignDoc', () => {
       designDocName={'doc-$-#-.1'}
     />);
 
-    assert.equal(el.find('.accordion-body li.active a').text(), 'Metadata');
+    expect(el.find('.accordion-body li.active a').text()).toBe('Metadata');
   });
 
   it('shows different icons for global and partitioned ddocs', () => {
@@ -149,14 +149,14 @@ describe('DesignDoc', () => {
       designDocName={'doc-$-#-.1'}
       isPartitioned={false}
     />);
-    assert.ok(wrapper.find('i.fonticon-document').exists());
+    expect(wrapper.find('i.fonticon-document').exists()).toBeTruthy();
 
     const wrapper2 = mount(<DesignDoc
       {...defaultProps}
       designDocName={'doc-$-#-.1'}
       isPartitioned={true}
     />);
-    assert.ok(wrapper2.find('i.fonticon-documents').exists());
+    expect(wrapper2.find('i.fonticon-documents').exists()).toBeTruthy();
   });
 
   it('confirms links only include the partition key when one is selected', () => {
@@ -165,16 +165,16 @@ describe('DesignDoc', () => {
       selectedPartitionKey={'part-key-$-%1'}
     />);
     // Metadata link
-    assert.include(wrapper.find('a.toggle-view .accordion-header').props()['href'], '/_partition/part-key-%24-%251/');
+    expect(wrapper.find('a.toggle-view .accordion-header').props()['href']).toContain('/_partition/part-key-%24-%251/');
     // New View link
-    assert.include(wrapper.find('li > a.icon .fonticon-plus-circled').props()['href'], '/_partition/part-key-%24-%251/');
+    expect(wrapper.find('li > a.icon .fonticon-plus-circled').props()['href']).toContain('/_partition/part-key-%24-%251/');
 
     const wrapper2 = mount(<DesignDoc
       {...defaultProps}
     />);
 
-    assert.notInclude(wrapper2.find('a.toggle-view .accordion-header').props()['href'], '/_partition/');
-    assert.notInclude(wrapper2.find('li > a.icon .fonticon-plus-circled').props()['href'], '/_partition/');
+    expect(wrapper2.find('a.toggle-view .accordion-header').props()['href']).not.toContain('/_partition/');
+    expect(wrapper2.find('li > a.icon .fonticon-plus-circled').props()['href']).not.toContain('/_partition/');
   });
 });
 
@@ -190,9 +190,9 @@ describe('MainSidebar', () => {
       selectedPartitionKey={'part-key-$-%1'}
     />);
 
-    assert.include(wrapper.find('a#all-docs').props()['href'], '/_partition/part-key-%24-%251/');
-    assert.include(wrapper.find('a#design-docs').props()['href'], '/_partition/part-key-%24-%251/');
-    assert.include(wrapper.find('a#mango-query').props()['href'], '/_partition/part-key-%24-%251/');
+    expect(wrapper.find('a#all-docs').props()['href']).toContain('/_partition/part-key-%24-%251/');
+    expect(wrapper.find('a#design-docs').props()['href']).toContain('/_partition/part-key-%24-%251/');
+    expect(wrapper.find('a#mango-query').props()['href']).toContain('/_partition/part-key-%24-%251/');
   });
 
   it('confirm New links are properly encoded and include the partition key when provided', () => {
@@ -204,9 +204,9 @@ describe('MainSidebar', () => {
     const newLinks = wrapper.instance().getNewButtonLinks()[0].links;
     newLinks.forEach(link => {
       if (link.title === 'New Doc') {
-        assert.include(link.url, '?partitionKey=part-key-%24-%251');
+        expect(link.url).toContain('?partitionKey=part-key-%24-%251');
       } else {
-        assert.include(link.url, '/_partition/part-key-%24-%251/');
+        expect(link.url).toContain('/_partition/part-key-%24-%251/');
       }
     });
   });
@@ -235,8 +235,9 @@ describe('IndexSection', () => {
     />);
 
     defaultProps.items.forEach((view, idx) => {
-      assert.include(wrapper.find('a.toggle-view').at(idx).prop('href'),
-        '/_design/' + encodeURIComponent('ddoc-%-1') + '/_view/' + encodeURIComponent(view));
+      expect(wrapper.find('a.toggle-view').at(idx).prop('href')).toContain(
+        '/_design/' + encodeURIComponent('ddoc-%-1') + '/_view/' + encodeURIComponent(view)
+      );
     });
   });
 
@@ -247,8 +248,7 @@ describe('IndexSection', () => {
     />);
 
     defaultProps.items.forEach((view, idx) => {
-      assert.include(wrapper.find('a.toggle-view').at(idx).prop('href'),
-        '/_partition/' + encodeURIComponent('part%1') + '/');
+      expect(wrapper.find('a.toggle-view').at(idx).prop('href')).toContain('/_partition/' + encodeURIComponent('part%1') + '/');
     });
   });
 });

--- a/app/addons/documents/sidebar/__tests__/sidebar.reducers.test.js
+++ b/app/addons/documents/sidebar/__tests__/sidebar.reducers.test.js
@@ -37,7 +37,7 @@ describe('Sidebar Reducer', () => {
         designDoc: designDoc
       };
       const newState = sidebar(undefined, action);
-      assert.ok(isVisible(newState, designDoc));
+      expect(isVisible(newState, designDoc)).toBeTruthy();
     });
 
     it('should not be visible after being toggled twice', () => {
@@ -48,7 +48,7 @@ describe('Sidebar Reducer', () => {
       };
       let newState = sidebar(undefined, action);
       newState = sidebar(newState, action);
-      assert.notOk(isVisible(newState, designDoc));
+      expect(isVisible(newState, designDoc)).toBe(false);
     });
 
   });
@@ -64,13 +64,13 @@ describe('Sidebar Reducer', () => {
 
     it('should toggle the state', () => {
       let newState = sidebar(undefined, action);
-      assert.ok(isVisible(newState, designDoc));
+      expect(isVisible(newState, designDoc)).toBeTruthy();
 
       newState = sidebar(newState, action);
-      assert.ok(isVisible(newState, designDoc, indexGroup));
+      expect(isVisible(newState, designDoc, indexGroup)).toBeTruthy();
 
       newState = sidebar(newState, action);
-      assert.notOk(isVisible(newState, designDoc, indexGroup));
+      expect(isVisible(newState, designDoc, indexGroup)).toBe(false);
     });
 
   });

--- a/app/addons/documents/sidebar/__tests__/sidebar.reducers.test.js
+++ b/app/addons/documents/sidebar/__tests__/sidebar.reducers.test.js
@@ -12,9 +12,6 @@
 
 import sidebar from "../reducers";
 import ActionTypes from "../actiontypes";
-import testUtils from "../../../../../test/mocha/testUtils";
-
-const assert = testUtils.assert;
 
 function isVisible (state, designDoc, indexGroup) {
   if (!state.toggledSections[designDoc]) {

--- a/app/addons/fauxton/__tests__/components.test.js
+++ b/app/addons/fauxton/__tests__/components.test.js
@@ -10,12 +10,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import Views from "../components";
-import utils from "../../../../test/mocha/testUtils";
 import React from "react";
-import ReactDOM from "react-dom";
 import {mount} from 'enzyme';
 import sinon from "sinon";
-const assert = utils.assert;
 
 describe('Pagination', () => {
 
@@ -25,14 +22,14 @@ describe('Pagination', () => {
     );
 
     const lis = pageEl.find('li');
-    assert.equal(1 + 3 + 1, lis.length);
-    assert.notOk(lis.first().hasClass("disabled"));
-    assert.notOk(lis.at(1).hasClass("class"));
-    assert.notOk(lis.at(2).hasClass("class"));
-    assert.ok(lis.at(3).hasClass("active"));
-    assert.ok(lis.at(4).hasClass("disabled"));
-    assert.equal("2", lis.at(2).text());
-    assert.equal("?prefix=2&suffix=88", lis.at(2).find("a").prop("href"));
+    expect(1 + 3 + 1).toBe(lis.length);
+    expect(lis.first().hasClass("disabled")).toBeFalsy();
+    expect(lis.at(1).hasClass("class")).toBeFalsy();
+    expect(lis.at(2).hasClass("class")).toBeFalsy();
+    expect(lis.at(3).hasClass("active")).toBeTruthy();
+    expect(lis.at(4).hasClass("disabled")).toBeTruthy();
+    expect("2").toBe(lis.at(2).text());
+    expect("?prefix=2&suffix=88").toBe(lis.at(2).find("a").prop("href"));
   });
 
   it("can overwrite collection size", () => {
@@ -41,7 +38,7 @@ describe('Pagination', () => {
     );
 
     const lis = pageEl.find('li');
-    assert.equal(1 + 6 + 1, lis.length);
+    expect(1 + 6 + 1).toBe(lis.length);
   });
 
   it("handles large collections properly - beginning", () => {
@@ -49,11 +46,11 @@ describe('Pagination', () => {
       <Views.Pagination page={3} total={600} />,
     );
     const lis = pageEl.find('li');
-    assert.equal(1 + 10 + 1, lis.length);
-    assert.ok(lis.at(3).hasClass("active"));
-    assert.equal("3", lis.at(3).text());
-    assert.equal("7", lis.at(7).text());
-    assert.equal("10", lis.at(10).text());
+    expect(1 + 10 + 1).toBe(lis.length);
+    expect(lis.at(3).hasClass("active")).toBeTruthy();
+    expect("3").toBe(lis.at(3).text());
+    expect("7").toBe(lis.at(7).text());
+    expect("10").toBe(lis.at(10).text());
   });
 
   it("handles large collections properly - middle", () => {
@@ -62,11 +59,11 @@ describe('Pagination', () => {
     );
 
     const lis = pageEl.find('li');
-    assert.equal(1 + 10 + 1, lis.length);
-    assert.ok(lis.at(6).hasClass("active"));
-    assert.equal("7", lis.at(3).text());
-    assert.equal("11", lis.at(7).text());
-    assert.equal("14", lis.at(10).text());
+    expect(1 + 10 + 1).toBe(lis.length);
+    expect(lis.at(6).hasClass("active")).toBeTruthy();
+    expect("7").toBe(lis.at(3).text());
+    expect("11").toBe(lis.at(7).text());
+    expect("14").toBe(lis.at(10).text());
   });
 
   it("handles large collections properly - end", () => {
@@ -75,11 +72,11 @@ describe('Pagination', () => {
     );
 
     const lis = pageEl.find('li');
-    assert.equal(1 + 10 + 1, lis.length);
-    assert.ok(lis.at(9).hasClass("active"));
-    assert.equal("23", lis.at(3).text());
-    assert.equal("27", lis.at(7).text());
-    assert.equal("30", lis.at(10).text());
+    expect(1 + 10 + 1).toBe(lis.length);
+    expect(lis.at(9).hasClass("active")).toBeTruthy();
+    expect("23").toBe(lis.at(3).text());
+    expect("27").toBe(lis.at(7).text());
+    expect("30").toBe(lis.at(10).text());
   });
 
   it('limits the number of total pages when customized', () => {
@@ -88,7 +85,7 @@ describe('Pagination', () => {
       <Views.Pagination page={1} total={1000} maxNavPages={maxNavPages} />
     );
     const lis = pageEl.find('li');
-    assert.equal(1 + maxNavPages + 1, lis.length);
+    expect(1 + maxNavPages + 1).toBe(lis.length);
   });
 
   it('calls callback method when supplied', () => {
@@ -101,10 +98,10 @@ describe('Pagination', () => {
     links.at(3).simulate('click');
 
     // confirm it gets called
-    assert.ok(spy.calledOnce);
+    expect(spy.calledOnce).toBeTruthy();
 
     // confirm it's called with the pagination number (3)
-    assert.ok(spy.calledWith(3));
+    expect(spy.calledWith(3)).toBeTruthy();
   });
 
   it('calls callback method with correct values for prev and next', () => {
@@ -117,10 +114,10 @@ describe('Pagination', () => {
     var links = pageEl.find("a");
 
     links.first().simulate('click');
-    assert.ok(spy.calledWith(currentPage - 1));
+    expect(spy.calledWith(currentPage - 1)).toBeTruthy();
 
     links.at(11).simulate('click');
-    assert.ok(spy.calledWith(currentPage + 1));
+    expect(spy.calledWith(currentPage + 1)).toBeTruthy();
   });
 
 });

--- a/app/addons/fauxton/notifications/__tests__/components.test.js
+++ b/app/addons/fauxton/notifications/__tests__/components.test.js
@@ -37,11 +37,11 @@ describe('Notification', () => {
       onHideComplete={() => {}}
     />);
 
-    assert.notOk(spy.called);
+    expect(spy.called).toBeFalsy();
 
     setTimeout(() => {
       component.update();
-      assert.ok(spy.called);
+      expect(spy.called).toBeTruthy();
       done();
     }, 3000);
   });
@@ -56,7 +56,7 @@ describe('Notification', () => {
       onStartHide={() => {}}
       onHideComplete={() => {}}
     />);
-    assert.ok(/&lt;script&gt;window.whatever=1;&lt;\/script&gt;/.test(wrapper.html()));
+    expect(/&lt;script&gt;window.whatever=1;&lt;\/script&gt;/.test(wrapper.html())).toBeTruthy();
   });
 
   it('notification text can be rendered unescaped', () => {
@@ -70,7 +70,7 @@ describe('Notification', () => {
       onStartHide={() => {}}
       onHideComplete={() => {}}
     />);
-    assert.ok(/<script>window.whatever=1;<\/script>/.test(wrapper.html()));
+    expect(/<script>window.whatever=1;<\/script>/.test(wrapper.html())).toBeTruthy();
   });
 });
 
@@ -117,20 +117,20 @@ describe('NotificationPanelRow', () => {
       item={notifications.success}
     />);
 
-    assert.notOk(row1.find('li').prop('aria-hidden'));
+    expect(row1.find('li').prop('aria-hidden')).toBeFalsy();
 
     const row2 = mount(<NotificationPanelRow
       {...defaultProps}
       item={notifications.error}
     />
     );
-    assert.notOk(row2.find('li').prop('aria-hidden'));
+    expect(row2.find('li').prop('aria-hidden')).toBeFalsy();
 
     const row3 = mount(<NotificationPanelRow
       {...defaultProps}
       item={notifications.info} />
     );
-    assert.notOk(row3.find('li').prop('aria-hidden'));
+    expect(row3.find('li').prop('aria-hidden')).toBeFalsy();
   });
 
   it('hides notification when filter doesn\'t match', () => {
@@ -140,7 +140,7 @@ describe('NotificationPanelRow', () => {
         filter="success"
         item={notifications.info}
       />);
-    assert.ok(rowEl.find('li').prop('aria-hidden'));
+    expect(rowEl.find('li').prop('aria-hidden')).toBeTruthy();
   });
 
   it('shows notification when filter exact match', () => {
@@ -150,7 +150,7 @@ describe('NotificationPanelRow', () => {
         filter="info"
         item={notifications.info}
       />);
-    assert.notOk(rowEl.find('li').prop('aria-hidden'));
+    expect(rowEl.find('li').prop('aria-hidden')).toBeFalsy();
   });
 });
 

--- a/app/addons/fauxton/notifications/__tests__/components.test.js
+++ b/app/addons/fauxton/notifications/__tests__/components.test.js
@@ -17,9 +17,6 @@ import sinon from 'sinon';
 import Notification from '../components/Notification';
 import NotificationCenterPanel from '../components/NotificationCenterPanel';
 import NotificationPanelRow from '../components/NotificationPanelRow';
-import utils from '../../../../../test/mocha/testUtils';
-
-const assert = utils.assert;
 
 describe('Notification', () => {
   it('startHide is only called after visible time is out', (done) => {

--- a/app/addons/fauxton/notifications/__tests__/reducers.test.js
+++ b/app/addons/fauxton/notifications/__tests__/reducers.test.js
@@ -12,17 +12,14 @@
 
 import reducer from '../reducers';
 import ActionTypes from '../actiontypes';
-import testUtils from '../../../../../test/mocha/testUtils';
-
-const assert = testUtils.assert;
 
 describe('Notifications Reducer', () => {
 
   it('sets reasonable defaults', () => {
     const newState = reducer(undefined, { type: 'DO_NOTHING'});
-    assert.equal(newState.notifications.length, 0);
-    assert.equal(newState.notificationCenterVisible, false);
-    assert.equal(newState.selectedNotificationFilter, 'all');
+    expect(newState.notifications.length).toBe(0);
+    expect(newState.notificationCenterVisible).toBe(false);
+    expect(newState.selectedNotificationFilter).toBe('all');
   });
 
   it('confirm only known notification types get added', () => {
@@ -34,19 +31,19 @@ describe('Notifications Reducer', () => {
     };
 
     let newState = reducer(undefined, action);
-    assert.equal(newState.notifications.length, 1);
+    expect(newState.notifications.length).toBe(1);
 
     action.options.info.type = 'success';
     newState = reducer(newState, action);
-    assert.equal(newState.notifications.length, 2);
+    expect(newState.notifications.length).toBe(2);
 
     action.options.info.type = 'error';
     newState = reducer(newState, action);
-    assert.equal(newState.notifications.length, 3);
+    expect(newState.notifications.length).toBe(3);
 
     action.options.info.type = 'rhubarb';
     newState = reducer(newState, action);
-    assert.equal(newState.notifications.length, 3);
+    expect(newState.notifications.length).toBe(3);
   });
 
   it('notifications should be escaped by default', () => {
@@ -57,7 +54,7 @@ describe('Notifications Reducer', () => {
       }
     };
     let newState = reducer(undefined, action);
-    assert.equal(newState.notifications[0].escape, true);
+    expect(newState.notifications[0].escape).toBe(true);
   });
 
   it('clears a specific notification', () => {
@@ -75,7 +72,7 @@ describe('Notifications Reducer', () => {
     newState = reducer(newState, action);
     action.options.info.msg = 'four';
     newState = reducer(newState, action);
-    assert.equal(newState.notifications.length, 4);
+    expect(newState.notifications.length).toBe(4);
 
     const idToRemove = newState.notifications[1].notificationId;
     const msgToRemove = newState.notifications[1].msg;
@@ -83,11 +80,11 @@ describe('Notifications Reducer', () => {
       type: ActionTypes.CLEAR_SINGLE_NOTIFICATION,
       options: { notificationId: idToRemove }
     });
-    assert.equal(newState.notifications.length, 3);
+    expect(newState.notifications.length).toBe(3);
     const item = newState.notifications.find(el => {
       return el.msg === msgToRemove;
     });
-    assert.isUndefined(item);
+    expect(item).not.toBeDefined();
   });
 
   it('setNotificationFilter only sets for known notification types', () => {
@@ -100,12 +97,12 @@ describe('Notifications Reducer', () => {
     validFilters.forEach(filter => {
       action.options.filter = filter;
       newState = reducer(newState, action);
-      assert.equal(newState.selectedNotificationFilter, filter);
+      expect(newState.selectedNotificationFilter).toBe(filter);
     });
 
     action.options.filter = 'invalid_filter';
     newState = reducer(newState, action);
-    assert.equal(newState.selectedNotificationFilter, validFilters[validFilters.length - 1]);
+    expect(newState.selectedNotificationFilter).toBe(validFilters[validFilters.length - 1]);
   });
 
   it('clear all notifications', () => {
@@ -123,12 +120,12 @@ describe('Notifications Reducer', () => {
     newState = reducer(newState, action);
     action.options.info.msg = 'four';
     newState = reducer(newState, action);
-    assert.equal(newState.notifications.length, 4);
+    expect(newState.notifications.length).toBe(4);
 
     newState = reducer(newState, {
       type: ActionTypes.CLEAR_ALL_NOTIFICATIONS
     });
-    assert.equal(newState.notifications.length, 0);
+    expect(newState.notifications.length).toBe(0);
   });
 
 });

--- a/app/addons/replication/__tests__/actions.test.js
+++ b/app/addons/replication/__tests__/actions.test.js
@@ -26,7 +26,10 @@ FauxtonAPI.session = {
 describe("Replication Actions", () => {
 
   describe('replicate', () => {
-    afterEach(fetchMock.reset);
+
+    afterEach(() => {
+      fetchMock.reset();
+    });
 
     it('creates a new database if it does not exist', () => {
       const dispatch = () => {};
@@ -50,7 +53,7 @@ describe("Replication Actions", () => {
         body: {
           ok: true
         }
-      });
+      }, { overwriteRoutes: false });
 
       return replicate ({
         localSource: "animaldb",
@@ -65,6 +68,8 @@ describe("Replication Actions", () => {
         username: "tester"
       })(dispatch).then(() => {
         expect(finalPost.calls('./_replicator').length).toBe(3);
+
+        //fetchMock.done();
       });
     });
 
@@ -90,11 +95,17 @@ describe("Replication Actions", () => {
         username: "tester"
       })(dispatch).then(() => {
         expect(mockPost.calls('./_replicator').length).toBe(1);
+        fetchMock.done();
       });
     });
   });
 
   describe('getReplicationStateFrom', () => {
+
+    afterEach(() => {
+      fetchMock.reset();
+    });
+
     const doc = {
       "_id": "7dcea9874a8fcb13c6630a1547001559",
       "_rev": "2-98d29cc74e77b6dc38f5fc0dcec0033c",
@@ -137,7 +148,7 @@ describe("Replication Actions", () => {
       "targetAuth":{"username":"tester", "password":"testerpass"}
     };
 
-    it.only('builds up correct state', (done) => {
+    it('builds up correct state', (done) => {
       const dispatch = ({type, options}) => {
         if (ActionTypes.REPLICATION_SET_STATE_FROM_DOC === type) {
           expect(options).toEqual(docState);
@@ -156,14 +167,14 @@ describe("Replication Actions", () => {
           "continuous": true,
           "source": {
             "headers": {},
-            "url": "http://dev:8000/animaldb",
+            "url": "http://localhost:8000/animaldb",
             "auth": {
               "creds": "source_user_creds"
             }
           },
           "target": {
             "headers": {},
-            "url": "http://dev:8000/boom123",
+            "url": "http://localhost:8000/boom123",
             "auth": {
               "creds": "target_user_creds"
             }
@@ -194,8 +205,8 @@ describe("Replication Actions", () => {
       });
       const dispatch = ({type, options}) => {
         if (ActionTypes.REPLICATION_SET_STATE_FROM_DOC === type) {
-          expect(docStateWithCustomAuth).toEqual(options);
-          setTimeout(done);
+          expect(options).toEqual(docStateWithCustomAuth);
+          done();
         }
       };
 
@@ -205,6 +216,11 @@ describe("Replication Actions", () => {
   });
 
   describe('deleteDocs', () => {
+
+    afterEach(() => {
+      fetchMock.reset();
+    });
+
     it('sends bulk doc request', (done) => {
       const resp = [
         {
@@ -248,7 +264,7 @@ describe("Replication Actions", () => {
 
       const dispatch = ({type}) => {
         if (ActionTypes.REPLICATION_CLEAR_SELECTED_DOCS === type) {
-          setTimeout(done);
+          done();
         }
       };
 

--- a/app/addons/replication/__tests__/actions.test.js
+++ b/app/addons/replication/__tests__/actions.test.js
@@ -9,7 +9,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-import utils from '../../../../test/mocha/testUtils';
+
 import {replicate, getReplicationStateFrom, deleteDocs} from '../actions';
 import ActionTypes from '../actiontypes';
 import fetchMock from 'fetch-mock';
@@ -27,8 +27,6 @@ Object.defineProperty(window.location, 'origin', {
   writable: true,
   value: 'http://dev:8000'
 });
-
-const assert = utils.assert;
 
 describe("Replication Actions", () => {
 
@@ -71,7 +69,7 @@ describe("Replication Actions", () => {
         replicationType: "",
         username: "tester"
       })(dispatch).then(() => {
-        assert.lengthOf(finalPost.calls('./_replicator'), 3);
+        expect(finalPost.calls('./_replicator').length).toBe(3);
       });
     });
 
@@ -96,7 +94,7 @@ describe("Replication Actions", () => {
         replicationType: "",
         username: "tester"
       })(dispatch).then(() => {
-        assert.lengthOf(mockPost.calls('./_replicator'), 1);
+        expect(mockPost.calls('./_replicator').length).toBe(1);
       });
     });
   });
@@ -147,7 +145,7 @@ describe("Replication Actions", () => {
     it('builds up correct state', (done) => {
       const dispatch = ({type, options}) => {
         if (ActionTypes.REPLICATION_SET_STATE_FROM_DOC === type) {
-          assert.deepEqual(docState, options);
+          expect(docState).toEqual(options);
           setTimeout(done);
         }
       };
@@ -201,7 +199,7 @@ describe("Replication Actions", () => {
       });
       const dispatch = ({type, options}) => {
         if (ActionTypes.REPLICATION_SET_STATE_FROM_DOC === type) {
-          assert.deepEqual(docStateWithCustomAuth, options);
+          expect(docStateWithCustomAuth).toEqual(options);
           setTimeout(done);
         }
       };

--- a/app/addons/replication/__tests__/api.tests.js
+++ b/app/addons/replication/__tests__/api.tests.js
@@ -62,7 +62,7 @@ describe('Replication API', () => {
         remoteSource
       });
 
-      assert.deepEqual(source.url, 'http://remote-couchdb.com/my%2Fdb%2Fhere');
+      expect(source.url).toEqual('http://remote-couchdb.com/my%2Fdb%2Fhere');
     });
 
     it('returns local source with auth info and encoded', () => {
@@ -77,8 +77,8 @@ describe('Replication API', () => {
         sourceAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
       }, {origin: 'http://dev:6767'});
 
-      assert.deepEqual(source.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
-      assert.ok(/my%2Fdb/.test(source.url));
+      expect(source.headers).toEqual({Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
+      expect(source.url).toMatch(/my%2Fdb/);
     });
 
     it('returns local source with auth info and encoded when use relative url', () => {
@@ -93,8 +93,8 @@ describe('Replication API', () => {
         sourceAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
       }, {origin: 'http://dev:6767', pathname:'/db/_utils'});
 
-      assert.deepEqual(source.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
-      assert.ok(/\/db\/my%2Fdb/.test(source.url));
+      expect(source.headers).toEqual({Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
+      expect(source.url).toMatch(/\/db\/my%2Fdb/);
     });
 
     it('returns remote source url and auth header', () => {
@@ -109,8 +109,8 @@ describe('Replication API', () => {
         sourceAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
       }, {origin: 'http://dev:6767'});
 
-      assert.deepEqual(source.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
-      assert.deepEqual('http://my-couchdb.com/my-db', source.url);
+      expect(source.headers).toEqual({Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
+      expect(source.url).toBe('http://my-couchdb.com/my-db');
     });
 
     it('returns source with no auth', () => {
@@ -125,7 +125,7 @@ describe('Replication API', () => {
         sourceAuthType: Constants.REPLICATION_AUTH_METHOD.NO_AUTH
       }, {origin: 'http://dev:6767'});
 
-      assert.deepEqual(source.headers, {});
+      expect(source.headers).toEqual({});
 
       const source2 = getSource({
         replicationSource: Constants.REPLICATION_SOURCE.REMOTE,
@@ -133,7 +133,7 @@ describe('Replication API', () => {
         localSource: "local"
       }, {origin: 'http://dev:6767'});
 
-      assert.deepEqual(source2.headers, {});
+      expect(source2.headers).toEqual({});
     });
 
     it('returns source with custom auth', () => {
@@ -154,7 +154,7 @@ describe('Replication API', () => {
         sourceAuthType: 'TEST_CUSTOM_AUTH'
       }, {origin: 'http://dev:6767'});
 
-      assert.deepEqual(source.auth, { auth_creds: 'sample_creds' });
+      expect(source.auth).toEqual({ auth_creds: 'sample_creds' });
     });
   });
 
@@ -163,10 +163,11 @@ describe('Replication API', () => {
     it('returns remote encoded target', () => {
       const remoteTarget = 'http://remote-couchdb.com/my/db';
 
-      assert.deepEqual("http://remote-couchdb.com/my%2Fdb", getTarget({
+      const url = getTarget({
         replicationTarget: Constants.REPLICATION_TARGET.NEW_REMOTE_DATABASE,
         remoteTarget: remoteTarget
-      }).url);
+      }).url;
+      expect(url).toBe("http://remote-couchdb.com/my%2Fdb");
     });
 
     it("encodes username and password for remote", () => {
@@ -181,8 +182,8 @@ describe('Replication API', () => {
         targetAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
       });
 
-      assert.deepEqual(target.url, 'http://remote-couchdb.com/my%2Fdb');
-      assert.deepEqual(target.headers, {Authorization:"Basic amltaTpteS1wYXNzd29yZA=="});
+      expect(target.url).toEqual('http://remote-couchdb.com/my%2Fdb');
+      expect(target.headers).toEqual({Authorization:"Basic amltaTpteS1wYXNzd29yZA=="});
     });
 
     it('returns existing local database', () => {
@@ -196,8 +197,8 @@ describe('Replication API', () => {
         targetAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
       });
 
-      assert.deepEqual(target.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
-      assert.ok(/my-existing%2Fdb/.test(target.url));
+      expect(target.headers).toEqual({Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
+      expect(target.url).toMatch(/my-existing%2Fdb/);
     });
 
     it('returns existing local database even with relative urls', () => {
@@ -211,8 +212,8 @@ describe('Replication API', () => {
         targetAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
       }, {origin:'http://dev:6767', pathname:'/db/_utils'});
 
-      assert.deepEqual(target.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
-      assert.ok(/my-existing%2Fdb/.test(target.url));
+      expect(target.headers).toEqual({Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
+      expect(target.url).toMatch(/my-existing%2Fdb/);
     });
 
     it('returns new local database', () => {
@@ -227,8 +228,8 @@ describe('Replication API', () => {
         targetAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
       });
 
-      assert.deepEqual(target.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
-      assert.ok(/my-new%2Fdb/.test(target.url));
+      expect(target.headers).toEqual({Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
+      expect(target.url).toMatch(/my-new%2Fdb/);
     });
 
     it('returns new local for remote source', () => {
@@ -243,8 +244,8 @@ describe('Replication API', () => {
         targetAuthType: Constants.REPLICATION_AUTH_METHOD.BASIC
       }, {origin: 'http://dev:5555'});
 
-      assert.deepEqual(target.headers, {Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
-      assert.ok(/my-new%2Fdb/.test(target.url));
+      expect(target.headers).toEqual({Authorization:"Basic dGhlLXVzZXI6cGFzc3dvcmQ="});
+      expect(target.url).toMatch(/my-new%2Fdb/);
     });
 
     it("doesn't encode username and password if it is not supplied", () => {
@@ -264,8 +265,8 @@ describe('Replication API', () => {
         localTarget: 'my-new/db'
       }, location);
 
-      assert.deepEqual("http://dev:8000/my-new%2Fdb", target.url);
-      assert.deepEqual({}, target.headers);
+      expect(target.url).toBe("http://dev:8000/my-new%2Fdb");
+      expect(target.headers).toEqual({});
 
       const targetNoAuth = getTarget({
         replicationTarget: Constants.REPLICATION_TARGET.NEW_LOCAL_DATABASE,
@@ -273,7 +274,7 @@ describe('Replication API', () => {
         localTarget: 'my-new/db',
         targetAuthType: Constants.REPLICATION_AUTH_METHOD.NO_AUTH
       }, location);
-      assert.deepEqual({}, targetNoAuth.headers);
+      expect(targetNoAuth.headers).toEqual({});
     });
 
     it('returns target with custom auth', () => {
@@ -294,7 +295,7 @@ describe('Replication API', () => {
         targetAuthType: 'TEST_CUSTOM_AUTH'
       });
 
-      assert.deepEqual(target.auth, { auth_creds: 'sample_creds' });
+      expect(target.auth).toEqual({ auth_creds: 'sample_creds' });
     });
 
   });
@@ -302,26 +303,26 @@ describe('Replication API', () => {
   describe('continuous', () => {
 
     it('returns true for continuous', () => {
-      assert.ok(continuous(Constants.REPLICATION_TYPE.CONTINUOUS));
+      expect(continuous(Constants.REPLICATION_TYPE.CONTINUOUS)).toBeTruthy();
     });
 
     it('returns false for once', () => {
-      assert.notOk(continuous(Constants.REPLICATION_TYPE.ONE_TIME));
+      expect(continuous(Constants.REPLICATION_TYPE.ONE_TIME)).toBeFalsy();
     });
   });
 
   describe('create target', () => {
 
     it('returns true for new local', () => {
-      assert.ok(createTarget(Constants.REPLICATION_TARGET.NEW_LOCAL_DATABASE));
+      expect(createTarget(Constants.REPLICATION_TARGET.NEW_LOCAL_DATABASE)).toBeTruthy();
     });
 
     it('returns true for new remote', () => {
-      assert.ok(createTarget(Constants.REPLICATION_TARGET.NEW_REMOTE_DATABASE));
+      expect(createTarget(Constants.REPLICATION_TARGET.NEW_REMOTE_DATABASE)).toBeTruthy();
     });
 
     it('returns false for existing', () => {
-      assert.notOk(createTarget(Constants.REPLICATION_TARGET.EXISTING_REMOTE_DATABASE));
+      expect(createTarget(Constants.REPLICATION_TARGET.EXISTING_REMOTE_DATABASE)).toBeFalsy();
     });
 
   });
@@ -331,26 +332,23 @@ describe('Replication API', () => {
     it('adds doc id if it exists', () => {
       const docId = 'docId';
 
-      assert.deepEqual(
-        addDocIdAndRev(docId, null,  {}), {
-          _id: docId
-        });
+      expect(addDocIdAndRev(docId, null,  {})).toEqual({
+        _id: docId
+      });
     });
 
     it('adds doc and Rev if it exists', () => {
       const docId = 'docId';
       const _rev = "1-rev123";
 
-      assert.deepEqual(
-        addDocIdAndRev(docId, _rev, {}), {
-          _id: docId,
-          _rev: _rev
-        });
+      expect(addDocIdAndRev(docId, _rev, {})).toEqual({
+        _id: docId,
+        _rev: _rev
+      });
     });
 
     it('does not add doc id if it does not exists', () => {
-      assert.deepEqual(
-        addDocIdAndRev(null, null, {}), {});
+      expect(addDocIdAndRev(null, null, {})).toEqual({});
     });
   });
 
@@ -359,7 +357,7 @@ describe('Replication API', () => {
       const url = "http://userone:theirpassword@couchdb-host.com/my%2Fdb%2fhere";
       const cleanedUrl = "http://couchdb-host.com/my/db/here";
 
-      assert.deepEqual(getDocUrl(url), cleanedUrl);
+      expect(getDocUrl(url)).toEqual(cleanedUrl);
     });
   });
 
@@ -368,7 +366,7 @@ describe('Replication API', () => {
       const url = "http://dev:5984/boom/aaaa";
       const encodedUrl = encodeFullUrl(url);
 
-      assert.deepEqual("http://dev:5984/boom%2Faaaa", encodedUrl);
+      expect(encodedUrl).toBe("http://dev:5984/boom%2Faaaa");
     });
 
   });
@@ -379,7 +377,7 @@ describe('Replication API', () => {
       const url = "http://dev:5984/boom%2Faaaa";
       const encodedUrl = decodeFullUrl(url);
 
-      assert.deepEqual("http://dev:5984/boom/aaaa", encodedUrl);
+      expect(encodedUrl).toBe("http://dev:5984/boom/aaaa");
     });
 
   });
@@ -389,22 +387,22 @@ describe('Replication API', () => {
     it("can get username and password", () => {
       const {username, password } = getCredentialsFromUrl("https://bob:marley@my-couchdb.com/db");
 
-      assert.deepEqual(username, 'bob');
-      assert.deepEqual(password, 'marley');
+      expect(username).toBe('bob');
+      expect(password).toBe('marley');
     });
 
     it("can get username and password with special characters", () => {
       const {username, password } = getCredentialsFromUrl("http://bob:m@:/rley@my-couchdb.com/db");
 
-      assert.deepEqual(username, 'bob');
-      assert.deepEqual(password, 'm@:/rley');
+      expect(username).toBe('bob');
+      expect(password).toBe('m@:/rley');
     });
 
     it("returns nothing for no username and password", () => {
       const {username, password } = getCredentialsFromUrl("http://my-couchdb.com/db");
 
-      assert.deepEqual(username, '');
-      assert.deepEqual(password, '');
+      expect(username).toBe('');
+      expect(password).toBe('');
     });
   });
 
@@ -412,17 +410,17 @@ describe('Replication API', () => {
 
     it("can remove username and password", () => {
       const url = removeCredentialsFromUrl("https://bob:marley@my-couchdb.com/db");
-      assert.deepEqual(url, 'https://my-couchdb.com/db');
+      expect(url).toBe('https://my-couchdb.com/db');
     });
 
     it("returns url if no password", () => {
       const url = removeCredentialsFromUrl("https://my-couchdb.com/db");
-      assert.deepEqual(url, 'https://my-couchdb.com/db');
+      expect(url).toBe('https://my-couchdb.com/db');
     });
 
     it("can remove username and password with special characters", () => {
       const url = removeCredentialsFromUrl("https://bob:m@:/rley@my-couchdb.com/db");
-      assert.deepEqual(url, 'https://my-couchdb.com/db');
+      expect(url).toBe('https://my-couchdb.com/db');
     });
   });
 
@@ -435,7 +433,7 @@ describe('Replication API', () => {
       fetchMock.getOnce('./_scheduler/jobs', {});
       return supportNewApi(true)
         .then(resp => {
-          assert.ok(resp);
+          expect(resp).toBeTruthy();
         });
     });
 
@@ -447,7 +445,7 @@ describe('Replication API', () => {
 
       return supportNewApi(true)
         .then(resp => {
-          assert.notOk(resp);
+          expect(resp).toBeFalsy();
         });
     });
 
@@ -459,7 +457,7 @@ describe('Replication API', () => {
       fetchMock.getOnce('./_scheduler/jobs', {});
       return supportNewApi(true)
         .then(resp => {
-          assert.ok(resp);
+          expect(resp).toBeTruthy();
         });
     });
 
@@ -471,7 +469,7 @@ describe('Replication API', () => {
 
       return supportNewApi(true)
         .then(resp => {
-          assert.notOk(resp);
+          expect(resp).toBeFalsy();
         });
     });
 
@@ -583,8 +581,8 @@ describe('Replication API', () => {
         return supportNewApi(true)
           .then(fetchReplicationDocs)
           .then(docs => {
-            assert.deepEqual(docs.length, 1);
-            assert.deepEqual(docs[0]._id, "c94d4839d1897105cb75e1251e0003ea");
+            expect(docs.length).toBe(1);
+            expect(docs[0]._id).toBe("c94d4839d1897105cb75e1251e0003ea");
           });
       });
     });
@@ -601,9 +599,9 @@ describe('Replication API', () => {
         return supportNewApi(true)
           .then(fetchReplicationDocs)
           .then(docs => {
-            assert.deepEqual(docs.length, 1);
-            assert.deepEqual(docs[0]._id, "c94d4839d1897105cb75e1251e0003ea");
-            assert.deepEqual(docs[0].stateTime.toDateString(), (new Date('2017-03-07T14:46:17')).toDateString());
+            expect(docs.length).toBe(1);
+            expect(docs[0]._id).toBe("c94d4839d1897105cb75e1251e0003ea");
+            expect(docs[0].stateTime.toDateString()).toBe((new Date('2017-03-07T14:46:17')).toDateString());
           });
       });
     });

--- a/app/addons/replication/__tests__/api.tests.js
+++ b/app/addons/replication/__tests__/api.tests.js
@@ -10,7 +10,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 import FauxtonAPI from '../../../core/api';
-import utils from '../../../../test/mocha/testUtils';
 import {
   getSource,
   getTarget,
@@ -28,8 +27,6 @@ import {
 } from '../api';
 import Constants from '../constants';
 import fetchMock from 'fetch-mock';
-
-const assert = utils.assert;
 
 describe('Replication API', () => {
 

--- a/app/addons/replication/__tests__/common-table.test.js
+++ b/app/addons/replication/__tests__/common-table.test.js
@@ -21,17 +21,17 @@ describe('Common Table Component', () => {
     it("renders a url with tricky password characters", () => {
       const url = "http://hello:h#$!^@couchdb.com/my-db";
       const el = shallow(formatUrl(url));
-      assert.equal(el.find('a').prop('href'), '#/database/my-db/_all_docs');
+      expect(el.find('a').prop('href')).toBe('#/database/my-db/_all_docs');
     });
 
     it("renders a url with no password characters", () => {
       const url = "http://couchdb.com/my-db";
       const el = shallow(formatUrl(url));
-      assert.equal(el.find('a').prop('href'), '#/database/my-db/_all_docs');
+      expect(el.find('a').prop('href')).toBe('#/database/my-db/_all_docs');
     });
 
     it('renders a with a default url if no url is supplied', () => {
-      assert.equal(formatUrl(), '');
+      expect(formatUrl()).toBe('');
     });
   });
 });

--- a/app/addons/replication/__tests__/common-table.test.js
+++ b/app/addons/replication/__tests__/common-table.test.js
@@ -9,11 +9,9 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-import utils from "../../../../test/mocha/testUtils";
+
 import { shallow } from 'enzyme';
 import {formatUrl} from '../components/common-table';
-
-const {assert}  = utils;
 
 describe('Common Table Component', () => {
 

--- a/app/addons/replication/__tests__/newreplication.test.js
+++ b/app/addons/replication/__tests__/newreplication.test.js
@@ -44,7 +44,7 @@ describe('New Replication Component', () => {
         updateFormField={() => { return () => {}; }}
       />);
 
-      assert.ok(newreplication.instance().checkSourceTargetDatabases());
+      expect(newreplication.instance().checkSourceTargetDatabases()).toBeTruthy();
     });
 
     it('returns true for remote source and target selected', () => {
@@ -64,7 +64,7 @@ describe('New Replication Component', () => {
         updateFormField={() => { return () => {}; }}
       />);
 
-      assert.ok(newreplication.instance().checkSourceTargetDatabases());
+      expect(newreplication.instance().checkSourceTargetDatabases()).toBeTruthy();
     });
 
     it('returns false for invalid remote source', () => {
@@ -84,7 +84,7 @@ describe('New Replication Component', () => {
         updateFormField={() => { return () => {}; }}
       />);
 
-      assert.notOk(newreplication.instance().checkSourceTargetDatabases());
+      expect(newreplication.instance().checkSourceTargetDatabases()).toBeFalsy();
     });
 
     it('returns false for invalid remote target', () => {
@@ -104,7 +104,7 @@ describe('New Replication Component', () => {
         updateFormField={() => { return () => {}; }}
       />);
 
-      assert.notOk(newreplication.instance().checkSourceTargetDatabases());
+      expect(newreplication.instance().checkSourceTargetDatabases()).toBeFalsy();
     });
 
     it("warns if new local database exists", () => {
@@ -127,10 +127,10 @@ describe('New Replication Component', () => {
       />);
 
       newreplication.instance().checkSourceTargetDatabases();
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
 
       const notification = spy.args[0][0];
-      assert.ok(/database already exists/.test(notification.msg));
+      expect(notification.msg).toMatch(/database already exists/);
     });
 
     it("warns if database name is wrong", () => {
@@ -153,10 +153,10 @@ describe('New Replication Component', () => {
       />);
 
       newreplication.instance().checkSourceTargetDatabases();
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
 
       const notification = spy.args[0][0];
-      assert.ok(/may not contain any spaces/.test(notification.msg));
+      expect(notification.msg).toMatch(/may not contain any spaces/);
     });
 
     it("warns if database is same for local", () => {
@@ -179,10 +179,10 @@ describe('New Replication Component', () => {
       />);
 
       newreplication.instance().checkSourceTargetDatabases();
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
 
       const notification = spy.args[0][0];
-      assert.ok(/Cannot replicate a database to itself/.test(notification.msg));
+      expect(notification.msg).toMatch(/Cannot replicate a database to itself/);
     });
 
     it("warns if database is same for remote", () => {
@@ -205,10 +205,10 @@ describe('New Replication Component', () => {
       />);
 
       newreplication.instance().checkSourceTargetDatabases();
-      assert.ok(spy.calledOnce);
+      expect(spy.calledOnce).toBeTruthy();
 
       const notification = spy.args[0][0];
-      assert.ok(/Cannot replicate a database to itself/.test(notification.msg));
+      expect(notification.msg).toMatch(/Cannot replicate a database to itself/);
     });
   });
 
@@ -231,7 +231,7 @@ describe('New Replication Component', () => {
         updateFormField={() => { return () => {}; }}
       />);
 
-      assert.notOk(newreplication.instance().confirmButtonEnabled());
+      expect(newreplication.instance().confirmButtonEnabled()).toBeFalsy();
     });
 
     it('returns false for empty remote source', () => {
@@ -254,7 +254,7 @@ describe('New Replication Component', () => {
         updateFormField={() => { return () => {}; }}
       />);
 
-      assert.notOk(newreplication.instance().confirmButtonEnabled());
+      expect(newreplication.instance().confirmButtonEnabled()).toBeFalsy();
     });
 
     it('returns false for empty local source', () => {
@@ -278,7 +278,7 @@ describe('New Replication Component', () => {
       />);
 
 
-      assert.notOk(newreplication.instance().confirmButtonEnabled());
+      expect(newreplication.instance().confirmButtonEnabled()).toBeFalsy();
     });
 
     it("returns true for all details filled in", () => {
@@ -302,7 +302,7 @@ describe('New Replication Component', () => {
       />);
 
 
-      assert.ok(newreplication.instance().confirmButtonEnabled());
+      expect(newreplication.instance().confirmButtonEnabled()).toBeTruthy();
     });
 
   });
@@ -311,7 +311,7 @@ describe('New Replication Component', () => {
 
     it("shows conflict modal for existing replication doc", (done) => {
       const showConflictModal = () => {
-        assert.ok(true);
+        expect(true).toBeTruthy();
         done();
       };
 
@@ -368,7 +368,7 @@ describe('New Replication Component', () => {
 
       newreplication.instance().checkAuth = checkAuth;
       newreplication.instance().runReplicationChecks();
-      assert.ok(called);
+      expect(called).toBeTruthy();
     });
 
   });

--- a/app/addons/replication/__tests__/newreplication.test.js
+++ b/app/addons/replication/__tests__/newreplication.test.js
@@ -17,7 +17,7 @@ import sinon from "sinon";
 import NewReplication from '../components/newreplication';
 import Constants from '../constants';
 
-const {assert, restore}  = utils;
+const {restore}  = utils;
 
 describe('New Replication Component', () => {
 

--- a/app/addons/verifyinstall/__tests__/components.test.js
+++ b/app/addons/verifyinstall/__tests__/components.test.js
@@ -45,7 +45,7 @@ describe('VerifyInstallResults', function () {
     el = mount(<VerifyInstallResults testResults={testResults} />);
 
     tests.forEach((test) => {
-      assert.equal(el.find('#' + test.id).text(), '');
+      expect(el.find('#' + test.id).text()).toBe('');
     });
   });
 
@@ -62,7 +62,7 @@ describe('VerifyInstallResults', function () {
       el = mount(<VerifyInstallResults testResults={copy} />);
 
       // now look at the DOM for that element. It should contain a tick char
-      assert.equal(el.find('#' + test.id + ' span').text(), '✓');
+      expect(el.find('#' + test.id + ' span').text()).toBe('✓');
     });
   });
 
@@ -79,7 +79,7 @@ describe('VerifyInstallResults', function () {
       el = mount(<VerifyInstallResults testResults={copy} />);
 
       // now look at the DOM for that element. It should contain an error char
-      assert.equal(el.find('#' + test.id + ' span').text(), '✗');
+      expect(el.find('#' + test.id + ' span').text()).toBe('✗');
     });
   });
 });
@@ -93,19 +93,19 @@ describe('VerifyInstallButton', function () {
     const spy = sinon.spy(stub, 'func');
     el = mount(<VerifyInstallButton verify={stub.func} isVerifying={false} />);
     el.simulate('click');
-    assert.ok(spy.calledOnce);
+    expect(spy.calledOnce).toBeTruthy();
   });
 
   it('shows appropriate default label', function () {
     const stub = { func: () => { } };
     el = mount(<VerifyInstallButton verify={stub.func} isVerifying={false} />);
-    assert.equal(el.text(), 'Verify Installation');
+    expect(el.text()).toBe('Verify Installation');
   });
 
   it('shows appropriate label during verification', function () {
     const stub = { func: () => { } };
     el = mount(<VerifyInstallButton verify={stub.func} isVerifying={true} />);
-    assert.equal(el.text(), 'Verifying');
+    expect(el.text()).toBe('Verifying');
   });
 
 });

--- a/app/addons/verifyinstall/__tests__/components.test.js
+++ b/app/addons/verifyinstall/__tests__/components.test.js
@@ -12,16 +12,12 @@
 
 import FauxtonAPI from '../../../core/api';
 import React from 'react';
-import ReactDOM from 'react-dom';
-import testUtils from '../../../../test/mocha/testUtils';
 import Constants from '../constants';
 import VerifyInstallButton from '../components/VerifyInstallButton';
 import VerifyInstallResults from '../components/VerifyInstallResults';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
 FauxtonAPI.router = new FauxtonAPI.Router([]);
-
-var assert = testUtils.assert;
 
 describe('VerifyInstallResults', function () {
   let el;

--- a/app/addons/verifyinstall/__tests__/reducers.test.js
+++ b/app/addons/verifyinstall/__tests__/reducers.test.js
@@ -10,22 +10,19 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import testUtils from "../../../../test/mocha/testUtils";
 import reducer from "../reducers";
 import ActionTypes from "../actiontypes";
-
-var assert = testUtils.assert;
 
 describe('VerifyInstall Reducer', () => {
 
   it('initial state has all tests status set to false', () => {
     const newState = reducer(undefined, {type: 'something_else'});
 
-    assert.ok(newState.isVerifying === false);
+    expect(newState.isVerifying).toBe(false);
 
     // confirm all the tests are initially marked as incomplete
     Object.keys(newState.tests).forEach((test) => {
-      assert.ok(newState.tests[test].complete === false);
+      expect(newState.tests[test].complete).toBe(false);
     });
   });
 
@@ -34,14 +31,14 @@ describe('VerifyInstall Reducer', () => {
       type: ActionTypes.VERIFY_INSTALL_START
     });
 
-    assert.ok(newState.isVerifying === true);
+    expect(newState.isVerifying).toBe(true);
   });
 
   it('verification status changes to completed', () => {
     const newState = reducer(undefined, {
       type: ActionTypes.VERIFY_INSTALL_ALL_TESTS_COMPLETE
     });
-    assert.ok(newState.isVerifying === false);
+    expect(newState.isVerifying).toBe(false);
   });
 
   it('resets status of all tests', () => {
@@ -56,8 +53,8 @@ describe('VerifyInstall Reducer', () => {
       type: ActionTypes.VERIFY_INSTALL_RESET
     });
     Object.keys(newState.tests).forEach((test) => {
-      assert.ok(newState.tests[test].complete === false);
-      assert.isUndefined(newState.tests[test].success);
+      expect(newState.tests[test].complete).toBe(false);
+      expect(newState.tests[test].success).not.toBeDefined();
     });
   });
 

--- a/app/core/__tests__/ajax.test.js
+++ b/app/core/__tests__/ajax.test.js
@@ -78,7 +78,7 @@ describe('Fauxton Ajax', () => {
     unsubscribe = fetchObserver.filter(resp => resp.status === 400).subscribe({
       next (resp) {
         done();
-        assert.deepEqual(resp.status, 400);
+        expect(resp.status).toEqual(400);
       }
     });
 
@@ -95,7 +95,7 @@ describe('Fauxton Ajax', () => {
     });
 
     return get('/testing').then(resp =>{
-      assert.ok(resp.ok);
+      expect(resp.ok).toBeTruthy();
     });
   });
 
@@ -109,7 +109,7 @@ describe('Fauxton Ajax', () => {
 
     return put('/testing')
       .then(resp =>{
-        assert.ok(resp.ok);
+        expect(resp.ok).toBeTruthy();
       });
   });
 
@@ -123,7 +123,7 @@ describe('Fauxton Ajax', () => {
 
     return post('/testing')
       .then(resp =>{
-        assert.ok(resp.ok);
+        expect(resp.ok).toBeTruthy();
       });
   });
 
@@ -137,7 +137,7 @@ describe('Fauxton Ajax', () => {
 
     return deleteRequest('/testing')
       .then(resp =>{
-        assert.ok(resp.ok);
+        expect(resp.ok).toBeTruthy();
       });
   });
 
@@ -152,8 +152,8 @@ describe('Fauxton Ajax', () => {
       fetchMock.postOnce('/testing', successResponse);
       return post('/testing', '')
         .then(resp =>{
-          assert.ok(resp.ok);
-          assert.ok(fetchMock.lastOptions().body === '""');
+          expect(resp.ok).toBeTruthy();
+          expect(fetchMock.lastOptions().body).toBe('""');
         });
     });
 
@@ -161,8 +161,8 @@ describe('Fauxton Ajax', () => {
       fetchMock.postOnce('/testing', successResponse);
       return post('/testing', 0)
         .then(resp =>{
-          assert.ok(resp.ok);
-          assert.ok(fetchMock.lastOptions().body === '0');
+          expect(resp.ok).toBeTruthy();
+          expect(fetchMock.lastOptions().body).toBe('0');
         });
     });
 
@@ -170,8 +170,8 @@ describe('Fauxton Ajax', () => {
       fetchMock.postOnce('/testing', successResponse);
       return post('/testing', false)
         .then(resp =>{
-          assert.ok(resp.ok);
-          assert.ok(fetchMock.lastOptions().body === 'false');
+          expect(resp.ok).toBeTruthy();
+          expect(fetchMock.lastOptions().body).toBe('false');
         });
     });
   });
@@ -187,8 +187,8 @@ describe('Fauxton Ajax', () => {
       fetchMock.putOnce('/testing', successResponse);
       return put('/testing', '')
         .then(resp =>{
-          assert.ok(resp.ok);
-          assert.ok(fetchMock.lastOptions().body === '""');
+          expect(resp.ok).toBeTruthy();
+          expect(fetchMock.lastOptions().body).toBe('""');
         });
     });
 
@@ -196,8 +196,8 @@ describe('Fauxton Ajax', () => {
       fetchMock.putOnce('/testing', successResponse);
       return put('/testing', 0)
         .then(resp =>{
-          assert.ok(resp.ok);
-          assert.ok(fetchMock.lastOptions().body === '0');
+          expect(resp.ok).toBeTruthy();
+          expect(fetchMock.lastOptions().body).toBe('0');
         });
     });
 
@@ -205,8 +205,8 @@ describe('Fauxton Ajax', () => {
       fetchMock.putOnce('/testing', successResponse);
       return put('/testing', false)
         .then(resp =>{
-          assert.ok(resp.ok);
-          assert.ok(fetchMock.lastOptions().body === 'false');
+          expect(resp.ok).toBeTruthy();
+          expect(fetchMock.lastOptions().body).toBe('false');
         });
     });
   });

--- a/app/core/__tests__/ajax.test.js
+++ b/app/core/__tests__/ajax.test.js
@@ -18,8 +18,6 @@ import {
   post,
   deleteRequest
 } from '../ajax';
-import testUtils from "../../../test/mocha/testUtils";
-const assert = testUtils.assert;
 
 describe('Fauxton Ajax', () => {
   let unsubscribe;

--- a/app/core/__tests__/api.test.js
+++ b/app/core/__tests__/api.test.js
@@ -9,9 +9,8 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
+
 import FauxtonAPI from "../api";
-import testUtils from "../../../test/mocha/testUtils";
-const assert = testUtils.assert;
 
 describe('URLs', () => {
 

--- a/app/core/__tests__/api.test.js
+++ b/app/core/__tests__/api.test.js
@@ -24,7 +24,7 @@ describe('URLs', () => {
       }
     });
 
-    assert.equal(FauxtonAPI.urls('testURL', 'server'), testUrl);
+    expect(FauxtonAPI.urls('testURL', 'server')).toBe(testUrl);
 
   });
 
@@ -39,7 +39,7 @@ describe('URLs', () => {
       return false;
     });
 
-    assert.equal(FauxtonAPI.urls('testURL', 'intercept'), testUrl);
+    expect(FauxtonAPI.urls('testURL', 'intercept')).toBe(testUrl);
   });
 
 });

--- a/app/core/__tests__/utils.test.js
+++ b/app/core/__tests__/utils.test.js
@@ -9,9 +9,8 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-import testUtils from "../../../test/mocha/testUtils";
+
 import utils from "../utils";
-const assert = testUtils.assert;
 
 describe('Utils', () => {
 
@@ -71,7 +70,7 @@ describe('Utils', () => {
   describe('localStorage', () => {
 
     it('Should get undefined when getting a non-existent key', () => {
-      assert.isUndefined(utils.localStorageGet('qwerty'));
+      expect(utils.localStorageGet('qwerty')).not.toBeDefined();
     });
 
     it('Should get value after setting it', () => {

--- a/app/core/__tests__/utils.test.js
+++ b/app/core/__tests__/utils.test.js
@@ -19,17 +19,17 @@ describe('Utils', () => {
 
     it('returns doc if id not given', () => {
       const res = utils.getDocTypeFromId();
-      assert.equal(res, 'doc');
+      expect(res).toBe('doc');
     });
 
     it('returns design doc for design docs', () => {
       const res = utils.getDocTypeFromId('_design/foobar');
-      assert.equal(res, 'design doc');
+      expect(res).toBe('design doc');
     });
 
     it('returns doc for all others', () => {
       const res = utils.getDocTypeFromId('blerg');
-      assert.equal(res, 'doc');
+      expect(res).toBe('doc');
     });
   });
 
@@ -37,34 +37,34 @@ describe('Utils', () => {
 
     it('keeps _design/ intact', () => {
       const res = utils.getSafeIdForDoc('_design/foo/do');
-      assert.equal(res, '_design/foo%2Fdo');
+      expect(res).toBe('_design/foo%2Fdo');
     });
 
     it('encodes all other', () => {
       const res = utils.getSafeIdForDoc('_redesign/foobar');
-      assert.equal(res, '_redesign%2Ffoobar');
+      expect(res).toBe('_redesign%2Ffoobar');
     });
   });
 
   describe('safeURLName', () => {
 
     it('encodes special chars', () => {
-      assert.equal('foo-bar%2Fbaz', utils.safeURLName('foo-bar/baz'));
+      expect(utils.safeURLName('foo-bar/baz')).toBe('foo-bar%2Fbaz');
     });
 
     it('encodes an encoded doc', () => {
-      assert.equal('foo-bar%252Fbaz', utils.safeURLName('foo-bar%2Fbaz'));
+      expect(utils.safeURLName('foo-bar%2Fbaz')).toBe('foo-bar%252Fbaz');
     });
   });
 
   describe('isSystemDatabase', () => {
 
     it('detects system databases', () => {
-      assert.ok(utils.isSystemDatabase('_replicator'));
+      expect(utils.isSystemDatabase('_replicator')).toBeTruthy();
     });
 
     it('ignores other dbs', () => {
-      assert.notOk(utils.isSystemDatabase('foo'));
+      expect(utils.isSystemDatabase('foo')).toBeFalsy();
     });
   });
 
@@ -77,7 +77,7 @@ describe('Utils', () => {
     it('Should get value after setting it', () => {
       const key = 'key1';
       utils.localStorageSet(key, 1);
-      assert.equal(utils.localStorageGet(key), 1);
+      expect(utils.localStorageGet(key)).toBe(1);
     });
 
     it('Set and retrieve complex object', () => {
@@ -87,7 +87,7 @@ describe('Utils', () => {
               two: ['1', 'string', 3]
             };
       utils.localStorageSet(key, obj);
-      assert.deepEqual(utils.localStorageGet(key), obj);
+      expect(utils.localStorageGet(key)).toEqual(obj);
     });
 
     it('stripHTML removes HTML', () => {
@@ -97,7 +97,7 @@ describe('Utils', () => {
         { html: 'testing <a href="#whatever">attributes</span>', text: 'testing attributes' },
         { html: '<span>testing</span> multiple <p>elements</p>', text: 'testing multiple elements' }
       ].forEach(function (item) {
-        assert.equal(utils.stripHTML(item.html), item.text);
+        expect(utils.stripHTML(item.html)).toBe(item.text);
       });
     });
 
@@ -105,12 +105,11 @@ describe('Utils', () => {
 
   describe('queryParams', () => {
     it('builds query string from an object', () => {
-      assert.equal(
-        utils.queryParams({
-          startkey: JSON.stringify('_design/app'),
-          endkey: JSON.stringify('_design/app\u9999'),
-          limit:30
-        }),
+      expect(utils.queryParams({
+        startkey: JSON.stringify('_design/app'),
+        endkey: JSON.stringify('_design/app\u9999'),
+        limit:30
+      })).toBe(
         'startkey=%22_design%2Fapp%22&endkey=%22_design%2Fapp%E9%A6%99%22&limit=30'
       );
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3933,43 +3933,6 @@
         "lazy-cache": "^1.0.3"
       }
     },
-    "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
-      },
-      "dependencies": {
-        "assertion-error": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-          "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-          "requires": {
-            "type-detect": "0.1.1"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
-            }
-          }
-        },
-        "type-detect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
-        }
-      }
-    },
     "chai-nightwatch": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/chai-nightwatch/-/chai-nightwatch-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "base-64": "^0.1.0",
     "bluebird": "^3.4.6",
     "brace": "^0.11.0",
-    "chai": "^3.5.0",
     "classnames": "^2.2.5",
     "clean-css": "^4.0.5",
     "clipboard": "^1.5.16",

--- a/test/mocha/testUtils.js
+++ b/test/mocha/testUtils.js
@@ -10,7 +10,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import chai from "chai";
 import _ from 'lodash';
 
 var restore = function (fn) {
@@ -20,7 +19,5 @@ var restore = function (fn) {
 };
 
 export default {
-  chai: chai,
-  assert: chai.assert,
   restore: restore
 };


### PR DESCRIPTION
## Overview

Removes all uses of Chai's `assert` in favor of Jest's built-in `expect` matchers. This makes the test code more consistent instead of having a mix of `expect` and `assert` calls.

Most of the code changes were done using a codemod: https://github.com/skovhus/jest-codemods.
As a bonus, I fixed a few tests that were wrong (always passing) and re-enabled most skipped tests (there's only 1 skipped test now - yay!)

## Testing recommendations

Run Jest as usual


## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
