### PR TITLE
Fix: rev browser fails with doc ID with special chars

### DIFF
--- a/app/addons/documents/base.js
+++ b/app/addons/documents/base.js
@@ -106,7 +106,7 @@ FauxtonAPI.registerUrls('bulk_docs', {
 
 FauxtonAPI.registerUrls('revision-browser', {
   app: function (id, doc) {
-    return 'database/' + id + '/' + doc + '/conflicts';
+    return 'database/' + id + '/' + encodeURIComponent(doc) + '/conflicts';
   }
 });
 


### PR DESCRIPTION
## Overview

Clicking the "Conflicts" button to open the Revision Browser doesn't work when the doc ID contains URL special characters such as `#` or `/`.

The fix is to simply URL encode the doc ID when navigating to the rev browser.

## Testing recommendations

- Create a doc with special chars, e.g. `#mydoc`
- Generate conflicts on the doc
- Go to the Doc Editor and click the 'Conflicts' button
   - The rev browser should open

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
