### PR TITLE
Remove dependency with Backbone.Model

### DIFF
--- a/app/addons/components/actions.js
+++ b/app/addons/components/actions.js
@@ -24,11 +24,7 @@ function showDeleteDatabaseModal (options) {
 function deleteDatabase (dbId, onDeleteSuccess) {
   const url = FauxtonAPI.urls('databaseBaseURL', 'server', dbId, '');
 
-  deleteRequest(url).then(resp => {
-    if (!resp.ok) {
-      const msg = resp.reason || '';
-      throw new Error(msg);
-    }
+  deleteRequest(url).then(FauxtonAPI.throwIfCouchDbErrorResponse).then(() => {
     this.showDeleteDatabaseModal({ showModal: true });
 
     FauxtonAPI.addNotification({

--- a/app/addons/databases/actions.js
+++ b/app/addons/databases/actions.js
@@ -153,7 +153,7 @@ export default {
 
     const db = Stores.databasesStore.obtainNewDatabaseModel(databaseName, partitioned);
     FauxtonAPI.addNotification({ msg: 'Creating database.' });
-    db.save().done(() => {
+    db.save().then(() => {
       FauxtonAPI.addNotification({
         msg: 'Database created successfully',
         type: 'success',
@@ -161,11 +161,10 @@ export default {
       });
       const route = FauxtonAPI.urls('allDocs', 'app', app.utils.safeURLName(databaseName));
       app.router.navigate(route, { trigger: true });
-    }
-    ).fail((xhr) => {
-      const responseText = JSON.parse(xhr.responseText).reason;
+    }).catch(err => {
+      const reason = err.responseJSON ? err.responseJSON.reason : '';
       FauxtonAPI.addNotification({
-        msg: 'Create database failed: ' + responseText,
+        msg: 'Create database failed. ' + reason,
         type: 'error',
         clear: true
       });

--- a/app/addons/databases/resources.js
+++ b/app/addons/databases/resources.js
@@ -18,37 +18,40 @@ var Databases = FauxtonAPI.addon();
 
 Databases.DocLimit = 100;
 
-Databases.Model = FauxtonAPI.Model.extend({
+Databases.Model = class extends FauxtonAPI.Model {
 
-  partitioned: false,
+  constructor(attributes, options) {
+    super(attributes, options);
+    this.partitioned = false;
+  }
 
-  setPartitioned: function (partitioned) {
+  setPartitioned(partitioned) {
     this.partitioned = partitioned;
-  },
+  }
 
-  documentation: function () {
+  documentation() {
     return FauxtonAPI.constants.DOC_URLS.ALL_DBS;
-  },
+  }
 
-  buildAllDocs: function (params) {
+  buildAllDocs(params) {
     this.allDocs = new Documents.AllDocs(null, {
       database: this,
       params: params
     });
 
     return this.allDocs;
-  },
+  }
 
-  isNew: function () {
+  isNew() {
     // Databases are never new, to make Backbone do a PUT
     return false;
-  },
+  }
 
-  isSystemDatabase: function () {
+  isSystemDatabase() {
     return app.utils.isSystemDatabase(this.id);
-  },
+  }
 
-  url: function (context) {
+  url(context) {
     if (context === "index") {
       return "/database/" + this.safeID() + "/_all_docs";
     } else if (context === "web-index") {
@@ -67,12 +70,13 @@ Databases.Model = FauxtonAPI.Model.extend({
     }
     return Helpers.getServerUrl("/" + this.safeID());
 
-  },
+  }
 
-  safeID: function () {
+  safeID() {
     return app.utils.safeURLName(this.id);
-  },
-  buildChanges: function (params) {
+  }
+
+  buildChanges(params) {
     if (!params.limit) {
       params.limit = 100;
     }
@@ -84,18 +88,20 @@ Databases.Model = FauxtonAPI.Model.extend({
 
     return this.changes;
   }
-});
+};
 
-Databases.Changes = FauxtonAPI.Collection.extend({
+Databases.Changes = class extends FauxtonAPI.Collection {
 
-  initialize: function (options) {
+  initialize(options) {
     this.database = options.database;
     this.params = options.params;
-  },
-  documentation: function () {
+  }
+
+  documentation() {
     return FauxtonAPI.constants.DOC_URLS.CHANGES;
-  },
-  url: function (context) {
+  }
+
+  url(context) {
     var query = "";
     if (this.params) {
       query = "?" + app.utils.queryParams(this.params);
@@ -104,12 +110,12 @@ Databases.Changes = FauxtonAPI.Collection.extend({
     if (!context) { context = 'server';}
 
     return FauxtonAPI.urls('changes', context, this.database.safeID(), query);
-  },
+  }
 
-  parse: function (resp) {
+  parse(resp) {
     this.last_seq = resp.last_seq;
     return resp.results;
   }
-});
+};
 
 export default Databases;

--- a/app/addons/documents/doc-editor/actions.js
+++ b/app/addons/documents/doc-editor/actions.js
@@ -39,8 +39,8 @@ const initDocEditor = (params) => (dispatch) => {
     if (params.onLoaded) {
       params.onLoaded();
     }
-  }, function (xhr) {
-    if (xhr.status === 404) {
+  }).catch(err => {
+    if (err.status === 404) {
       errorNotification(`The ${doc.id} document does not exist.`);
     }
 
@@ -62,9 +62,10 @@ const saveDoc = (doc, isValidDoc, onSave, navigateToUrl) => {
       } else {
         FauxtonAPI.navigate('#/' + FauxtonAPI.urls('allDocs', 'app',  FauxtonAPI.url.encode(doc.database.id)), {trigger: true});
       }
-    }).fail(function (xhr) {
+    }).catch(err => {
+      const errMsg = err.responseJSON ? err.responseJSON.reason : '';
       FauxtonAPI.addNotification({
-        msg: 'Save failed: ' + JSON.parse(xhr.responseText).reason,
+        msg: 'Save failed. ' + errMsg,
         type: 'error',
         fade: false,
         clear: true
@@ -129,7 +130,7 @@ const cloneDoc = (database, doc, newId) => {
       msg: 'Document has been duplicated.'
     });
 
-  }, (error) => {
+  }).catch((error) => {
     const errorMsg = `Could not duplicate document, reason: ${error.responseText}.`;
     FauxtonAPI.addNotification({
       msg: errorMsg,

--- a/app/addons/documents/doc-editor/components/DocEditorScreen.js
+++ b/app/addons/documents/doc-editor/components/DocEditorScreen.js
@@ -12,7 +12,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import FauxtonAPI from '../../../../core/api';
 import FauxtonComponents from '../../../fauxton/components';
 import GeneralComponents from '../../../components/react-components';
@@ -96,8 +95,10 @@ export default class DocEditorScreen extends React.Component {
     if (this.props.numFilesUploaded !== nextProps.numFilesUploaded ||
         this.props.doc && this.props.doc.hasChanged() ||
         (this.props.doc && nextProps.doc && this.props.doc.id !== nextProps.doc.id)) {
-      this.getEditor().setValue(JSON.stringify(nextProps.doc.attributes, null, '  '));
-      this.onSaveComplete();
+      if (this.getEditor()) {
+        this.getEditor().setValue(JSON.stringify(nextProps.doc.attributes, null, '  '));
+        this.onSaveComplete();
+      }
     }
   }
 

--- a/app/addons/documents/index-editor/actions.js
+++ b/app/addons/documents/index-editor/actions.js
@@ -43,9 +43,9 @@ const dispatchClearIndex = () => {
 const dispatchFetchDesignDocsBeforeEdit = (options) => {
   options.designDocs.fetch({reset: true}).then(() => {
     editIndex(options)(FauxtonAPI.reduxDispatch);
-  }, xhr => {
+  }).catch(err => {
     let errorMsg = 'Error';
-    if (xhr.responseJSON && xhr.responseJSON.error === 'not_found') {
+    if (err.responseJSON && err.responseJSON.error === 'not_found') {
       const databaseName = options.designDocs.database.safeID();
       errorMsg = `The ${databaseName} database does not exist`;
       FauxtonAPI.navigate('/', {trigger: true});
@@ -103,9 +103,10 @@ const saveView = (viewInfo, navigateToURL) => (dispatch) => {
     SidebarActions.dispatchUpdateDesignDocs(viewInfo.designDocs);
     dispatch({ type: ActionTypes.VIEW_SAVED });
     FauxtonAPI.navigate(navigateToURL, { trigger: true });
-  }, (xhr) => {
+  }).catch(err => {
+    const errMsg = err.responseJSON ? err.responseJSON.reason : '';
     FauxtonAPI.addNotification({
-      msg: 'Save failed. ' + (xhr.responseJSON ? `Reason: ${xhr.responseJSON.reason}` : ''),
+      msg: 'Save failed. ' + errMsg,
       type: 'error',
       clear: true
     });
@@ -173,11 +174,11 @@ const cloneView = (params) => {
       clear: true
     });
     SidebarActions.dispatchUpdateDesignDocs(params.designDocs);
-  }, (xhr) => {
+  }).catch(err => {
     params.onComplete();
-    const responseText = JSON.parse(xhr.responseText).reason;
+    const errMsg = err.responseJSON ? err.responseJSON.reason : '';
     FauxtonAPI.addNotification({
-      msg: 'Clone failed: ' + responseText,
+      msg: 'Clone failed. ' + errMsg,
       type: 'error',
       clear: true
     });
@@ -236,10 +237,10 @@ const updateNewDesignDocPartitioned = (isPartitioned) => (dispatch) => {
 const safeDeleteIndex = (designDoc, designDocs, indexPropName, indexName, options) => {
   const opts = _.extend({
     onSuccess: function () { },
-    onError: function (xhr) {
-      const responseText = JSON.parse(xhr.responseText).reason;
+    onError: function (err) {
+      const reason = err.responseJSON ? err.responseJSON.reason : '';
       FauxtonAPI.addNotification({
-        msg: 'Delete failed: ' + responseText,
+        msg: 'Delete failed. ' + reason,
         type: 'error',
         clear: true
       });

--- a/app/addons/documents/index-editor/reducers.js
+++ b/app/addons/documents/index-editor/reducers.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+import Collection from '../../../core/data/collection';
 import ActionTypes from './actiontypes';
 import Resources from '../resources';
 import Helpers from '../helpers';
@@ -20,7 +21,7 @@ const builtInReducers = ['_sum', '_count', '_stats', '_approx_count_distinct'];
 const allReducers = builtInReducers.concat(['CUSTOM', 'NONE']);
 
 const initialState = {
-  designDocs: new Backbone.Collection(),
+  designDocs: new Collection(),
   isLoading: true,
   view: { reduce: '', map: defaultMap },
   database: { id: '0' },

--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -13,7 +13,6 @@
 import app from "../../app";
 import Helpers from '../../helpers';
 import FauxtonAPI from "../../core/api";
-import { post } from "../../core/ajax";
 import Documents from "./shared-resources";
 
 Documents.QueryParams = (function () {
@@ -42,35 +41,49 @@ Documents.QueryParams = (function () {
 })();
 
 
-Documents.DdocInfo = FauxtonAPI.Model.extend({
-  idAttribute: "_id",
-  documentation: function () {
-    return FauxtonAPI.constants.DOC_URLS.GENERAL;
-  },
-  initialize: function (_attrs, options) {
-    this.database = options.database;
-  },
+class DdocInfoModel extends FauxtonAPI.Model {
 
-  url: function (context) {
+  constructor(attributes, options) {
+    super(attributes, options);
+    this.idAttribute = '_id';
+  }
+
+  documentation() {
+    return FauxtonAPI.constants.DOC_URLS.GENERAL;
+  }
+
+  initialize(_attrs, options) {
+    this.database = options.database;
+  }
+
+  url(context) {
     if (!context) {
       context = 'server';
     }
 
     return FauxtonAPI.urls('designDocs', context, this.database.safeID(), this.safeID());
-  },
+  }
 
   // Need this to work around backbone router thinking _design/foo
   // is a separate route. Alternatively, maybe these should be
   // treated separately. For instance, we could default into the
   // json editor for docs, or into a ddoc specific page.
-  safeID: function () {
+  safeID() {
     var ddoc = this.id.replace(/^_design\//, "");
     return "_design/" + app.utils.safeURLName(ddoc);
   }
-});
 
-Documents.NewDoc = Documents.Doc.extend({
-  fetch: function () {
+  parse(data) {
+    if (!data._id) {
+      data._id = '_design/' + data.name;
+    }
+    return data;
+  }
+}
+Documents.DdocInfo = DdocInfoModel;
+
+class NewDocModel extends Documents.Doc {
+  fetch() {
     const prefix = this.partitionKey ? (this.partitionKey + ':') : '';
     return Helpers.getUUID().then((res) => {
       if (res.uuids) {
@@ -85,113 +98,7 @@ Documents.NewDoc = Documents.Doc.extend({
       this.set("_id", prefix + 'enter_document_id');
     });
   }
-});
-
-Documents.BulkDeleteDoc = FauxtonAPI.Model.extend({
-  idAttribute: "_id"
-});
-
-Documents.BulkDeleteDocCollection = FauxtonAPI.Collection.extend({
-
-  model: Documents.BulkDeleteDoc,
-
-  sync: function () {
-
-  },
-
-  initialize: function (models, options) {
-    this.databaseId = options.databaseId;
-  },
-
-  url: function () {
-    return FauxtonAPI.urls('bulk_docs', 'server', this.databaseId, '');
-  },
-
-  bulkDelete: function () {
-    const payload = this.createPayload(this.toJSON());
-    return new FauxtonAPI.Promise((resolve, reject) => {
-      post(this.url(), payload).then(res => {
-        if (res.error) {
-          throw new Error(res.reason || res.error);
-        }
-        this.handleResponse(res, resolve, reject);
-      }).catch(() => {
-        const ids = _.reduce(this.toArray(), (acc, doc) => {
-          acc.push(doc.id);
-          return acc;
-        }, []);
-        this.trigger('error', ids);
-        reject(ids);
-      });
-    });
-  },
-
-  handleResponse: function (res, resolve, reject) {
-    var ids = _.reduce(res, function (ids, doc) {
-      if (doc.error) {
-        ids.errorIds.push(doc.id);
-      }
-
-      if (!doc.error) {
-        ids.successIds.push(doc.id);
-      }
-
-      return ids;
-    }, { errorIds: [], successIds: [] });
-
-    this.removeDocuments(ids.successIds);
-
-    if (ids.errorIds.length) {
-      this.trigger('error', ids.errorIds);
-    }
-
-    // This is kind of tricky. If there are no documents deleted then rejects
-    // otherwise resolve with list of successful and failed documents
-    if (!_.isEmpty(ids.successIds)) {
-      resolve(ids);
-    } else {
-      reject(ids.errorIds);
-    }
-
-    this.trigger('updated');
-  },
-
-  removeDocuments: function (ids) {
-    _.each(ids, (id) => {
-      this.remove(this.get(id));
-    });
-
-    this.trigger('removed', ids);
-  },
-
-  createPayload: function (documents) {
-    var documentList = documents;
-
-    return {
-      docs: documentList
-    };
-  }
-});
-
-Documents.MangoBulkDeleteDocCollection = Documents.BulkDeleteDocCollection.extend({
-  url: function () {
-    return Helpers.getServerUrl(`/${this.databaseId}/_index/_bulk_delete`);
-  },
-
-  createPayload: function (documents) {
-    var documentList = documents
-      .filter(function (doc) {
-        return doc._id !== '_all_docs';
-      })
-      .map(function (doc) {
-        return doc._id;
-      });
-
-    return {
-      docids: documentList
-    };
-  }
-
-});
+}
+Documents.NewDoc = NewDocModel;
 
 export default Documents;

--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -46,14 +46,13 @@ class DdocInfoModel extends FauxtonAPI.Model {
   constructor(attributes, options) {
     super(attributes, options);
     this.idAttribute = '_id';
+    if (options) {
+      this.database = options.database;
+    }
   }
 
   documentation() {
     return FauxtonAPI.constants.DOC_URLS.GENERAL;
-  }
-
-  initialize(_attrs, options) {
-    this.database = options.database;
   }
 
   url(context) {

--- a/app/addons/documents/sidebar/actions.js
+++ b/app/addons/documents/sidebar/actions.js
@@ -32,9 +32,9 @@ const dispatchNewOptions = (options) => {
       type: ActionTypes.SIDEBAR_NEW_OPTIONS,
       options: options
     });
-  }, xhr => {
+  }).catch(err => {
     let errorMsg = 'Unable to update the sidebar.';
-    if (xhr.responseJSON && xhr.responseJSON.error === 'not_found') {
+    if (err.responseJSON && err.responseJSON.error === 'not_found') {
       const databaseName = options.designDocs.database.safeID();
       errorMsg = `The ${databaseName} database does not exist.`;
       FauxtonAPI.navigate('/', {trigger: true});

--- a/app/addons/documents/sidebar/reducers.js
+++ b/app/addons/documents/sidebar/reducers.js
@@ -12,11 +12,12 @@
 
 import React from 'react';
 import app from '../../../app';
+import Collection from '../../../core/data/collection';
 import Helpers from '../helpers';
 import ActionTypes from './actiontypes';
 
 const initialState = {
-  designDocs: new Backbone.Collection(),
+  designDocs: new Collection(),
   designDocList: [],
   selected: {
     navItem: 'all-docs',

--- a/app/addons/fauxton/api.js
+++ b/app/addons/fauxton/api.js
@@ -1,0 +1,18 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import Helpers from '../../helpers';
+import { get } from '../../core/ajax';
+
+export function fetchVersionInfo() {
+  return get(Helpers.getServerUrl('/'));
+}

--- a/app/addons/fauxton/base.js
+++ b/app/addons/fauxton/base.js
@@ -10,27 +10,26 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import app from '../../app';
 import FauxtonAPI from '../../core/api';
 import * as NavigationActions from './navigation/actions';
 import navigationReducers from './navigation/reducers';
 import notificationsReducer from './notifications/reducers';
+import { fetchVersionInfo } from './api';
 import './assets/less/fauxton.less';
 
 const Fauxton = FauxtonAPI.addon();
 
 Fauxton.initialize = () => {
-  const versionInfo = new Fauxton.VersionInfo();
-  versionInfo.fetch().then(function () {
-    NavigationActions.setNavbarVersionInfo(versionInfo.get('version'));
+  fetchVersionInfo().then(res => {
+    if (res.version) {
+      NavigationActions.setNavbarVersionInfo(res.version);
+    }
+  }).catch(() => {
+    // ignore
   });
 };
 
-Fauxton.VersionInfo = Backbone.Model.extend({
-  url: function () {
-    return app.host;
-  }
-});
+
 
 FauxtonAPI.addReducers({
   navigation: navigationReducers,

--- a/app/addons/replication/actions.js
+++ b/app/addons/replication/actions.js
@@ -276,10 +276,10 @@ export const deleteReplicates = (replicates) => dispatch => {
         escape: false,
         clear: true
       });
-    }, (xhr) => {
-      const errorMessage = JSON.parse(xhr.responseText);
+    }).catch(err => {
+      const errorMessage = err.responseJSON ? err.responseJSON.reason : 'Failed to delete replication.';
       FauxtonAPI.addNotification({
-        msg: errorMessage.reason,
+        msg: errorMessage,
         type: 'error',
         clear: true
       });

--- a/app/addons/verifyinstall/actions.js
+++ b/app/addons/verifyinstall/actions.js
@@ -29,9 +29,9 @@ const testPassed = function (test, dispatch) {
 
 let allTestsPassed = true;
 const testFailed = function (test, dispatch) {
-  return function (xhr) {
+  return function (err) {
     allTestsPassed = false;
-    if (!xhr) { return; }
+    if (!err) { return; }
 
     dispatch({
       type: ActionTypes.VERIFY_INSTALL_SINGLE_TEST_COMPLETE,
@@ -39,10 +39,10 @@ const testFailed = function (test, dispatch) {
       success: false
     });
     let reason = 'n/a';
-    if (xhr.responseText) {
-      reason = JSON.parse(xhr.responseText).reason;
-    } else if (xhr.message) {
-      reason = xhr.message;
+    if (err.responseJSON) {
+      reason = err.responseJSON.reason;
+    } else if (err.message) {
+      reason = err.message;
     }
     FauxtonAPI.addNotification({
       msg: 'Error: ' + reason,

--- a/app/addons/verifyinstall/resources.js
+++ b/app/addons/verifyinstall/resources.js
@@ -59,8 +59,8 @@ Verifyinstall.testProcess = {
         resolve();
       }).then(() => {
         resolve();
-      }, (xhr, error, reason) => {
-        reject(new Error(reason));
+      }, (err) => {
+        reject(err);
       });
     });
     return promise;
@@ -79,12 +79,7 @@ Verifyinstall.testProcess = {
       resolve = res;
       reject = rej;
     });
-    const getPromise = get(viewDoc.url() + '/_view/testview').then(res => {
-      if (res.error) {
-        throw new Error(res.reason || res.error);
-      }
-      return res;
-    });
+    const getPromise = get(viewDoc.url() + '/_view/testview').then(FauxtonAPI.throwIfCouchDbErrorResponse);
 
     getPromise.then(function (resp) {
       resp = _.isString(resp) ? JSON.parse(resp) : resp;
@@ -127,12 +122,7 @@ Verifyinstall.testProcess = {
     return post(
       Helpers.getServerUrl('/_replicate'),
       body
-    ).then(res => {
-      if (res.error) {
-        throw new Error(res.reason || res.error);
-      }
-      return res;
-    });
+    ).then(FauxtonAPI.throwIfCouchDbErrorResponse);
   },
 
   testReplicate: function () {

--- a/app/core/data/collection.js
+++ b/app/core/data/collection.js
@@ -1,0 +1,108 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import { sendRequest } from './helpers';
+import Model from './model';
+
+/**
+ * A replacement for Backbone.Collection that only depends on 'fetch' and 'Promise'.
+ * Note it's not intended to be a full replacement for Backbone. It only replicates
+ * the Backbone.Model functions required by Fauxton.
+ *
+ * @export
+ * @class Model
+ */
+export default class Collection {
+
+  models = [];
+
+  constructor(models, options) {
+    if (models) {
+      // shallow copy
+      this.models = models.slice(0);
+    }
+    this.initialize(models, options);
+  }
+
+  initialize() {
+    // default is a no-op
+  }
+
+  url() {
+    return '/';
+  }
+
+  fetch() {
+    const url = this.url();
+    return sendRequest(url).then(res => {
+      const parsedRes = this.parse(res);
+      this.models = parsedRes.map(obj => {
+        let newModel;
+        const options = { collection: this };
+        if (this.model) {
+          newModel = new this.model(obj, options);
+        } else {
+          newModel = new Model(obj, options);
+        }
+        return newModel;
+      });
+      return res;
+    });
+  }
+
+  parse(res) {
+    return res;
+  }
+
+  filter(fn) {
+    return this.models.filter(fn);
+  }
+
+  find(fn) {
+    return this.models.find(fn);
+  }
+
+  map(fn) {
+    return this.models.map(fn);
+  }
+
+  onRemove() {
+    // default is a no-op
+  }
+
+  toJSON() {
+    return this.models.map(obj => obj.toJSON());
+  }
+
+  add(models) {
+    const toAdd = Array.isArray(models) ? models : [models];
+    toAdd.forEach(modelToAdd => {
+      const idx = this.models.findIndex(el => el.id === modelToAdd.id);
+      //Only add if it's not part of the collection yet
+      if (idx === -1) {
+        modelToAdd.collection = this;
+        this.models.push(modelToAdd);
+      }
+    });
+  }
+
+  remove(models) {
+    const toRemove = Array.isArray(models) ? models : [models];
+    toRemove.forEach(modelToRemove => {
+      const idx = this.models.findIndex(el => el.id === modelToRemove.id);
+      if (idx > -1) {
+        this.models.splice(idx, 1);
+        this.onRemove();
+      }
+    });
+  }
+}

--- a/app/core/data/helpers.js
+++ b/app/core/data/helpers.js
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+export const sendRequest = (url, method = "GET", body) => {
+  const options = {
+    method,
+    credentials: "include",
+    headers: {
+      accept: "application/json",
+      "Content-Type": "application/json",
+      "Pragma":"no-cache"
+    },
+    cache: "no-cache",
+    body: body ? JSON.stringify(body) : undefined
+  };
+  return fetch(url, options).then(res => {
+    if (!res.ok) {
+      return res.text().then(errAsText => {
+        const err = new Error(errAsText);
+        // Add these fields for compatibility with XHR response that backbone uses
+        err.status = res.status;
+        err.responseText = errAsText;
+        try {
+          err.responseJSON = JSON.parse(errAsText);
+        } catch (e) {
+          //ignore
+        }
+        throw err;
+      });
+    }
+    return res.json();
+  });
+};
+
+export function isObject(value) {
+  return typeof value === 'object' && value !== null;
+}

--- a/app/core/data/model.js
+++ b/app/core/data/model.js
@@ -1,0 +1,138 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import { sendRequest, isObject } from './helpers';
+
+/**
+ * A replacement for Backbone.Model that only depends on 'fetch' and 'Promise'.
+ * Note it's not intended to be a full replacement for Backbone. It only replicates
+ * the Backbone.Model functions required by Fauxton.
+ *
+ * @export
+ * @class Model
+ */
+export default class Model {
+
+  attributes = {};
+  exists = false;
+  isDirty = false;
+
+  /**
+   *Creates an instance of Model.
+   * @param {*} attributes
+   * @param {*} [options={}]
+   * @memberof Model
+   */
+  constructor(attributes, options = {}) {
+    if (attributes) {
+      this.attributes = attributes;
+    }
+    if (options && options.collection) {
+      this.collection = options.collection;
+    }
+    this.initialize(attributes, options);
+  }
+
+  get id() {
+    if (this.idAttribute) {
+      return this.attributes[this.idAttribute];
+    }
+    return this.attributes.id;
+  }
+
+  initialize() {
+    // default is a no-op
+  }
+
+  isNew() {
+    return this.exists;
+  }
+
+  save() {
+    const url = this.url();
+    const method = this.isNew() ? 'POST' : 'PUT';
+    return sendRequest(url, method, this.attributes).then(res => {
+      if (res.ok) {
+        this.exists = true;
+        this.isDirty = false;
+      }
+      return res;
+    });
+  }
+
+  destroy() {
+    return sendRequest(this.url(), 'DELETE');
+  }
+
+  url() {
+    if (this.id) {
+      return '/' + encodeURIComponent(this.id);
+    }
+  }
+
+  fetch() {
+    const url = this.url();
+    if (url) {
+      return sendRequest(url).then(res => {
+        this.attributes = this.parse(res);
+        this.exists = true;
+        return res;
+      });
+    }
+    return Promise.reject(new Error('Model has an invalid url.'));
+  }
+
+  parse(data) {
+    return data;
+  }
+
+  get(propName) {
+    return this.attributes[propName];
+  }
+
+  set(arg1, arg2) {
+    if (typeof arg1 === 'string' && arg2 !== undefined && arg2 !== null) {
+      this.attributes[arg1] = arg2;
+      this.isDirty = true;
+    } else if (isObject(arg1)) {
+      Object.assign(this.attributes, arg1);
+      this.isDirty = true;
+    }
+  }
+
+  unset(propName) {
+    delete this.attributes[propName];
+  }
+
+  hasChanged() {
+    return this.isDirty;
+  }
+
+  clear() {
+    this.attributes = {};
+    this.exists = false;
+    this.isDirty = false;
+    return this;
+  }
+
+  on() {
+    // no-op
+  }
+
+  trigger() {
+    // no-op
+  }
+
+  toJSON() {
+    return this.attributes;
+  }
+}


### PR DESCRIPTION
## Overview

Introduces new classes `Model` and `Collection` to directly replace Backbone's `Model` and `Collection`. The new classes implement the main Backbone's methods (e.g. `save()` and  `destroy()`) using `fetch`. This provides a quick(er) way to remove the dependency with Backbone since most of the Fauxton code/logic that relies on Backbone models and collections can remain unchanged.

Summary of changes:
 - replaced all references to Backbone.Model/Collection with Model/Collection
 - it now uses `class extends Model` / `class extends Collection` instead of `Backbone.Model.extend` / `Backbone.Collection.extend`
 - callers now use `then/catch` (Promises) instead of `done/fail` (jQuery deferred).

 - Misc:
   - Replaced `Fauxton.VersionInfo` with a `fetch` call.
   - Removed unused classes: `BulkDeleteDocModel`, `BulkDeleteDocCollection`, `MangoBulkDeleteDocCollection`


## Testing recommendations

- Verify you can create, list, delete databases
- Verify you can list all docs, list view results
- Edit and save docs
- Edit and save views

## GitHub issue number


## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
