### PR TITLE
[DISCUSS] feat: prototype news page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ app/addons/*
 !app/addons/cors
 !app/addons/setup
 !app/addons/search
+!app/addons/news
 settings.json*
 i18n.json
 !settings.json.default

--- a/app/addons/news/assets/less/news.less
+++ b/app/addons/news/assets/less/news.less
@@ -1,0 +1,16 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#news-page {
+  width: 100%;
+  height: 100%;
+}

--- a/app/addons/news/base.js
+++ b/app/addons/news/base.js
@@ -1,0 +1,28 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import FauxtonAPI from "../../core/api";
+import News from "./routes";
+import "./assets/less/news.less";
+
+News.initialize = function () {
+  FauxtonAPI.addHeaderLink({
+    id: 'News',
+    title: 'News',
+    icon: 'fonticon-clipboard',
+    href: '#/news',
+    bottomNav: true,
+    top: true
+  });
+};
+
+export default News;

--- a/app/addons/news/components.js
+++ b/app/addons/news/components.js
@@ -1,0 +1,25 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import React from "react";
+
+const NewsPage = () => {
+  return (
+    <div id="news-page" className="">
+      <iframe src="https://blog.couchdb.org" width="100%" height="100%"></iframe>
+    </div>
+  );
+};
+
+export default {
+  NewsPage: NewsPage
+};

--- a/app/addons/news/routes.js
+++ b/app/addons/news/routes.js
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import React from 'react';
+import FauxtonAPI from "../../core/api";
+import NewsComponents from "./components";
+import {OnePaneSimpleLayout} from '../components/layouts';
+
+var NewsRouteObject = FauxtonAPI.RouteObject.extend({
+  selectedHeader: 'News',
+  hideApiBar: true,
+  hideNotificationCenter: true,
+  routes: {
+    'news': 'news'
+  },
+  roles: ['fx_loggedIn'],
+  news: function () {
+    return <OnePaneSimpleLayout
+      component={<NewsComponents.NewsPage/>}
+      crumbs={[
+        {'name': 'News'}
+      ]}
+    />;
+  }
+});
+NewsRouteObject.RouteObjects = [NewsRouteObject];
+
+export default NewsRouteObject;

--- a/devserver.js
+++ b/devserver.js
@@ -51,7 +51,7 @@ const devSetup = function (cb) {
   });
 };
 
-const defaultHeaderValue = "default-src 'self'; child-src 'self' blob:; img-src 'self' data:; font-src 'self'; " +
+const defaultHeaderValue = "default-src 'self'; child-src 'self' blob: https://blog.couchdb.org; img-src 'self' data:; font-src 'self'; " +
                   "script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline';";
 function getCspHeaders () {
   if (!settings.contentSecurityPolicy) {

--- a/settings.json.default.json
+++ b/settings.json.default.json
@@ -14,7 +14,8 @@
   { "name": "permissions" },
   { "name": "auth" },
   { "name": "verifyinstall" },
-  { "name": "documentation" }
+  { "name": "documentation" },
+  { "name": "news" }
   ],
     "template": {
       "development": {


### PR DESCRIPTION
Hey all,

I thought it would be neat to be able to show the blog inline with fauxton, that way folks can see project updates in a more timely manner.

What do you think?

<img width="1369" alt="Screenshot 2020-05-22 at 16 31 42" src="https://user-images.githubusercontent.com/11321/82678342-bddacc00-9c49-11ea-970f-116409f70225.png">
