### PR TITLE
Mango: support multiple server-side warnings

### DIFF
--- a/app/addons/documents/mango/components/ExecutionStats.js
+++ b/app/addons/documents/mango/components/ExecutionStats.js
@@ -13,8 +13,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
 
-const TOO_MANY_DOCS_SCANNED_WARNING = "The number of documents examined is high in proportion to the number of results returned. Consider adding an index to improve this.";
-
 export default class ExecutionStats extends React.Component {
   constructor (props) {
     super(props);
@@ -37,18 +35,13 @@ export default class ExecutionStats extends React.Component {
     return [minutes, ' ', minuteText, ', ', seconds, ' ', secondsText].join('');
   }
 
-  getWarning(executionStats, warning) {
-    if (!executionStats) { return warning; }
-
-    // warn if many documents scanned in relation to results returned
-    if (!warning && executionStats.results_returned) {
-      const docsExamined = executionStats.total_docs_examined || executionStats.total_quorum_docs_examined;
-      if (docsExamined / executionStats.results_returned > 10) {
-        return TOO_MANY_DOCS_SCANNED_WARNING;
-      }
+  getWarning(warnings) {
+    if (warnings) {
+      const lines = warnings.split('\n').map((warnText, i) => {
+        return <React.Fragment key={i}>{warnText}<br/></React.Fragment>;
+      });
+      return <span>{lines}</span>;
     }
-
-    return warning;
   }
 
   warningPopupComponent(warningText) {
@@ -95,7 +88,7 @@ export default class ExecutionStats extends React.Component {
       warning
     } = this.props;
 
-    const warningText = this.getWarning(executionStats, warning);
+    const warningText = this.getWarning(warning);
 
     let warningComponent = null;
     if (warningText) {

--- a/bin/build-couchdb-dev.sh
+++ b/bin/build-couchdb-dev.sh
@@ -11,6 +11,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
+set -xe
+
 if [[ $COUCHDB_IMAGE == "couchdb:dev" ]]; then
     git clone https://github.com/apache/couchdb-docker.git
     cd couchdb-docker


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Changes the handling of mango warnings to support multiple warnings
delimited by a newline, as added in https://github.com/apache/couchdb/pull/2410.

This also removes the client-side warning for too many docs scanned as that is now generated on the server.

## Testing recommendations

When https://github.com/apache/couchdb/pull/2410 is merged, run some Mango queries with bad  / no indexes to generate warnings.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
