### PR TITLE
Use partitioned query for all docs

### DIFF
--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -69,6 +69,9 @@ FauxtonAPI.registerUrls('partitioned_allDocs', {
   },
   apiurl: function (databaseName, partitionKey, query) {
     return Helpers.getApiUrl('/' + databaseName + '/_partition/' + partitionKey + '/_all_docs' + getQueryParam(query));
+  },
+  server: function (databaseName, partitionKey, query) {
+    return Helpers.getServerUrl('/' + databaseName + '/_partition/' + partitionKey + '/_all_docs' + getQueryParam(query));
   }
 });
 

--- a/app/addons/documents/components/actions.js
+++ b/app/addons/documents/components/actions.js
@@ -15,15 +15,16 @@ import { get } from "../../../core/ajax";
 
 export default {
   fetchAllDocsWithKey: (database, partitionKey) => {
-    const keyPrefix = partitionKey ? `${partitionKey}:` : "";
     return (id, callback) => {
       const query = '?' + app.utils.queryParams({
-        startkey: JSON.stringify(keyPrefix + id),
-        endkey: JSON.stringify(keyPrefix + id + "\u9999"),
+        startkey: JSON.stringify(id),
+        endkey: JSON.stringify(id + "\u9999"),
         limit: 30
       });
 
-      const url = FauxtonAPI.urls('allDocs', 'server', database.safeID(), query);
+      const url = partitionKey ?
+        FauxtonAPI.urls('partitioned_allDocs', 'server', database.safeID(), encodeURIComponent(partitionKey), query) :
+        FauxtonAPI.urls('allDocs', 'server', database.safeID(), query);
       get(url).then(res => {
         let options = [];
         if (!res.error) {

--- a/app/addons/documents/index-results/api.js
+++ b/app/addons/documents/index-results/api.js
@@ -19,10 +19,6 @@ import FauxtonAPI from '../../../core/api';
 export const queryAllDocs = (fetchUrl, partitionKey, params) => {
   // Exclude params 'group', 'reduce' and 'group_level' if present since they not allowed for '_all_docs'
   Object.assign(params, {reduce: undefined, group: undefined, group_level: undefined});
-  if (partitionKey) {
-    // partition filter overrides any 'between keys' values set
-    Object.assign(params, {inclusive_end: false, start_key: `"${partitionKey}:"`, end_key: `"${partitionKey}:\ufff0"`});
-  }
   const query = app.utils.queryString(params);
   const url = `${fetchUrl}${fetchUrl.includes('?') ? '&' : '?'}${query}`;
   return get(url).then(json => {

--- a/app/addons/documents/routes-documents.js
+++ b/app/addons/documents/routes-documents.js
@@ -103,7 +103,9 @@ var DocumentsRouteObject = BaseRoute.extend({
     const params = this.createParams(options);
     const docParams = params.docParams;
 
-    const url = FauxtonAPI.urls('allDocsSanitized', 'server', databaseName);
+    const url = partitionKey ?
+      FauxtonAPI.urls('partitioned_allDocs', 'server', encodeURIComponent(databaseName), encodeURIComponent(partitionKey)) :
+      FauxtonAPI.urls('allDocsSanitized', 'server', databaseName);
 
     // this is used for the header and sidebar
     this.database.buildAllDocs(docParams);


### PR DESCRIPTION
## Overview

The All Documents query was using `startkey` and `endkey` parameters when a partition is selected. This was done because support for `/<db>/_partition/<key>/_all_docs` was added after this feature was implemented in Fauxton.

This PR changes the All Documents query to use `/<db>/_partition/<key>/_all_docs` when a partition is selected. The same was done for the query that populates the Document Search combobox.

## Testing recommendations

- Go to All Documents page and select a partition
  - Use the DevTools to verify the network request was made to `/<db>/_partition/<key>/_all_docs`
  - Verify only the docs for the selected partition are displayed
  - Verify the Document Search combobox only lists docs for the selected partition

