### PR TITLE
Don't change the browser default for Ctrl + L

### DIFF
--- a/app/addons/components/components/codeeditor.js
+++ b/app/addons/components/components/codeeditor.js
@@ -45,6 +45,11 @@ export class CodeEditor extends React.Component {
 
     // optional editor key commands (e.g. specific save action)
     editorCommands: [],
+    
+    extraKeys: {
+      "Cmd+L" -> null,
+      "Ctrl+L" -> null
+    },
 
     // notifies users that there is unsaved changes in the editor when navigating away from the page
     notifyUnsavedChanges: false,


### PR DESCRIPTION
Ctrl + L or Cmd + L is the shortcut to jump to the address bar. Codemirror shows a jump to line prompt. I personally prefer to jump to the address bar.

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
