### PR TITLE
Fix - cannot edit docs with IDs starting with 'new'

### DIFF
--- a/app/addons/documents/routes-doc-editor.js
+++ b/app/addons/documents/routes-doc-editor.js
@@ -41,7 +41,8 @@ const DocEditorRouteObject = FauxtonAPI.RouteObject.extend({
     'database/:database/_design/:ddoc': 'showDesignDoc',
     'database/:database/_local/:doc': 'showLocalDoc',
     'database/:database/:doc': 'codeEditor',
-    'database/:database/new(:extra)': 'codeEditor'
+    'database/:database/new': 'codeEditor',
+    'database/:database/new?(:extra)': 'codeEditor'
   },
 
   revisionBrowser: function (databaseName, docId) {


### PR DESCRIPTION
## Overview

Fixes the doc editor router to avoid matching to any doc ID that starts with 'new'

## Testing recommendations

- Create a doc with ID 'newdoc'
- From the list of all docs, click on the newly created doc
- The doc editor should open successfully

