### PR TITLE
Fixes broken URLs pointing to master branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,4 +39,4 @@
 - [ ] Code is written and works correctly;
 - [ ] Changes are covered by tests;
 - [ ] Documentation reflects the changes;
-- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
+- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,12 @@ you want to help with the larger project. Come join us!
 If you never created a pull request before, welcome :tada: :smile: [Here is a great tutorial](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
 on how to send one :)
 
-The [Readme file](https://github.com/apache/couchdb-fauxton/blob/master/readme.md) has information about how to get the project set up for development.
+The [Readme file](https://github.com/apache/couchdb-fauxton/blob/main/readme.md) has information about how to get the project set up for development.
 
 ## Guide to Contributions
 
 We follow our coding-styleguide to make it easier for everyone to write, read and review code:
-[https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md](https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md)
+[https://github.com/apache/couchdb-fauxton/blob/main/styleguide.md](https://github.com/apache/couchdb-fauxton/blob/main/styleguide.md)
 
 To start working on a specific ticket, create a branch with the GitHub Issue # followed by a traincase description of the issue.
 
@@ -61,4 +61,4 @@ there is room for improvement.
 [6]: http://couchdb.apache.org/conduct.html
 [7]: http://couchdb.apache.org/bylaws.html
 [8]: http://webchat.freenode.net?channels=%23couchdb-dev
-[9]: https://github.com/apache/couchdb/blob/master/CONTRIBUTING.md
+[9]: https://github.com/apache/couchdb/blob/main/CONTRIBUTING.md

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/apache/couchdb-fauxton.svg?branch=master)](https://travis-ci.org/apache/couchdb-fauxton)
+[![Build Status](https://travis-ci.org/apache/couchdb-fauxton.svg?branch=main)](https://travis-ci.org/apache/couchdb-fauxton)
 
 # Fauxton
 
@@ -89,11 +89,11 @@ part of the deployable release artifact.
 
 Check out the following pages for a lot more information about Fauxton:
 
-- [The Fauxton Code Layout](https://github.com/apache/couchdb-fauxton/blob/master/code-layout.md)
-- [Style Guide](https://github.com/apache/couchdb-fauxton/blob/master/styleguide.md)
-- [Testing Fauxton](https://github.com/apache/couchdb-fauxton/blob/master/tests.md)
-- [Extensions](https://github.com/apache/couchdb-fauxton/blob/master/extensions.md)
-- [How to contribute](https://github.com/apache/couchdb-fauxton/blob/master/CONTRIBUTING.md)
+- [The Fauxton Code Layout](https://github.com/apache/couchdb-fauxton/blob/main/code-layout.md)
+- [Style Guide](https://github.com/apache/couchdb-fauxton/blob/main/styleguide.md)
+- [Testing Fauxton](https://github.com/apache/couchdb-fauxton/blob/main/tests.md)
+- [Extensions](https://github.com/apache/couchdb-fauxton/blob/main/extensions.md)
+- [How to contribute](https://github.com/apache/couchdb-fauxton/blob/main/CONTRIBUTING.md)
 
 
 ------


### PR DESCRIPTION
## Overview

Changed all the urls pointing to master branch to main branch.

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/master/rebar.config.script) with the correct tag once a new Fauxton release is made
