### PR TITLE
In Replication panel warn that not all replications may be displayed.

### DIFF
--- a/app/addons/replication/components/activity.js
+++ b/app/addons/replication/components/activity.js
@@ -74,6 +74,7 @@ export default class Activity extends React.Component {
       <div className="replication__activity">
         <p className="replication__activity-caveat">
           Replications must have a replication document to display in the following table.
+          Up to about 100 replications are displayed.
         </p>
         <ReplicationHeader
           filter={filter}


### PR DESCRIPTION
## Overview

In the `Replicator DB Activity` tab of the Replication panel
add the message "Up to about 100 replications are displayed."

When there are many _replicator documents, users are puzzled
when some replications do not show up in the
`Replicator DB Activity` panel of the Replication panel.

In my test using Cloudant I found that the number of replications
displayed in the `Replicator DB Activity` tab of the Replication panel was 99.
That must be because we get 100 _replicator documents at:
 https://github.com/apache/couchdb-fauxton/blob/main/app/addons/replication/api.js#L314
```
const url = Helpers.getServerUrl('/_replicator/_all_docs?include_docs=true&limit=100');
```
And then at https://github.com/apache/couchdb-fauxton/blob/main/app/addons/replication/api.js#L321
we filter out all the design documents:
```
return parseReplicationDocs(res.rows.filter(row => row.id.indexOf("_design/") === -1));
```
And in Cloudant the _replicator database is created with a
design document _design/_replicator.
So of the 100 _replicator documents that were retrieved,
one was filtered out, leaving 99 replications to be displayed
in the "Replicator DB Activity" tab of the Replication panel.

When I tried the same thing with Apache CouchDB,
the _replicator document did not contain any design documents,
so 100 replications were displayed.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
Go to the `Replicator DB Activity` tab of the `Replication` panel 
and observe that the string:
"Up to about 100 replications are displayed." 
appears after the string:
"Replications must have a replication document to display in the following table."


## Related Pull Requests

#1288 "Support pagination in ReplicatorDB activity panel "
would prevent the problem addressed by the present Pull Request.
But 1288 is still Open and it is not clear when or if it will ever be complete.

#1301 is my previous attempt to submit this change, 
but somehow the build failed. So I will delete that Pull Request 
and use the present Pull Request instead.
