### PR TITLE
Replaces deprecated fields disk_size and data_size

### DIFF
--- a/app/addons/databases/__tests__/stores.test.js
+++ b/app/addons/databases/__tests__/stores.test.js
@@ -60,15 +60,18 @@ describe('Databases Store', function () {
       expect(!store.doesDatabaseExist('db3')).toBeTruthy();
     });
 
-    it('uses the data_size prop', () => {
+    it('uses the sizes.active prop', () => {
       DatabaseActions.updateDatabases({
         dbList: ['db1'],
         databaseDetails: [{
           db_name: 'db1',
           doc_count: 5,
           doc_del_count: 3,
-          data_size: 1337,
-          disk_size: 0
+          sizes: {
+            active: 1337,
+            file: 0,
+            external: 59
+          }
         }],
         failedDbs: []
       });

--- a/app/addons/databases/stores.js
+++ b/app/addons/databases/stores.js
@@ -112,7 +112,7 @@ const DatabasesStoreConstructor = FauxtonAPI.Store.extend({
     if (!details) {
       return {};
     }
-    const dataSize = details.data_size || details.disk_size || 0;
+    const dataSize = (details.sizes && details.sizes.active) || 0;
 
     return {
       dataSize: Helpers.formatSize(dataSize),

--- a/app/addons/documents/designdocinfo/components/DesignDocInfo.js
+++ b/app/addons/documents/designdocinfo/components/DesignDocInfo.js
@@ -56,8 +56,8 @@ export default class DesignDocInfo extends React.Component {
       return <LoadLines />;
     }
     const viewIndex = this.props.viewIndex;
-    const actualSize = (viewIndex.data_size) ? viewIndex.data_size.toLocaleString('en') : 0;
-    const dataSize = (viewIndex.disk_size) ? viewIndex.disk_size.toLocaleString('en') : 0;
+    const actualSize = (viewIndex.sizes && viewIndex.sizes.external) ? viewIndex.sizes.external.toLocaleString('en') : 0;
+    const dataSize = (viewIndex.sizes && viewIndex.sizes.file) ? viewIndex.sizes.file.toLocaleString('en') : 0;
 
     return (
       <div className="metadata-page">


### PR DESCRIPTION
## Overview

Replace `data_size` with `sizes.active`, `disk_size` with `sizes.file` and `other.data_size` with `sizes.external` for any calls to `GET /{db}`.
Replace `data_size` with `sizes.external` and `disk_size` with `sizes.file` for `GET /{db}/_design/{ddoc}/_info`

## Testing recommendations

Database size is displayed on the Databases page.
Index size is displayed on the Design Doc Metadata page

## GitHub issue number

https://github.com/apache/couchdb/issues/2162 
https://github.com/apache/couchdb-documentation/pull/435 

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
