### PR TITLE
Remove deprecated size properties from .info()

### DIFF
--- a/app/addons/databases/__tests__/components.test.js
+++ b/app/addons/databases/__tests__/components.test.js
@@ -116,7 +116,7 @@ describe('DatabaseTable', () => {
   beforeEach(() => {
     Actions.updateDatabases({
       dbList: ['db1'],
-      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0}],
+      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0, sizes: {}}],
       failedDbs: ['db1'],
       fullDbList: ['db1']
     });
@@ -165,7 +165,7 @@ describe('DatabaseTable', () => {
 
     Actions.updateDatabases({
       dbList: ['db1'],
-      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0}],
+      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0, sizes: {}}],
       failedDbs: [],
       fullDbList: ['db1']
     });
@@ -188,7 +188,7 @@ describe('DatabaseTable', () => {
   it('shows error message if row marked as failed to load', () => {
     Actions.updateDatabases({
       dbList: ['db1'],
-      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0}],
+      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0, sizes: {}}],
       failedDbs: ['db1'],
       fullDbList: ['db1']
     });
@@ -204,7 +204,7 @@ describe('DatabaseTable', () => {
   it('shows no error if row marked as loaded', () => {
     Actions.updateDatabases({
       dbList: ['db1'],
-      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0}],
+      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0, sizes: {}}],
       failedDbs: [],
       fullDbList: ['db1']
     });
@@ -221,7 +221,7 @@ describe('DatabaseTable', () => {
   it('shows Partitioned column only when prop is set to true', () => {
     Actions.updateDatabases({
       dbList: ['db1'],
-      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0, props: {partitioned: true}}],
+      databaseDetails: [{db_name: 'db1', doc_count: 0, doc_del_count: 0, sizes:{}, props: {partitioned: true}}],
       failedDbs: [],
       fullDbList: ['db1']
     });
@@ -245,8 +245,8 @@ describe('DatabaseTable', () => {
     Actions.updateDatabases({
       dbList: ['db1', 'db2'],
       databaseDetails: [
-        {db_name: 'db1', doc_count: 1, doc_del_count: 0, props: {partitioned: true}},
-        {db_name: 'db2', doc_count: 2, doc_del_count: 0, props: {partitioned: false}}
+        {db_name: 'db1', doc_count: 1, doc_del_count: 0, sizes: {}, props: {partitioned: true}},
+        {db_name: 'db2', doc_count: 2, doc_del_count: 0, sizes: {}, props: {partitioned: false}}
       ],
       failedDbs: [],
       fullDbList: ['db1', 'db2']

--- a/app/addons/databases/__tests__/stores.test.js
+++ b/app/addons/databases/__tests__/stores.test.js
@@ -27,7 +27,7 @@ describe('Databases Store', function () {
     it('marks failed detail fetches as failed dbs', () => {
       DatabaseActions.updateDatabases({
         dbList: ['db1', 'db2'],
-        databaseDetails: [{db_name: 'db1'}, {db_name: 'db2'}],
+        databaseDetails: [{db_name: 'db1', sizes: {}}, {db_name: 'db2', sizes: {}}],
         failedDbs: ['db1']
       });
 
@@ -39,7 +39,7 @@ describe('Databases Store', function () {
     it('unions details', () => {
       DatabaseActions.updateDatabases({
         dbList: ['db1'],
-        databaseDetails: [{db_name: 'db1', doc_count: 5, doc_del_count: 3}],
+        databaseDetails: [{db_name: 'db1', doc_count: 5, doc_del_count: 3, sizes: {}}],
         failedDbs: []
       });
 
@@ -60,15 +60,18 @@ describe('Databases Store', function () {
       expect(!store.doesDatabaseExist('db3')).toBeTruthy();
     });
 
-    it('uses the data_size prop', () => {
+    it('uses the sizes.active prop', () => {
       DatabaseActions.updateDatabases({
         dbList: ['db1'],
         databaseDetails: [{
           db_name: 'db1',
           doc_count: 5,
           doc_del_count: 3,
-          data_size: 1337,
-          disk_size: 0
+          sizes: {
+            active: 1337,
+            external: 0,
+            file: 0,
+          }
         }],
         failedDbs: []
       });

--- a/app/addons/databases/stores.js
+++ b/app/addons/databases/stores.js
@@ -113,7 +113,7 @@ const DatabasesStoreConstructor = FauxtonAPI.Store.extend({
       return {};
     }
     const {sizes} = details;
-    const dataSize = sizes.active || details.file || 0;
+    const dataSize = sizes.active || 0;
 
     return {
       dataSize: Helpers.formatSize(dataSize),

--- a/app/addons/databases/stores.js
+++ b/app/addons/databases/stores.js
@@ -112,7 +112,8 @@ const DatabasesStoreConstructor = FauxtonAPI.Store.extend({
     if (!details) {
       return {};
     }
-    const dataSize = details.data_size || details.disk_size || 0;
+    const {sizes} = details;
+    const dataSize = sizes.active || details.file || 0;
 
     return {
       dataSize: Helpers.formatSize(dataSize),

--- a/app/addons/documents/designdocinfo/components/DesignDocInfo.js
+++ b/app/addons/documents/designdocinfo/components/DesignDocInfo.js
@@ -58,7 +58,7 @@ export default class DesignDocInfo extends React.Component {
     const viewIndex = this.props.viewIndex;
     const {sizes} = viewIndex;
     const actualSize = (sizes.active) ? sizes.active.toLocaleString('en') : 0;
-    const dataSize = (sizes.file) ? sizes.file.toLocaleString('en') : 0;
+    const dataSize = (sizes.external) ? sizes.external.toLocaleString('en') : 0;
 
     return (
       <div className="metadata-page">

--- a/app/addons/documents/designdocinfo/components/DesignDocInfo.js
+++ b/app/addons/documents/designdocinfo/components/DesignDocInfo.js
@@ -56,8 +56,9 @@ export default class DesignDocInfo extends React.Component {
       return <LoadLines />;
     }
     const viewIndex = this.props.viewIndex;
-    const actualSize = (viewIndex.data_size) ? viewIndex.data_size.toLocaleString('en') : 0;
-    const dataSize = (viewIndex.disk_size) ? viewIndex.disk_size.toLocaleString('en') : 0;
+    const {sizes} = viewIndex;
+    const actualSize = (sizes.active) ? sizes.active.toLocaleString('en') : 0;
+    const dataSize = (sizes.file) ? sizes.file.toLocaleString('en') : 0;
 
     return (
       <div className="metadata-page">


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Replace deprecated size properties with the new ones.
<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
