### PR TITLE
Show reason why a file upload fails

### DIFF
--- a/app/addons/documents/doc-editor/actions.js
+++ b/app/addons/documents/doc-editor/actions.js
@@ -207,20 +207,20 @@ const uploadAttachment = (params) => (dispatch) => {
   httpRequest.onerror = () => {
     onError('Error uploading file');
   };
-  httpRequest.onload = (e) => {
+  httpRequest.onload = () => {
     if (httpRequest.status >= 200 && httpRequest.status < 300) {
       onSuccess(params.doc);
     } else {
       let errorMsg = 'Error uploading file. ';
-      if (e.responseText) {
-        try {
-          const json = JSON.parse(e.responseText);
+      try {
+        if (httpRequest.responseText) {
+          const json = JSON.parse(httpRequest.responseText);
           if (json.error) {
             errorMsg += 'Reason: ' + (json.reason || json.error);
           }
-        } catch (err) {
-          //ignore parsing error
         }
+      } catch (err) {
+        //ignore parsing error
       }
       onError(errorMsg);
     }


### PR DESCRIPTION
## Overview

When file attachment fails, Fauxton only displays the generic 'Error uploading file' message, even when a more detailed explanation is available.

This PR fixes the `onload` event to inspect the request object instead of the event when trying to get the error details.

## Testing recommendations

Not sure how one would simulate an error.
Your browser devtools can simulate a network error but that hits a separate code path.

I've added a couple of unit tests, so that should be enough to validate the change.

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
