### PR TITLE
Replace safeURLName usage in code

### DIFF
--- a/app/addons/documents/index-editor/components/IndexEditor.js
+++ b/app/addons/documents/index-editor/components/IndexEditor.js
@@ -101,9 +101,7 @@ export default class IndexEditor extends Component {
     if (this.props.designDocId === 'new-doc' || this.props.isNewView) {
       return '#' + FauxtonAPI.urls('allDocs', 'app', encodedDatabase, encodedPartitionKey);
     }
-    const encodedDDoc = this.props.designDocId.startsWith('_design/') ?
-      '_design/' + encodeURIComponent(this.props.designDocId.substring(8)) :
-      encodeURIComponent(this.props.designDocId);
+    const encodedDDoc = app.utils.getSafeIdForDoc(this.props.designDocId);
     const encodedView = encodeURIComponent(this.props.viewName);
     return '#' + FauxtonAPI.urls('view', 'showView', encodedDatabase, encodedPartitionKey, encodedDDoc, encodedView);
   }

--- a/app/addons/documents/resources.js
+++ b/app/addons/documents/resources.js
@@ -64,8 +64,7 @@ Documents.DdocInfo = FauxtonAPI.Model.extend({
   // treated separately. For instance, we could default into the
   // json editor for docs, or into a ddoc specific page.
   safeID: function () {
-    var ddoc = this.id.replace(/^_design\//, "");
-    return "_design/" + app.utils.safeURLName(ddoc);
+    return app.utils.getSafeIdForDoc(this.id);
   }
 });
 

--- a/app/addons/search/components/SearchIndexEditor.js
+++ b/app/addons/search/components/SearchIndexEditor.js
@@ -96,8 +96,7 @@ export default class SearchIndexEditor extends React.Component {
       return '#' + FauxtonAPI.urls('allDocs', 'app', encodedDatabase, encodedPartitionKey);
     }
 
-    const cleanDDocName = this.props.lastSavedDesignDocName.replace(/^_design\//, '');
-    const encodedDDoc = '_design/' + encodeURIComponent(cleanDDocName);
+    const encodedDDoc = app.utils.getSafeIdForDoc(this.props.lastSavedDesignDocName);
     const encodedIndex = encodeURIComponent(this.props.lastSavedSearchIndexName);
     return '#' + FauxtonAPI.urls('search', 'showIndex', encodedDatabase,
       encodedPartitionKey, encodedDDoc, encodedIndex);


### PR DESCRIPTION
## Overview

Replacing the usage of `safeUrlName` for designDocs with removed `_design/` with a appUtils method `getSafeIdForDoc` which does the same internally. I have updated the code in places which was manually doing the same.

## Testing recommendations

Current test cases should cover the regression testing.

## GitHub issue number

Fixes #875 

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
