### PR TITLE
Nav: Fix potential ID selector collisions

### DIFF
--- a/app/addons/documents/sidebar/components/DesignDoc.js
+++ b/app/addons/documents/sidebar/components/DesignDoc.js
@@ -157,7 +157,7 @@ export default class DesignDoc extends React.Component {
           </div>
         </div>
         <Collapse in={this.props.isExpanded}>
-          <ul className={toggleBodyClassNames} id={this.props.designDocName}>
+          <ul className={toggleBodyClassNames} id={`design-doc-menu-${this.props.designDocName}`}>
             <li className={metadataRowClass}>
               <a href={"#/" + designDocMetaUrl} className="toggle-view accordion-header">
                 Metadata

--- a/app/addons/documents/tests/nightwatch/viewDelete.js
+++ b/app/addons/documents/tests/nightwatch/viewDelete.js
@@ -29,7 +29,7 @@ module.exports = {
       .assert.containsText('.prettyprint', 'stub')
 
       // confirm the sidebar shows the testdesigndoc design doc
-      .waitForElementVisible('#testdesigndoc', waitTime, true)
+      .waitForElementVisible('#design-doc-menu-testdesigndoc', waitTime, true)
 
       .clickWhenVisible('.index-list .active span', waitTime, true)
       .clickWhenVisible('.popover-content .fonticon-trash', waitTime, true)

--- a/app/addons/documents/tests/nightwatch/viewEdit.js
+++ b/app/addons/documents/tests/nightwatch/viewEdit.js
@@ -201,7 +201,7 @@ module.exports = {
       .waitForElementPresent('.prettyprint', waitTime, false)
 
       // confirm the sidebar shows the testdesigndoc design doc
-      .waitForElementVisible('#testdesigndoc', waitTime, true)
+      .waitForElementVisible('#design-doc-menu-testdesigndoc', waitTime, true)
 
       .waitForElementPresent('.faux-header__doc-header-title', waitTime, false)
       .waitForAttribute('.faux-header__doc-header-title', 'textContent', function (docContents) {
@@ -234,7 +234,7 @@ module.exports = {
 
       // now wait for the old design doc to be gone, and the new one to have shown up
       .waitForElementNotPresent('#testdesigndoc', waitTime, true)
-      .waitForElementPresent('#brand-new-ddoc', waitTime, true)
+      .waitForElementPresent('#design-doc-menu-brand-new-ddoc', waitTime, true)
       .end();
   }
 

--- a/app/addons/search/tests/nightwatch/deleteSearchIndex.js
+++ b/app/addons/search/tests/nightwatch/deleteSearchIndex.js
@@ -77,7 +77,7 @@ module.exports = {
 
       // just assert the search indexes section has been removed, but the design doc still exists
       .waitForElementNotPresent('#nav-design-function-testdesigndocindexes', waitTime, true)
-      .waitForElementPresent('#testdesigndoc', waitTime, true)
+      .waitForElementPresent('#design-doc-menu-testdesigndoc', waitTime, true)
 
       .end();
   }


### PR DESCRIPTION
## Overview

If a design doc is created with a name that conflicts with an existing HTML element's ID, it will receive the styling for that element in addition to causing invalid HTML.

In my case, I'd created a design doc named `dashboard`, which then produced a navigation item with an ID of `#dashboard`. This conflicts with the existing `#dashboard` element, which has several CSS styles applied. It then breaks the navigation layout (see screenshot). It becomes impossible to edit the views within the design doc without manually editing the UI.

![image](https://user-images.githubusercontent.com/130131/72366271-ed8c2d00-36c7-11ea-8285-477eb08e5aba.png)

This change prefixes those IDs in order to ensure they
are unique.


## Testing recommendations

Tested the UI locally to ensure the rendering was fixed and that I could still access my docs, views, etc.

![image](https://user-images.githubusercontent.com/130131/72366321-04328400-36c8-11ea-9d7d-cb6b17c17ad1.png)


## GitHub issue number

N/A

## Related Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
