### PR TITLE
Query results fail to load when stats field is missing

### DIFF
--- a/app/addons/documents/mango/components/ExecutionStats.js
+++ b/app/addons/documents/mango/components/ExecutionStats.js
@@ -53,8 +53,11 @@ export default class ExecutionStats extends React.Component {
   }
 
   executionStatsLine(title, value, alwaysShow = false, units = "") {
-    const hasValue = value === 0 && !alwaysShow ? "false" : "true";
-    return <div data-status={hasValue}>{title + ": "}<span className="value">{value.toLocaleString()} {units}</span></div>;
+    if (typeof value === 'number') {
+      const hasValue = value === 0 && !alwaysShow ? "false" : "true";
+      return <div data-status={hasValue}>{title + ": "}<span className="value">{value.toLocaleString()} {units}</span></div>;
+    }
+    return null;
   }
 
   executionStatsPopupComponent(executionStats) {


### PR DESCRIPTION
## Overview

Adds an extra check to prevent throwing a TypeError when the stats response does not have one of the expected fields.

## Testing recommendations

Unit tests pass

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
