### PR TITLE
Fixed stack ordering of absolute positioned no results view

### DIFF
--- a/app/addons/documents/assets/less/index-results.less
+++ b/app/addons/documents/assets/less/index-results.less
@@ -13,11 +13,10 @@
 @import "../../../../../assets/less/variables.less";
 
 .document-result-screen {
-
   .loading-lines-wrapper {
     margin-left: auto;
     margin-right: auto;
-    width:  80px;
+    width: 80px;
   }
 
   .loading-lines {
@@ -28,6 +27,7 @@
 .document-result-screen__toolbar {
   display: flex;
   padding-bottom: 20px;
+  position: relative;
 
   .bulk-action-component {
     min-width: 90px;
@@ -41,12 +41,11 @@
     padding: 8px 0;
   }
 
-  .toolbar-dropdown {    
-    
+  .toolbar-dropdown {
     .btn {
       color: #666;
     }
-    
+
     .dropdown-menu.arrow:before {
       right: 80%;
     }
@@ -63,7 +62,6 @@
       }
     }
   }
-  
 }
 
 .document-result-screen__toolbar-flex-container {
@@ -101,11 +99,12 @@ a.document-result-screen__toolbar-create-btn:visited {
     text-align: center;
     i {
       padding-right: 0.5rem;
-    } 
+    }
   }
 }
 .watermark-logo {
-  background: transparent url('../../../../../assets/img/couch-watermark.png') no-repeat 50% 50%;
+  background: transparent url("../../../../../assets/img/couch-watermark.png")
+    no-repeat 50% 50%;
   height: 205px;
   text-align: center;
   margin: 0 20%;
@@ -116,7 +115,6 @@ a.document-result-screen__toolbar-create-btn:visited {
 
 .table-view-docs {
   position: absolute;
-
 
   .bulk-action-component {
     padding-bottom: 0;
@@ -150,13 +148,16 @@ a.document-result-screen__toolbar-create-btn:visited {
       }
     }
   }
-  td, th, td a {
+  td,
+  th,
+  td a {
     vertical-align: middle;
     line-height: 20px;
     font-size: 0.875rem;
   }
 
-  td, th {
+  td,
+  th {
     color: @defaultHTag;
     max-width: 160px;
     overflow: hidden;
@@ -175,16 +176,17 @@ a.document-result-screen__toolbar-create-btn:visited {
       font-size: 1rem;
     }
   }
-  td.tableview-checkbox-cell, th.tableview-header-el-checkbox {
+  td.tableview-checkbox-cell,
+  th.tableview-header-el-checkbox {
     width: 35px;
     padding-left: 0px;
   }
   .tableview-conflict {
-    color: #F00;
+    color: #f00;
   }
   .icon-code-fork {
     padding-right: 2px;
-    color: #F00;
+    color: #f00;
   }
   .tableview-el-last {
     width: 75px;
@@ -235,7 +237,6 @@ a.document-result-screen__toolbar-create-btn:visited {
 }
 
 .document-result-screen {
-
   .table-bulkselector-section {
     .bulk-action-component {
       float: left;

--- a/app/addons/documents/index-results/components/results/ResultsScreen.js
+++ b/app/addons/documents/index-results/components/results/ResultsScreen.js
@@ -10,36 +10,36 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import React from 'react';
-import FauxtonAPI from '../../../../../core/api';
-import Constants from '../../../constants';
+import React from "react";
+import FauxtonAPI from "../../../../../core/api";
+import Constants from "../../../constants";
 import Components from "../../../../components/react-components";
-import {ResultsToolBar} from "../../../components/results-toolbar";
-import NoResultsScreen from './NoResultsScreen';
-import TableView from './TableView';
+import { ResultsToolBar } from "../../../components/results-toolbar";
+import NoResultsScreen from "./NoResultsScreen";
+import TableView from "./TableView";
 
 const { LoadLines, Document } = Components;
 
 export default class ResultsScreen extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props);
   }
 
-  componentDidMount () {
+  componentDidMount() {
     prettyPrint();
   }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     prettyPrint();
   }
 
-  onClick (id, doc) {
+  onClick(id, doc) {
     if (doc.url) {
       FauxtonAPI.navigate(doc.url);
     }
   }
 
-  getUrlFragment (url) {
+  getUrlFragment(url) {
     if (!this.props.isEditable) {
       return null;
     }
@@ -47,10 +47,11 @@ export default class ResultsScreen extends React.Component {
     return (
       <a href={url}>
         <i className="fonticon-pencil"></i>
-      </a>);
+      </a>
+    );
   }
 
-  getDocumentList () {
+  getDocumentList() {
     const noop = () => {};
     const data = this.props.results.results;
     return _.map(data, (doc, i) => {
@@ -67,30 +68,29 @@ export default class ResultsScreen extends React.Component {
           docChecked={this.props.docChecked}
           isDeletable={doc.isDeletable}
           docIdentifier={doc.id}
-          resultsStyle={this.props.resultsStyle} >
-          {doc.url ? this.getUrlFragment('#' + doc.url) : doc.url}
+          resultsStyle={this.props.resultsStyle}
+        >
+          {doc.url ? this.getUrlFragment("#" + doc.url) : doc.url}
         </Document>
       );
     });
   }
 
-  getDocumentStyleView () {
-    let classNames = 'view';
+  getDocumentStyleView() {
+    let classNames = "view";
 
     if (this.props.isListDeletable) {
-      classNames += ' show-select';
+      classNames += " show-select";
     }
 
     return (
       <div className={classNames}>
-        <div id="doc-list">
-          {this.getDocumentList()}
-        </div>
+        <div id="doc-list">{this.getDocumentList()}</div>
       </div>
     );
   }
 
-  getTableStyleView () {
+  getTableStyleView() {
     return (
       <div>
         <TableView
@@ -100,28 +100,37 @@ export default class ResultsScreen extends React.Component {
           isListDeletable={this.props.isListDeletable}
           data={this.props.results}
           isLoading={this.props.isLoading}
-
           removeItem={this.props.removeItem}
           isChecked={this.props.allDocumentsSelected}
           hasSelectedItem={this.props.hasSelectedItem}
           toggleSelect={this.toggleSelectAll}
           changeField={this.props.changeTableHeaderAttribute}
           resultsStyle={this.props.resultsStyle}
-          title="Select all docs that can be..." />
+          title="Select all docs that can be..."
+        />
       </div>
     );
   }
 
-  render () {
+  render() {
     let mainView = null;
+    let noResultsView = null;
 
     if (this.props.isLoading) {
-      mainView = <div className="loading-lines-wrapper"><LoadLines /></div>;
+      mainView = (
+        <div className="loading-lines-wrapper">
+          <LoadLines />
+        </div>
+      );
     } else if (this.props.noResultsWarning) {
-      mainView = <NoResultsScreen text={this.props.noResultsWarning} isWarning={true}/>;
+      noResultsView = (
+        <NoResultsScreen text={this.props.noResultsWarning} isWarning={true} />
+      );
     } else if (!this.props.hasResults) {
-      mainView = <NoResultsScreen text={this.props.textEmptyIndex}/>;
-    } else if (this.props.selectedLayout === Constants.LAYOUT_ORIENTATION.JSON) {
+      noResultsView = <NoResultsScreen text={this.props.textEmptyIndex} />;
+    } else if (
+      this.props.selectedLayout === Constants.LAYOUT_ORIENTATION.JSON
+    ) {
       mainView = this.getDocumentStyleView();
     } else {
       mainView = this.getTableStyleView();
@@ -129,10 +138,10 @@ export default class ResultsScreen extends React.Component {
 
     return (
       <div className="document-result-screen">
+        {noResultsView}
         <ResultsToolBar {...this.props} />
         {mainView}
       </div>
     );
   }
-
 }

--- a/app/addons/documents/index-results/components/results/ResultsScreen.js
+++ b/app/addons/documents/index-results/components/results/ResultsScreen.js
@@ -10,13 +10,13 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-import React from "react";
-import FauxtonAPI from "../../../../../core/api";
-import Constants from "../../../constants";
-import Components from "../../../../components/react-components";
-import { ResultsToolBar } from "../../../components/results-toolbar";
-import NoResultsScreen from "./NoResultsScreen";
-import TableView from "./TableView";
+import React from 'react';
+import FauxtonAPI from '../../../../../core/api';
+import Constants from '../../../constants';
+import Components from '../../../../components/react-components';
+import { ResultsToolBar } from '../../../components/results-toolbar';
+import NoResultsScreen from './NoResultsScreen';
+import TableView from './TableView';
 
 const { LoadLines, Document } = Components;
 
@@ -52,7 +52,7 @@ export default class ResultsScreen extends React.Component {
   }
 
   getDocumentList() {
-    const noop = () => {};
+    const noop = () => { };
     const data = this.props.results.results;
     return _.map(data, (doc, i) => {
       return (
@@ -70,17 +70,17 @@ export default class ResultsScreen extends React.Component {
           docIdentifier={doc.id}
           resultsStyle={this.props.resultsStyle}
         >
-          {doc.url ? this.getUrlFragment("#" + doc.url) : doc.url}
+          {doc.url ? this.getUrlFragment(`#${doc.url}`) : doc.url}
         </Document>
       );
     });
   }
 
   getDocumentStyleView() {
-    let classNames = "view";
+    let classNames = 'view';
 
     if (this.props.isListDeletable) {
-      classNames += " show-select";
+      classNames = `${classNames} show-select`;
     }
 
     return (

--- a/app/addons/documents/index-results/components/results/ResultsScreen.js
+++ b/app/addons/documents/index-results/components/results/ResultsScreen.js
@@ -112,35 +112,42 @@ export default class ResultsScreen extends React.Component {
     );
   }
 
-  render() {
-    let mainView = null;
-    let noResultsView = null;
-
+  getMainView() {
     if (this.props.isLoading) {
-      mainView = (
+      return (
         <div className="loading-lines-wrapper">
           <LoadLines />
         </div>
       );
-    } else if (this.props.noResultsWarning) {
-      noResultsView = (
-        <NoResultsScreen text={this.props.noResultsWarning} isWarning={true} />
-      );
-    } else if (!this.props.hasResults) {
-      noResultsView = <NoResultsScreen text={this.props.textEmptyIndex} />;
-    } else if (
-      this.props.selectedLayout === Constants.LAYOUT_ORIENTATION.JSON
-    ) {
-      mainView = this.getDocumentStyleView();
-    } else {
-      mainView = this.getTableStyleView();
+    } else if (!this.props.noResultsWarning && this.props.hasResults) {
+      if (this.props.selectedLayout === Constants.LAYOUT_ORIENTATION.JSON) {
+        return this.getDocumentStyleView();
+      }
+      return this.getTableStyleView();
     }
+  }
 
+  getNoResultScreen() {
+    if (!this.props.isLoading) {
+      if (this.props.noResultsWarning) {
+        return (
+          <NoResultsScreen
+            text={this.props.noResultsWarning}
+            isWarning={true}
+          />
+        );
+      } else if (!this.props.hasResults) {
+        return <NoResultsScreen text={this.props.textEmptyIndex} />;
+      }
+    }
+  }
+
+  render() {
     return (
       <div className="document-result-screen">
-        {noResultsView}
+        {this.getNoResultScreen()}
         <ResultsToolBar {...this.props} />
-        {mainView}
+        {this.getMainView()}
       </div>
     );
   }


### PR DESCRIPTION
# Overview

<img width="398" alt="Screen Shot 2019-09-10 at 11 24 30 PM" src="https://user-images.githubusercontent.com/1408766/64667524-16559a80-d428-11e9-8b41-66fe0a5e4230.png">

# Github Issue

Addresses one of many issues in #998 

# Solution

Using image below I determined the stack ordering of the elements and then re-arranged them.

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_without_z-index

<img width="671" alt="Screen Shot 2019-09-11 at 12 07 21 AM" src="https://user-images.githubusercontent.com/1408766/64667555-2d948800-d428-11e9-9b96-4ee81de24635.png">

NOTE: there is a psuedo element called ":has" that is in the future browser spec where you could do something like ":has( + .no-results-screen)" as a way to target the previous sibling from the next sibling ... this could have been a solution but its far in the future.


# Checklist

- [x] - Code works correct;
- [x] - Changes are covered by tests (styling issue, so not needed in this project)