### PR TITLE
Avoid overriding Browser's default in CodeEditor

### DIFF
--- a/app/addons/components/components/codeeditor.js
+++ b/app/addons/components/components/codeeditor.js
@@ -81,6 +81,14 @@ export class CodeEditor extends React.Component {
   setupAce = (props, shouldUpdateCode) => {
     this.editor = ace.edit(this.ace);
 
+    // see https://github.com/ajaxorg/ace/issues/36 don't steal browser's default keybinding
+    this.editor.commands.bindKeys(
+      {
+        "Ctrl-L|Command-L": null,
+        "Ctrl-Shift-L|Command-Shift-L": "gotoline"
+      }
+    );
+
     // suppresses an Ace editor error
     this.editor.$blockScrolling = Infinity;
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
