### PR TITLE
Make cluster config warning applicable to CouchDB 3 as well

### DIFF
--- a/app/addons/cluster/cluster.js
+++ b/app/addons/cluster/cluster.js
@@ -23,7 +23,7 @@ export class DisabledConfigController extends React.Component {
               <i className="fonticon-attention-circled"></i>
             </div>
             It seems that you are running a cluster with {this.props.nodes.length} nodes. For CouchDB 2.0
-            we recommend using a configuration management tools like Chef, Ansible,
+            or greater we recommend using a configuration management tools like Chef, Ansible,
             Puppet or Salt (in no particular order) to configure your nodes in a cluster.
             <br/>
             <br/>


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

When trying to configure a CouchDB 3 cluster in Fauxton right now, a message about CouchDB 2 will be shown, which is slightly confusing. Instead, mention that this applies to CouchDB version 2 or greater so that Fauxton remains compatible with CouchDB 2.

## Testing recommendations

Run Fauxton against a CouchDB 3 cluster and try to use in-browser configuration.

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
