### PR TITLE
Improve execution stats formatting

### DIFF
--- a/app/addons/documents/mango/components/ExecutionStats.js
+++ b/app/addons/documents/mango/components/ExecutionStats.js
@@ -29,9 +29,12 @@ export default class ExecutionStats extends React.Component {
       return Math.floor(seconds) + ' seconds';
     }
     const minutes = Math.floor(seconds / 60);
-    seconds = seconds - (minutes * 60);
+    seconds = Math.floor(seconds - (minutes * 60));
 
-    return minutes + 'minute, ' + seconds + 'seconds';
+    const minuteText = minutes > 1 ? 'minutes' : 'minute';
+    const secondsText = seconds > 1 ? 'seconds' : 'second';
+
+    return [minutes, ' ', minuteText, ', ', seconds, ' ', secondsText].join('');
   }
 
   getWarning(executionStats, warning) {
@@ -70,7 +73,7 @@ export default class ExecutionStats extends React.Component {
         {this.executionStatsLine("documents examined", executionStats.total_docs_examined)}
         {this.executionStatsLine("documents examined (quorum)", executionStats.total_quorum_docs_examined)}
         {this.executionStatsLine("results returned", executionStats.results_returned, true)}
-        {this.executionStatsLine("execution time", executionStats.execution_time_ms, false, "ms")}
+        {this.executionStatsLine("execution time", Math.round(executionStats.execution_time_ms), false, "ms")}
       </div>
     );
   }


### PR DESCRIPTION


<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

As observed in https://github.com/apache/couchdb/issues/2236#issuecomment-546884302,
minute/second values were not rounded correctly.

This PR floors the minute/second values and handles the case where
minute/second == 1.

## Testing recommendations

Run a query which takes a long time to execute. View the execution stats text and popup.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
