### PR TITLE
Fix: Changes page generates incorrect link for doc IDs with special chars

### DIFF
--- a/app/addons/documents/__tests__/changes.test.js
+++ b/app/addons/documents/__tests__/changes.test.js
@@ -183,4 +183,15 @@ describe('ChangeRow', () => {
     const changeRow = mount(<ChangeRow change={change} databaseName="testDatabase" />);
     expect(changeRow.find('a.js-doc-link').length).toBe(1);
   });
+
+  it('generates correct URL for doc and db with special chars', () => {
+    const changeSpecialChars = {
+      id: 'space newline\nquestion_mark?',
+      seq: 5,
+      deleted: false,
+      changes: { code: 'here' }
+    };
+    const changeRow = mount(<ChangeRow change={changeSpecialChars} databaseName="db/name" />);
+    expect(changeRow.find('a.js-doc-link').at(0).prop('href')).toBe('#/database/db%2Fname/space%20newline%0Aquestion_mark%3F');
+  });
 });

--- a/app/addons/documents/changes/components/ChangeID.js
+++ b/app/addons/documents/changes/components/ChangeID.js
@@ -21,7 +21,7 @@ export default class ChangeID extends React.Component {
         <span className="js-doc-id">{id}</span>
       );
     }
-    const link = '#' + FauxtonAPI.urls('document', 'app', databaseName, id);
+    const link = '#' + FauxtonAPI.urls('document', 'app', encodeURIComponent(databaseName), encodeURIComponent(id));
     return (
       <a href={link} className="js-doc-link">{id}</a>
     );


### PR DESCRIPTION
## Overview

Changes page generates incorrect link for doc IDs with special chars.
The fix is to URL encode the doc ID and database name when generating the URL.

## Testing recommendations

1. Create a document with ID `test\n\r_?`
2. Go to Changes page and scroll the list to find the entry for the new doc
3. Click on the link. It should load the document in the editor

## GitHub issue number

none

## Related Pull Requests

none

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
