### PR TITLE
Fix all docs JSON link when partition is selected

### DIFF
--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -66,6 +66,9 @@ FauxtonAPI.registerUrls('allDocs', {
 FauxtonAPI.registerUrls('partitioned_allDocs', {
   app: function (databaseName, partitionKey, query) {
     return 'database/' + databaseName + '/_partition/' + partitionKey + '/_all_docs' + getQueryParam(query);
+  },
+  apiurl: function (databaseName, partitionKey, query) {
+    return Helpers.getApiUrl('/' + databaseName + '/_partition/' + partitionKey + '/_all_docs' + getQueryParam(query));
   }
 });
 

--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -117,7 +117,9 @@ var DocumentsRouteObject = BaseRoute.extend({
     const selectedNavItem = new SidebarItemSelection(tab);
     ComponentsActions.showDeleteDatabaseModal({showDeleteModal: false, dbId: ''});
 
-    const endpoint = this.database.allDocs.urlRef("apiurl", {});
+    const endpoint = partitionKey ?
+      FauxtonAPI.urls('partitioned_allDocs', 'apiurl', encodeURIComponent(databaseName), encodeURIComponent(partitionKey)) :
+      this.database.allDocs.urlRef("apiurl", {});
     const docURL = FauxtonAPI.constants.DOC_URLS.GENERAL;
     const navigateToPartitionedAllDocs = (partKey) => {
       const baseUrl = FauxtonAPI.urls('partitioned_allDocs', 'app', encodeURIComponent(databaseName),


### PR DESCRIPTION
## Overview

Fix all docs JSON link when partition is selected

## Testing recommendations

- Go to All Documents page
- Click the `{} JSON` icon and verify it points to `/<db>/_all_docs`
- Select a partition
- Click the `{} JSON` icon and verify it points to `/<db>/_partition/<partition>/_all_docs`

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
