### PR TITLE
Fix db url in fetchDatabaseInfo()

### DIFF
--- a/app/addons/databases/api.js
+++ b/app/addons/databases/api.js
@@ -12,10 +12,8 @@
 
 import FauxtonAPI from '../../core/api';
 import { get } from '../../core/ajax';
-import Helpers from '../../helpers';
 
 export const fetchDatabaseInfo = (databaseName) => {
-  const base = FauxtonAPI.urls('databaseBaseURL', 'server', databaseName);
-  const url = Helpers.getServerUrl(base);
+  const url = FauxtonAPI.urls('databaseBaseURL', 'server', databaseName);
   return get(url);
 };


### PR DESCRIPTION
## Overview

`fetchDatabaseInfo()` is incorrectly generating the URL one level too high, which affects deployments behind a reverse proxy using a relative path (e.g. http://localhost:8080/couchdb/) instead of the default root (i.e. http://localhost:8080/).

## Testing recommendations

- Access Fauxton through a reverse proxy under a relative URL. 
- Click on a database
- Verify the documents list and left nav bar loads correctly


FYI, on my tests I used nginx with the following config:
```
        #proxy to dev Fauxton server. Open http://localhost:8080/fauxton-dev/ on your browser
        location /fauxton-dev {
            rewrite /fauxton-dev(.*) /$1 break;
            # dev server URL
            proxy_pass http://localhost:8000;
            proxy_redirect off;
            proxy_buffering off;
            proxy_set_header Host $host;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        }
```

## GitHub issue number

Fixes #1188 
Fixes #1189 

