### PR TITLE
Updates Search addon

### DIFF
--- a/app/addons/search/__tests__/search.reducers.test.js
+++ b/app/addons/search/__tests__/search.reducers.test.js
@@ -12,6 +12,7 @@
 
 import reducer from '../reducers';
 import ActionTypes from '../actiontypes';
+import Constants from '../constants';
 
 describe('Search Reducer', () => {
 
@@ -138,6 +139,38 @@ describe('Search Reducer', () => {
     };
     newState = reducer(newState, initAction);
     expect(newState.searchResults).toBeUndefined();
+  });
+
+  it('loads the single analyzer correctly', () => {
+    const initialState = reducer(undefined, { type: 'DO_NOTHING' });
+    expect(initialState.singleAnalyzer).toBe('standard');
+
+    const ddocID = '_design/ddoc_test';
+    const mockDesigDocModel = {
+      id: ddocID,
+      dDocModel: () => { return mockDesigDocModel; },
+      getAnalyzer: () => 'keyword',
+      getIndex: () => '',
+      analyzerType: () => Constants.ANALYZER_SINGLE
+    };
+    const designDocs = [mockDesigDocModel];
+    const action = {
+      type: ActionTypes.SEARCH_INDEX_INIT_EDIT_SEARCH_INDEX,
+      options: {
+        database: 'db1',
+        designDocs,
+        ddocID,
+        indexName: 'idx1'
+      }
+    };
+    // Validate the single analyzer is correct
+    const stateWithKeywordAnalyzer = reducer(initialState, action);
+    expect(stateWithKeywordAnalyzer.singleAnalyzer).toBe('keyword');
+
+    // Validate the default analyzer is set when the DDoc doesn't specify one
+    mockDesigDocModel.getAnalyzer = () => undefined;
+    const stateWithNoAnalyzer = reducer(initialState, action);
+    expect(stateWithNoAnalyzer.singleAnalyzer).toBe(Constants.DEFAULT_ANALYZER);
   });
 
 });

--- a/app/addons/search/actions.js
+++ b/app/addons/search/actions.js
@@ -13,7 +13,6 @@
 import FauxtonAPI from '../../core/api';
 import ActionTypes from './actiontypes';
 import Search from './resources';
-import Documents from '../documents/base';
 import SidebarActions from '../documents/sidebar/actions';
 import IndexEditorActions from '../documents/index-editor/actions';
 import * as API from './api';
@@ -66,8 +65,7 @@ const dispatchInitSearchIndex = (params)  => {
 };
 
 const dispatchEditSearchIndex = (params) => {
-  var ddocInfo = new Documents.DdocInfo({ _id: params.ddocID }, { database: params.database });
-
+  const {database, ddocID, designDocs, indexName} = params;
   FauxtonAPI.reduxDispatch({
     type: ActionTypes.SEARCH_INDEX_SET_LOADING,
     options: {
@@ -75,24 +73,24 @@ const dispatchEditSearchIndex = (params) => {
     }
   });
 
-  FauxtonAPI.Promise.all([params.designDocs.fetch(), ddocInfo.fetch()]).then(([ddocs]) => {
-    const ddoc = ddocs.rows.find(ddoc => ddoc._id === ddocInfo.id).doc;
-    if (!ddoc.indexes || !ddoc.indexes[params.indexName]) {
-      throw Error(`Index "${params.indexName}" not found`);
+  designDocs.fetch().then(ddocs => {
+    const ddoc = ddocs.rows.find(ddoc => ddoc._id === ddocID).doc;
+    if (!ddoc.indexes || !ddoc.indexes[indexName]) {
+      throw Error(`Index "${indexName}" not found`);
     }
     FauxtonAPI.reduxDispatch({
       type: ActionTypes.SEARCH_INDEX_INIT_EDIT_SEARCH_INDEX,
       options: {
-        indexName: params.indexName,
-        database: params.database,
-        ddocInfo: ddocInfo,
-        designDocs: params.designDocs
+        indexName,
+        database,
+        ddocID,
+        designDocs,
       }
     });
   }).catch(err => {
     const details = err.message ? err.message : '';
     FauxtonAPI.addNotification({
-      msg: `There was a problem editing the search index "${params.indexName}". ` + details,
+      msg: `There was a problem editing the search index "${indexName}". ` + details,
       type: 'error',
       clear: true
     });

--- a/app/addons/search/reducers.js
+++ b/app/addons/search/reducers.js
@@ -92,9 +92,9 @@ function setAnalyzerRow (state, { analyzer, rowIndex }) {
   return newAnalyzerFields;
 }
 
-function initEditSearch (state, { database, designDocs, ddocInfo, indexName }) {
+function initEditSearch (state, { database, designDocs, ddocID, indexName }) {
   const ddoc = designDocs.find(ddoc => {
-    return ddoc.id === ddocInfo.id;
+    return ddoc.id === ddocID;
   }).dDocModel();
 
   // the selected analyzer returned in the ddoc can be applied to both the single analyzer and the default multiple
@@ -128,9 +128,9 @@ function initEditSearch (state, { database, designDocs, ddocInfo, indexName }) {
     database: database,
     designDocs: designDocs,
     searchIndexName: indexName,
-    ddocName: ddocInfo.id,
+    ddocName: ddocID,
     lastSavedSearchIndexName: indexName,
-    lastSavedDesignDocName: ddocInfo.id,
+    lastSavedDesignDocName: ddocID,
     searchIndexFunction: ddoc.getIndex(indexName),
     analyzerType: ddoc.analyzerType(indexName),
     // this either returns a simple string (single) or a complex object (multiple)

--- a/app/addons/search/reducers.js
+++ b/app/addons/search/reducers.js
@@ -107,7 +107,7 @@ function initEditSearch (state, { database, designDocs, ddocID, indexName }) {
     if (_.has(analyzer, 'default')) {
       newSingleAnalyzer = analyzer.default;
     } else {
-      newSingleAnalyzer = Constants.DEFAULT_ANALYZER_TYPE;
+      newSingleAnalyzer = Constants.DEFAULT_ANALYZER;
     }
   }
   const newAnalyzerFields = [];


### PR DESCRIPTION
## Overview

A couple of improvements to the Search add-on:
 - Removes an unnecessary call to `/_design/DOC_ID/_info` when editing an existing search index
 - Fix: editor was setting an invalid analyzer when the index doesn't specify one

## Testing recommendations

1) To test the call to `/_design/DOC_ID/_info` was removed, using Chrome:
 - Open dev tools
 - Navigate to the design doc metadata page
 - Go to the dev tools, network tab. Then right click the request `/YOUR_DB/_design/YOUR_DDOC/_info`, and select 'Block request URL'.
 - Reload the page. An error message should be displayed. The loading icon is not shown.

2) To verify the correct analyzer is set

 - Create a new search index and save it
 - Edit the ddoc and erase the line "analyzer": "standard", then save it
 - Open the index in the Search Index Editor. Don't change anything and save it.
 - Edit the ddoc again and verify analyzer is set to "standard"

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
