### PR TITLE
Enabled JSON and Table modes when querying partitioned views

### DIFF
--- a/app/addons/documents/__tests__/results-toolbar.test.js
+++ b/app/addons/documents/__tests__/results-toolbar.test.js
@@ -147,14 +147,14 @@ describe('Results Toolbar', () => {
     expect(wrapper.find('button')).toHaveLength(4);
   });
 
-  it('hides Table and JSON modes when querying a partitioned view', () => {
+  it('shows Table, Metadata and JSON modes when querying a partitioned view', () => {
     const wrapper = mount(<ResultsToolBar
       {...defaultProps}
       hasResults={true}
       isListDeletable={false}
       partitionKey={'partKey1'}
       fetchUrl='/my_db/_partition/my_partition/_design/ddoc1/_view/view1'/>);
-    expect(wrapper.find('button')).toHaveLength(2);
+    expect(wrapper.find('button')).toHaveLength(4);
   });
 
   it('shows Table, Metadata and JSON modes when showing All Documents filtered by partition', () => {

--- a/app/addons/documents/header/header.js
+++ b/app/addons/documents/header/header.js
@@ -24,7 +24,6 @@ export default class BulkDocumentHeaderController extends React.Component {
       selectedLayout,
       docType,
       queryOptionsParams,
-      partitionKey,
       fetchUrl
     } = this.props;
 
@@ -42,10 +41,9 @@ export default class BulkDocumentHeaderController extends React.Component {
 
     // Reduce doesn't allow for include_docs=true, so we'll hide the JSON and table modes
     // since they force 'include_docs=true' when reduce is checked in the query options panel.
-    // Partitioned views don't support 'include_docs=true' either.
     const isAllDocsQuery = fetchUrl && fetchUrl.includes('/_all_docs');
     const isMangoQuery = docType === Constants.INDEX_RESULTS_DOC_TYPE.MANGO_QUERY;
-    if (isAllDocsQuery || isMangoQuery || (!queryOptionsParams.reduce && !partitionKey)) {
+    if (isAllDocsQuery || isMangoQuery || (!queryOptionsParams.reduce)) {
       table = <Button
         className={selectedLayout === Constants.LAYOUT_ORIENTATION.TABLE ? 'active' : ''}
         onClick={this.toggleLayout.bind(this, Constants.LAYOUT_ORIENTATION.TABLE)}

--- a/app/addons/documents/index-results/api.js
+++ b/app/addons/documents/index-results/api.js
@@ -50,7 +50,6 @@ export const queryMapReduceView = (fetchUrl, params) => {
   // removes params not supported by partitioned views
   const isPartitioned = fetchUrl.includes('/_partition/');
   if (isPartitioned) {
-    params.include_docs = undefined;
     params.stable = undefined;
     params.conflicts = undefined;
   }
@@ -63,7 +62,7 @@ export const queryMapReduceView = (fetchUrl, params) => {
     return {
       docs: json.rows,
       docType: Constants.INDEX_RESULTS_DOC_TYPE.VIEW,
-      layout: isPartitioned ? Constants.LAYOUT_ORIENTATION.METADATA : undefined
+      layout: undefined
     };
   });
 };


### PR DESCRIPTION
## Overview

Now that include_docs is supported on partitioned views, we can remove the restriction in the dashboard that limits partitioned views results to be displayed only on the Metadata mode.

## Testing recommendations

- Create a partitioned view, then click on the view
- Verify the Table, Metadata and JSON display modes work

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
