### PR TITLE
Show icons to identify global vs partitioned mango indexes

### DIFF
--- a/app/addons/components/__tests__/doc.test.js
+++ b/app/addons/components/__tests__/doc.test.js
@@ -142,4 +142,40 @@ describe('Document', () => {
     expect(el.find('.doc-content-truncated').length).toBe(0);
   });
 
+  it('shows icon only for docs with type MangoIndex', () => {
+    const index = {
+      type: "json",
+      def: { fields: [{ foo: "asc" }] }
+    };
+    const content = JSON.stringify(index, null, '  ');
+    const elMangoIndex = mount(
+      <ReactComponents.Document docChecked={noop} header="foo" isDeletable={true}
+        checked={false} docIdentifier="foo" docContent={content}
+        truncate={false} docType="MangoIndex"/>
+    );
+    expect(elMangoIndex.find('i.fonticon-document').exists()).toBe(true);
+
+    const elRegularDoc = mount(
+      <ReactComponents.Document docChecked={noop} header="foo" isDeletable={true}
+        checked={false} docIdentifier="foo" docContent={content}
+        truncate={false} docType="view"/>
+    );
+    expect(elRegularDoc.find('i.fonticon-documents').exists()).toBe(false);
+  });
+
+  it('shows icon for partitioned mango index', () => {
+    const index = {
+      type: "json",
+      partitioned: true,
+      def: { fields: [{ foo: "asc" }] }
+    };
+    const content = JSON.stringify(index, null, '  ');
+    const elMangoIndex = mount(
+      <ReactComponents.Document docChecked={noop} header="foo" isDeletable={true}
+        checked={false} docIdentifier="foo" docContent={content}
+        truncate={false} docType="MangoIndex"/>
+    );
+    expect(elMangoIndex.find('i.fonticon-documents').exists()).toBe(true);
+  });
+
 });

--- a/app/addons/components/components/document.js
+++ b/app/addons/components/components/document.js
@@ -20,6 +20,7 @@ import Helpers from '../../documents/helpers';
 export class Document extends React.Component {
   static propTypes = {
     docIdentifier: PropTypes.string.isRequired,
+    docType: PropTypes.string,
     docChecked: PropTypes.func.isRequired,
     truncate: PropTypes.bool,
     maxRows: PropTypes.number,
@@ -31,7 +32,8 @@ export class Document extends React.Component {
     maxRows: 500,
     resultsStyle: {
       fontSize: Constants.INDEX_RESULTS_STYLE.FONT_SIZE_MEDIUM
-    }
+    },
+    docType: Constants.INDEX_RESULTS_DOC_TYPE.VIEW
   };
 
   onChange = (e) => {
@@ -56,6 +58,16 @@ export class Document extends React.Component {
     return _.map(extensions, (Extension, i) => {
       return (<Extension doc={this.props.doc} key={i} />);
     });
+  };
+
+  getDocumentTypeIcon = () => {
+    if (this.props.docType === Constants.INDEX_RESULTS_DOC_TYPE.MANGO_INDEX) {
+      if (this.props.docContent.includes(`"partitioned": true`)) {
+        return <i className="fonticon-documents" title="Partitioned index"></i>;
+      }
+      return <i className="fonticon-document" title="Global index"></i>;
+    }
+    return null;
   };
 
   getCheckbox = () => {
@@ -118,6 +130,7 @@ export class Document extends React.Component {
         <div className="doc-item">
           <header onClick={this.onClick}>
             <span className="header-keylabel">
+              {this.getDocumentTypeIcon()}
               {this.props.keylabel}
             </span>
             <span className="header-doc-id">

--- a/app/addons/documents/index-results/components/results/ResultsScreen.js
+++ b/app/addons/documents/index-results/components/results/ResultsScreen.js
@@ -51,8 +51,8 @@ export default class ResultsScreen extends React.Component {
   }
 
   getDocumentList () {
-    let noop = () => {};
-    let data = this.props.results.results;
+    const noop = () => {};
+    const data = this.props.results.results;
     return _.map(data, (doc, i) => {
       return (
         <Document
@@ -61,6 +61,7 @@ export default class ResultsScreen extends React.Component {
           onClick={this.props.isEditable ? this.onClick : noop}
           keylabel={doc.keylabel}
           docContent={doc.content}
+          docType={this.props.docType}
           checked={this.props.isSelected(doc.id)}
           header={doc.header}
           docChecked={this.props.docChecked}


### PR DESCRIPTION
## Overview

When listing mango indexes, each entry now has an icon to identify between global vs partitioned indexes. 
For consistency, it uses the same icons displayed for global/partitioned design docs.

## Testing recommendations

- Create two mango indexes, one global and another partitioned
- Verify each of them display a different icon, and its tooltip correctly identifies the index type

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;

