### PR TITLE
In Replication panel warn that not all replications may be displayed.

### DIFF
--- a/app/addons/replication/components/activity.js
+++ b/app/addons/replication/components/activity.js
@@ -73,7 +73,7 @@ export default class Activity extends React.Component {
     return (
       <div className="replication__activity">
         <p className="replication__activity-caveat">
-          Replications must have a replication document to display in the following table.
+          Replications must have a replication document to display in the following table. Up to about 100 replications are displayed.
         </p>
         <ReplicationHeader
           filter={filter}


### PR DESCRIPTION
## Overview
In the "Replicator DB Activity" tab of the Replication panel
add the message "Up to about 100 replications are displayed."

When there are many _replicator documents, users are puzzled 
when some replications do not show up in the 
`Replicator DB Activity` panel of the Replication panel.

In my test using Cloudant I found that the number of replications 
displayed in the `Replicator DB Activity` tab of the Replication panel was 99.
That must be because we get 100 _replicator documents at:
 https://github.com/apache/couchdb-fauxton/blob/main/app/addons/replication/api.js#L314
<code>
      const url = Helpers.getServerUrl('/_replicator/_all_docs?include_docs=true&limit=100');
</code>
And then at https://github.com/apache/couchdb-fauxton/blob/main/app/addons/replication/api.js#L321
we filter out all the design documents:
<code>
         return parseReplicationDocs(res.rows.filter(row => row.id.indexOf("_design/") === -1));       
</code>
And in Cloudant the _replicator database is created with a 
design document _design/_replicator.
So of the 100 _replicator documents that were retrieved, 
one was filtered out, leaving 99 replications to be displayed 
in the "Replicator DB Activity" tab of the Replication panel.

When I tried the same thing with Apache CouchDB, 
the _replicator document did not contain any design documents, 
so 100 replications were displayed.

## Related Pull Requests
https://github.com/apache/couchdb-fauxton/pull/1288 "Support pagination in ReplicatorDB activity panel " 
would prevent the problem addressed by the present Pull Request. 
But 1288 is still Open and it is not clear when or if it will ever be complete.
