### PR TITLE
Test with Couchdb 3.0 docker image instead of dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ git:
   depth: 1
 env:
   - COUCHDB_IMAGE=apache/couchdb:2.3.1 NIGHTWATCH_SKIPTAGS="search,partitioned"
-  - COUCHDB_IMAGE=apache/couchdb:3 NIGHTWATCH_SKIPTAGS="search,nonpartitioned"
+  - COUCHDB_IMAGE=apache/couchdb:3 NIGHTWATCH_SKIPTAGS="search,nonpartitioned,couchdb-v2-only"
   # - COUCHDB_IMAGE=couchdb:dev NIGHTWATCH_SKIPTAGS="search,nonpartitioned"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ git:
   depth: 1
 env:
   - COUCHDB_IMAGE=apache/couchdb:2.3.1 NIGHTWATCH_SKIPTAGS="search,partitioned"
-  - COUCHDB_IMAGE=couchdb:dev NIGHTWATCH_SKIPTAGS="search,nonpartitioned"
+  - COUCHDB_IMAGE=apache/couchdb:3 NIGHTWATCH_SKIPTAGS="search,nonpartitioned"
+  # - COUCHDB_IMAGE=couchdb:dev NIGHTWATCH_SKIPTAGS="search,nonpartitioned"
 
 before_install:
   - npm install -g npm@latest

--- a/app/addons/databases/tests/nightwatch/permissionsDbTable.js
+++ b/app/addons/databases/tests/nightwatch/permissionsDbTable.js
@@ -12,6 +12,8 @@
 
 module.exports = {
 
+  '@tags': ['couchdb-v2-only'],
+
   'lists databases with a 401' : function (client) {
     const waitTime = client.globals.maxWaitTime;
 


### PR DESCRIPTION
## Overview

Now that CouchDB 3.0 is out we can use the Docker image for v3 instead of dev.
We still test with the v2.3.1 image to make sure Fauxton is backward compatible.

## Testing recommendations

Automated tests pass


