### PR TITLE
Make only header clickable in the JSON view

### DIFF
--- a/app/addons/components/__tests__/doc.test.js
+++ b/app/addons/components/__tests__/doc.test.js
@@ -72,7 +72,7 @@ describe('Document', () => {
     el = mount(
       <ReactComponents.Document docChecked={noop} isDeletable={true} onClick={spy} docIdentifier="foo" />
     );
-    el.find('.doc-item').first().simulate('click');
+    el.find('.doc-item header').first().simulate('click');
     expect(spy.calledOnce).toBeTruthy();
   });
 

--- a/app/addons/components/assets/less/docs.less
+++ b/app/addons/components/assets/less/docs.less
@@ -21,7 +21,6 @@
   div.doc-row {
     margin-bottom: 20px;
     .doc-item {
-      cursor: pointer;
       vertical-align: top;
       position: relative;
       .box-shadow(3px 4px 0 rgba(0, 0, 0, 0.3));
@@ -38,6 +37,7 @@
         }
       }
       header {
+        cursor: pointer;
         font-weight: bold;
         position: relative;
         padding: 5px 10px;

--- a/app/addons/components/components/document.js
+++ b/app/addons/components/components/document.js
@@ -115,8 +115,8 @@ export class Document extends React.Component {
         <div className="custom-inputs">
           {this.getCheckbox()}
         </div>
-        <div className="doc-item" onClick={this.onClick}>
-          <header>
+        <div className="doc-item">
+          <header onClick={this.onClick}>
             <span className="header-keylabel">
               {this.props.keylabel}
             </span>


### PR DESCRIPTION
## Overview

Makes only header clickable in the JSON view, instead of the whole document.

## Testing recommendations

- Go to All Documents and switch to JSON view
- Verify you can select text (and copy) from a document
- Verify you can still click on the header to edit the document

## GitHub issue number

#1163 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
