### PR TITLE
Add extension point for database size

### DIFF
--- a/app/addons/databases/stores.js
+++ b/app/addons/databases/stores.js
@@ -112,8 +112,15 @@ const DatabasesStoreConstructor = FauxtonAPI.Store.extend({
     if (!details) {
       return {};
     }
+
+    const sizeReporter = FauxtonAPI.getExtensions('DatabaseList:dbSizeReportFieldName');
+    let fieldName = 'active';
+    if (sizeReporter.length > 0) {
+      fieldName = sizeReporter[0];
+    }
+
     const {sizes} = details;
-    const dataSize = (sizes && sizes.active) || (sizes && sizes.external) || details.data_size || 0;
+    const dataSize = (sizes && sizes[fieldName]) || (sizes && sizes.active) || (sizes && sizes.external) || details.data_size || 0;
 
     return {
       dataSize: Helpers.formatSize(dataSize),


### PR DESCRIPTION
## Overview

Add extension point for database size called `DatabaseList:dbSizeReportFieldName`,
this enables consumers to override the displayed value to meet
their deployment needs. For example, in the case of Cloudant's usage,
the default `sizes.active` field is meaningless to their customers
since they bill using the value from `sizes.external`, using the
extension it is possible to customize the view to provide a better experiance.


The extension point `DatabaseList:dbSizeReportFieldName` only supports
the single extentsion, and assumes the field name is in the `sizes`
object returned from db_info.


## Testing recommendations

Regular CI tests passing. It can be further tested by providing an extension
to use one of the other fields in the `sizes` object from the `{db}/` endpoint.

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
