### PR TITLE
Fix: permanent notification banner

### DIFF
--- a/app/addons/fauxton/appwrapper.js
+++ b/app/addons/fauxton/appwrapper.js
@@ -76,6 +76,9 @@ class App extends React.Component {
     const mainClass = classNames(
       {'closeMenu': this.props.isPrimaryNavMinimized}
     );
+    const appContainerClass = classNames(
+      {'app-container__with-perm-notification': this.props.isPermanentNotificationShowing}
+    );
     return (
       <div>
         <ToastContainer
@@ -96,7 +99,7 @@ class App extends React.Component {
           <NotificationPanelContainer />
         </div>
         <div id="main"  className={mainClass}>
-          <div id="app-container">
+          <div id="app-container" className={appContainerClass}>
             <div className="wrapper">
               <div role="main" className="pusher">
                 <ContentWrapper router={this.props.router} setNavbarActiveLink={this.props.setNavbarActiveLink}/>
@@ -113,9 +116,11 @@ class App extends React.Component {
 }
 
 export default connect(
-  ({ navigation }) => {
+  ({ navigation, notifications }) => {
     return {
-      isPrimaryNavMinimized: navigation.isMinimized};
+      isPrimaryNavMinimized: navigation.isMinimized,
+      isPermanentNotificationShowing: notifications.permanentNotificationVisible,
+    };
   },
   (dispatch) => {
     return {

--- a/app/addons/fauxton/assets/less/components.less
+++ b/app/addons/fauxton/assets/less/components.less
@@ -54,13 +54,19 @@ button.clipboard-copy-element {
 
 #perma-warning {
   background-color: white;
+  height: 3.5rem;
+  border-bottom-style: solid;
+  border-width: 2px;
+  border-top-style: solid;
+  border-color: #B11925; 
+  overflow-y: auto;
 }
 
 .perma-warning__content {
-  margin: 4px;
-  padding: 10px;
+  margin: 0rem;
+  padding: 0.5rem 1rem 0.5rem 1rem;
   color: #B11925;
-  outline-style: solid;
-  outline-color: #B11925;
-  outline-width: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  position: relative;
 }

--- a/app/addons/fauxton/notifications/components/PermanentNotification.js
+++ b/app/addons/fauxton/notifications/components/PermanentNotification.js
@@ -34,15 +34,15 @@ export default class PermanentNotification extends React.Component {
   }
 
   getContent () {
-    if (!this.props.visible || !this.props.message) {
-      return null;
-    }
     return (
       <p className="perma-warning__content" dangerouslySetInnerHTML={this.getMsg()}></p>
     );
   }
 
   render () {
+    if (!this.props.visible || !this.props.message) {
+      return null;
+    }
     return (
       <div id="perma-warning">
         {this.getContent()}

--- a/assets/less/templates.less
+++ b/assets/less/templates.less
@@ -28,6 +28,10 @@
   height: 100vh;
   position: relative;
   overflow: hidden;
+
+  &.app-container__with-perm-notification {
+    height: calc(100vh - 3.5rem);
+  }
 }
 
 @media screen and (max-height: 600px) {


### PR DESCRIPTION
## Overview

When the permanent notification banner is displayed, the browser shows a vertical scroll bar for the whole page.
This happens because the banner is located outside the App `<div>`, which is is set to 100% height. 
Therefore, the total height becomes 100% + banner height, hence the scrollbar showing.

This PR adjusts the height of the App `<div>` when the permanent notification is visible.

**BEFORE**
![image](https://user-images.githubusercontent.com/30349380/151430343-048d71ff-8c31-4ccd-a7c3-dfc9534053e7.png)

**AFTER**
![image](https://user-images.githubusercontent.com/30349380/151430379-783d2778-baf1-42b8-8551-fe78b61e3e50.png)


## Testing recommendations

Call `Fauxton.showPermanentNotification("a msg here");` and verify the vertical scrollbar doesn't appear.

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
