### PR TITLE
Scope docs search to selected partition key

### DIFF
--- a/app/addons/components/components/throttledreacselect.js
+++ b/app/addons/components/components/throttledreacselect.js
@@ -19,8 +19,6 @@ export class ThrottledReactSelectAsync extends React.Component {
   constructor(props) {
     super(props);
     this.lastCall = undefined;
-    const { loadOptions } = props;
-    this.throttledLoadOptions = this.wrapThrottler(loadOptions).bind(this);
   }
 
   wrapThrottler(loadOptions) {
@@ -38,9 +36,12 @@ export class ThrottledReactSelectAsync extends React.Component {
   }
 
   render() {
+    // wrapThrottler() must be called here to ensure a new
+    // function is created when props.loadOptions is updated
+    const throttledLoadOptions = this.wrapThrottler(this.props.loadOptions).bind(this);
     const newProps = {
       ...this.props,
-      loadOptions: this.throttledLoadOptions
+      loadOptions: throttledLoadOptions
     };
     return (
       <ReactSelect.Async {...newProps} />

--- a/app/addons/documents/components/actions.js
+++ b/app/addons/documents/components/actions.js
@@ -14,11 +14,12 @@ import FauxtonAPI from "../../../core/api";
 import { get } from "../../../core/ajax";
 
 export default {
-  fetchAllDocsWithKey: (database) => {
+  fetchAllDocsWithKey: (database, partitionKey) => {
+    const keyPrefix = partitionKey ? `${partitionKey}:` : "";
     return (id, callback) => {
       const query = '?' + app.utils.queryParams({
-        startkey: JSON.stringify(id),
-        endkey: JSON.stringify(id + "\u9999"),
+        startkey: JSON.stringify(keyPrefix + id),
+        endkey: JSON.stringify(keyPrefix + id + "\u9999"),
         limit: 30
       });
 

--- a/app/addons/documents/components/header-docs-right.js
+++ b/app/addons/documents/components/header-docs-right.js
@@ -17,13 +17,20 @@ import QueryOptionsContainer from '../index-results/containers/QueryOptionsConta
 import JumpToDoc from './jumptodoc';
 import Actions from './actions';
 
-const RightAllDocsHeader = ({database, hideQueryOptions, hideJumpToDoc, queryDocs, ddocsOnly, selectedNavItem}) =>
+const RightAllDocsHeader = ({database, hideQueryOptions, hideJumpToDoc, queryDocs, ddocsOnly, selectedNavItem, partitionKey}) =>
   <div className="header-right right-db-header flex-layout flex-row">
 
     <div className="faux-header__searchboxwrapper">
       <div className="faux-header__searchboxcontainer">
         {hideJumpToDoc ? null :
-          <JumpToDoc cache={false} loadOptions={Actions.fetchAllDocsWithKey(database)} database={database} /> }
+          <JumpToDoc
+            // 'key' is set to force mounting a new component when the partition key changes
+            // otherwise the internal ReactSelect doesn't reload the options even though
+            // it loadOptions is assigned a new function
+            key={JSON.stringify(database + partitionKey)}
+            cache={false}
+            loadOptions={Actions.fetchAllDocsWithKey(database, partitionKey)}
+            database={database} /> }
       </div>
     </div>
     {hideQueryOptions ? null :
@@ -35,7 +42,8 @@ RightAllDocsHeader.propTypes = {
   hideQueryOptions: PropTypes.bool,
   isRedux: PropTypes.bool,
   queryDocs: PropTypes.func,
-  selectedNavItem: PropTypes.object
+  selectedNavItem: PropTypes.object,
+  partitionKey: PropTypes.string
 };
 
 RightAllDocsHeader.defaultProps = {


### PR DESCRIPTION
## Overview

The Document Search dropdown isn’t scoped to the selected partition, which can be confusing to the user.

This PR changes that so when a partition is selected, the dropdown options are updated. Similarly, when typing a doc ID, the search results are constrained to docs in the selected partition.

## Testing recommendations

- Create some documents in a partition "foo" and another partition "bar"
- Use the selector at the top to select partition "foo"
- Click the Document Search dropdown
  - Verify the list contains only docs from "foo"
- Type a doc id
  - Verify the search results contains only docs from "foo"
- Click the partition selector to switch back to "No partition selected"
  - Verify the dropdown options list all docs


