### PR TITLE
Remove link to Google Plus

### DIFF
--- a/app/addons/documentation/components.js
+++ b/app/addons/documentation/components.js
@@ -59,11 +59,6 @@ const docLinks = [
     iconClassName: 'twitter-icon'
   },
   {
-    title: 'Follow CouchDB on Google Plus',
-    link: 'https://plus.google.com/+CouchDB',
-    iconClassName: 'google-plus-icon'
-  },
-  {
     title: 'Follow CouchDB on LinkedIn',
     link: 'https://www.linkedin.com/company/apache-couchdb',
     iconClassName: 'linkedin-icon'


### PR DESCRIPTION
closes https://github.com/apache/couchdb-fauxton/issues/1307

## Overview

Google Plus no longer exists.

## Testing recommendations

Link should no longer appear in

![rabbit-7490](https://user-images.githubusercontent.com/60706/108183633-90ed1400-710a-11eb-817c-1fa1a7a12aa1.png)



## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
