### PR TITLE
Use _dbs_info instead of fetching the db info one-by-one

### DIFF
--- a/app/addons/databases/base.js
+++ b/app/addons/databases/base.js
@@ -108,6 +108,12 @@ FauxtonAPI.registerUrls('databaseBaseURL', {
   }
 });
 
+FauxtonAPI.registerUrls('dbsInfo', {
+  server: function () {
+    return Helpers.getServerUrl('/_dbs_info');
+  }
+});
+
 FauxtonAPI.registerUrls('permissions', {
   server: function (db) {
     return Helpers.getServerUrl('/' + db + '/_security');


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

Slight efficiency improvement, use `_dbs_info` instead of fetching the info about the databases one by one.

Note, I'm by no means a react expert, so please let me know if I missed something or otherwise did something stupid.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Visit the all dbs page. It should work the same.

## GitHub issue number

Fixes #1123 
<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
