### PR TITLE
Fix: display warning when partition is selected for a global view

### DIFF
--- a/app/addons/documents/index-results/actions/fetch.js
+++ b/app/addons/documents/index-results/actions/fetch.js
@@ -103,7 +103,7 @@ export const fetchDocs = (queryDocs, fetchParams, queryOptionsParams) => {
       // dispatch that we're all done
       dispatch(newResultsAvailable(finalDocList, params, canShowNext, docType, executionStats, warning));
     }).catch((error) => {
-      if (error && error.message.includes('partition query is not supported')) {
+      if (error && error.message.includes('`partition` parameter is not supported')) {
         dispatch(partitionParamNotSupported());
       } else if (error && error.message.includes('`partition` parameter is mandatory')) {
         dispatch(partitionParamIsMandatory());


### PR DESCRIPTION
## Overview

Display a warning message when a partition key is selected and the user tries to access a global view. Currently Fauxton is displaying an error which is incorrect.

## Testing recommendations

1. In a partitioned database
2. Create a new global (non-partitioned) view
3. Click on the view
4. Results are displayed
5. Select a partition at the top
6. An empty results page is displayed with a warning

## GitHub issue number

Fixes #1183 

## Checklist

- [x] Code is written and works correctly;
