### PR TITLE
Applied css fix to align create doc btn text when it becomes two lines

### DIFF
--- a/app/addons/documents/assets/less/index-results.less
+++ b/app/addons/documents/assets/less/index-results.less
@@ -71,14 +71,9 @@
 }
 
 .document-result-screen__toolbar-create-btn {
+  display: flex;
+  align-items: center;
   height: 42px;
-}
-
-// Fixes text centering when it goes from a one line to two
-@media (max-width: 965px) {
-  .document-result-screen__toolbar-create-btn {
-    line-height: 12px;
-  }
 }
 
 a.document-result-screen__toolbar-create-btn:active,

--- a/app/addons/documents/assets/less/index-results.less
+++ b/app/addons/documents/assets/less/index-results.less
@@ -74,6 +74,13 @@
   height: 42px;
 }
 
+// Fixes text centering when it goes from a one line to two
+@media (max-width: 965px) {
+  .document-result-screen__toolbar-create-btn {
+    line-height: 12px;
+  }
+}
+
 a.document-result-screen__toolbar-create-btn:active,
 a.document-result-screen__toolbar-create-btn:visited {
   color: #fff;


### PR DESCRIPTION
# Overview

On a certain screen size the create document button text gets cut off when it goes from one line to two lines. This is a fix to center it appropriately. 

# Github Issue

Addresses one of many issues in #998 

# Checklist

- [x] - Code works correct;
- [x] - Changes are covered by tests (styling issue, so not needed in this project)