### PR TITLE
Extract all styles from index html

### DIFF
--- a/assets/index.underscore
+++ b/assets/index.underscore
@@ -21,18 +21,6 @@
   <link rel="shortcut icon" type="image/png" href="dashboard.assets/img/couchdb-logo.png"/>
   <title><%= htmlWebpackPlugin.options.title %></title>
 
-  <!-- Application styles. -->
-  <style>
-    .noscript-warning {
-      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-      padding: 1px 30px 10px 30px;
-      color: #fff;
-      background: @brandHighlight;
-      margin: 100px;
-      box-shadow: 2px 2px 5px #989898;
-    }
-  </style>
-
 </head>
 
 <body id="home">

--- a/assets/less/fauxton.less
+++ b/assets/less/fauxton.less
@@ -37,6 +37,7 @@
 @import "animations.less";
 @import "react-animations.less";
 @import "notification-center.less";
+@import "noscript.less";
 
 /**
  * HTML-wide overrides

--- a/assets/less/noscript.less
+++ b/assets/less/noscript.less
@@ -1,0 +1,22 @@
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+//  use this file except in compliance with the License. You may obtain a copy of
+//  the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//  License for the specific language governing permissions and limitations under
+//  the License.
+
+@import "variables.less";
+
+.noscript-warning {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  padding: 1px 30px 10px 30px;
+  color: #fff;
+  background: @brandHighlight;
+  margin: 100px;
+  box-shadow: 2px 2px 5px #989898;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15768,29 +15768,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "style-loader": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
-      "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^1.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "node-fetch": "^2.6.7",
     "redux-mock-store": "^1.5.4",
     "sinon": "^7.5.0",
-    "style-loader": "^0.23.1",
     "url-loader": "^2.3.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -12,6 +12,7 @@
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const settings = require('./tasks/helper')
   .init()
   .readSettingsFile()
@@ -40,6 +41,10 @@ module.exports = {
       generationLabel: 'Fauxton Dev',
       generationDate: new Date().toISOString()
     }, settings.variables)),
+    new MiniCssExtractPlugin({
+      filename: 'dashboard.assets/css/styles.[chunkhash].css',
+      chunkFilename: 'dashboard.assets/css/styles.[chunkhash].css'
+    })
   ],
   module: {
     rules: [
@@ -75,7 +80,13 @@ module.exports = {
       {
         test: /\.less$/,
         use: [
-          "style-loader",
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: '../../',
+              hmr: false,
+            },
+          },
           "css-loader",
           {
             loader: "less-loader",
@@ -91,7 +102,13 @@ module.exports = {
       {
         test: /\.css$/,
         use: [
-          "style-loader",
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: '../../',
+              hmr: false,
+            },
+          },
           "css-loader"
         ]
       },

--- a/webpack.config.release.js
+++ b/webpack.config.release.js
@@ -129,7 +129,13 @@ module.exports = {
     },
     {
       test: /\.css$/, use: [
-        'style-loader',
+        {
+          loader: MiniCssExtractPlugin.loader,
+          options: {
+            publicPath: '../../',
+            hmr: false,
+          },
+        },
         'css-loader'
       ]
     },


### PR DESCRIPTION
## Overview

Configure webpack to insert generated css styles as links rather than
inline. This completely removes the need for CSP policies with
`style-src unsafe-inline`, enabling users to have more restrictive
CSP policies.

## Testing recommendations

To verify if the styles are correctly loaded a server with the CSP policy preventing unsafe-inline styles needs to be used, javascript needs to be disabled in the browser to verify the styles are correctly applied for the nonscript use case.

## GitHub issue number

n/a

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
