### PR TITLE
Add "None" analyzer option for the Search View editor

### DIFF
--- a/app/addons/search/components/Analyzer.js
+++ b/app/addons/search/components/Analyzer.js
@@ -34,7 +34,7 @@ export default class Analyzer extends React.Component {
   };
 
   validate = () => {
-    if (this.props.analyzerType === Constants.ANALYZER_SINGLE) {
+    if (this.props.analyzerType !== Constants.ANALYZER_MULTIPLE) {
       return true;
     }
     return this.analyzerMultiple.validate();
@@ -49,6 +49,10 @@ export default class Analyzer extends React.Component {
   };
 
   getInfo = () => {
+    if (this.props.analyzerType === Constants.ANALYZER_NONE) {
+      return;
+    }
+
     return this.props.analyzerType === Constants.ANALYZER_SINGLE
       ? this.props.singleAnalyzer
       : {
@@ -67,6 +71,9 @@ export default class Analyzer extends React.Component {
   };
 
   getAnalyzerType = () => {
+    if (this.props.analyzerType === Constants.ANALYZER_NONE) {
+      return;
+    }
     return this.props.analyzerType === Constants.ANALYZER_SINGLE
       ? (<AnalyzerDropdown
         label="Type"
@@ -95,6 +102,11 @@ export default class Analyzer extends React.Component {
       singleClasses += ' active';
     }
 
+    let noneClasses = 'btn';
+    if (this.props.analyzerType === Constants.ANALYZER_NONE) {
+      noneClasses += ' active';
+    }
+
     return (
       <div className="well">
         <div className="control-group">
@@ -116,6 +128,14 @@ export default class Analyzer extends React.Component {
               checked={this.props.analyzerType === Constants.ANALYZER_MULTIPLE}
               onChange={this.selectAnalyzerType} />
             <label style={{width: '82px'}} htmlFor="multiple-analyzer" className={multipleClasses}>Multiple</label>
+            <input
+              type="radio"
+              id="none-analyzer"
+              name="search-analyzer"
+              value="none"
+              checked={this.props.analyzerType === Constants.ANALYZER_NONE}
+              onChange={this.selectAnalyzerType} />
+            <label style={{width: '82px'}} htmlFor="none-analyzer" className={noneClasses}>None</label>
           </div>
         </div>
         {this.getAnalyzerType()}

--- a/app/addons/search/constants.js
+++ b/app/addons/search/constants.js
@@ -10,6 +10,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 export default {
+  ANALYZER_NONE: 'none',
   ANALYZER_SINGLE: 'single',
   ANALYZER_MULTIPLE: 'multiple',
   DEFAULT_SEARCH_INDEX_NAME: 'newSearch',

--- a/app/addons/search/resources.js
+++ b/app/addons/search/resources.js
@@ -45,8 +45,12 @@ Search.Doc = Documents.Doc.extend({
   },
 
   analyzerType: function (indexName) {
-    if (typeof this.getAnalyzer(indexName) === 'object') {
+    const analyzer = this.getAnalyzer(indexName);
+
+    if (typeof analyzer === 'object') {
       return Constants.ANALYZER_MULTIPLE;
+    } else if (!analyzer) {
+      return Constants.ANALYZER_NONE;
     }
     return Constants.ANALYZER_SINGLE;
   },

--- a/app/addons/search/tests/nightwatch/editSearchWithoutAnalyzer.js
+++ b/app/addons/search/tests/nightwatch/editSearchWithoutAnalyzer.js
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+module.exports = {
+  '@tags': ['search'],
+  'Edit search without analyzer': function (client) {
+    var waitTime = client.globals.maxWaitTime,
+        newDatabaseName = client.globals.testDatabaseName,
+        baseUrl = client.globals.test_settings.launch_url;
+
+    client
+      .loginToGUI()
+      .populateDatabase(newDatabaseName)
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+
+      // 1. Create a search index in a new design document
+      .waitForElementPresent('#new-design-docs-button', waitTime, false)
+      .click('#new-design-docs-button a')
+      .click('#new-design-docs-button a[href="#/database/' + newDatabaseName + '/new_search"]')
+      .waitForElementVisible('#new-ddoc', waitTime, false)
+      .setValue('#new-ddoc', 'edit_search_wo_analyzer')
+      .clearValue('#search-name')
+      .setValue('#search-name', 'test1-index')
+      .click('label[for="none-analyzer"]')
+      .clickWhenVisible('#save-index')
+      .waitForElementVisible('#global-notifications .alert.alert-success', client.globals.maxWaitTime, false)
+      .url(baseUrl + '/#/database/' + newDatabaseName + '/_all_docs')
+      .waitForElementPresent('.tableview-checkbox-cell', client.globals.maxWaitTime, false)
+      .waitForElementNotPresent('.loading-lines', client.globals.maxWaitTime, false)
+
+      // Make sure there's not analyzer field in the document JSON
+      .clickWhenVisible('.fonticon-json')
+      .waitForElementPresent('.prettyprint', waitTime, false)
+      .waitForElementPresent('div[data-id="_design/edit_search_wo_analyzer"]', waitTime)
+      .getText('div[data-id="_design/edit_search_wo_analyzer"]', function (result) {
+        this.verify.ok(result.value.indexOf('"analyzer":') === -1, 'make sure no analyzer was saved');
+      })
+
+      // Now we edit that search index and make sure none is selected
+      .click('#nav-design-function-edit_search_wo_analyzerindexes .fonticon-wrench2')
+      .waitForElementPresent('#index-menu-component-popover', waitTime)
+      .click('#index-menu-component-popover .fonticon-file-code-o')
+      .waitForElementVisible('#search-name', waitTime, false)
+      .assert.attributeContains('#none-analyzer', 'checked', true)
+      .end();
+  },
+};


### PR DESCRIPTION
Prevents from adding an analyzer if none were defined in the design document

<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

#1256

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
