### PR TITLE
chore: remove google plus references

### DIFF
--- a/app/addons/documentation/assets/less/documentation.less
+++ b/app/addons/documentation/assets/less/documentation.less
@@ -51,13 +51,6 @@
       background-size: 40px auto;
     }
 
-    .google-plus-icon {
-      background: transparent url('../../../../../assets/img/googleplus.png') no-repeat 50% 50%;
-      height: 40px;
-      width: 40px;
-      background-size: 40px auto;
-    }
-
     .twitter-icon {
       background: transparent url('../../../../../assets/img/twitter.png') no-repeat 50% 50%;
       height: 50px;

--- a/app/addons/documentation/components.js
+++ b/app/addons/documentation/components.js
@@ -59,11 +59,6 @@ const docLinks = [
     iconClassName: 'twitter-icon'
   },
   {
-    title: 'Follow CouchDB on Google Plus',
-    link: 'https://plus.google.com/+CouchDB',
-    iconClassName: 'google-plus-icon'
-  },
-  {
     title: 'Follow CouchDB on LinkedIn',
     link: 'https://www.linkedin.com/company/apache-couchdb',
     iconClassName: 'linkedin-icon'

--- a/app/addons/documentation/tests/nightwatch/checksDocsPage.js
+++ b/app/addons/documentation/tests/nightwatch/checksDocsPage.js
@@ -28,7 +28,6 @@ module.exports = {
       .waitForElementVisible('a[href="https://couchdb.apache.org/fauxton-visual-guide/index.html"]', waitTime, false)
       .waitForElementVisible('a[href="http://www.apache.org/"]', waitTime, false)
       .waitForElementVisible('a[href="https://twitter.com/couchdb"]', waitTime, false)
-      .waitForElementVisible('a[href="https://plus.google.com/+CouchDB"]', waitTime, false)
       .waitForElementVisible('a[href="https://www.linkedin.com/company/apache-couchdb"]', waitTime, false)
       .end();
   }

--- a/assets/less/bootstrap/font-awesome/font-awesome-ie7.less
+++ b/assets/less/bootstrap/font-awesome/font-awesome-ie7.less
@@ -1041,16 +1041,6 @@ a [class*=" icon-"] {
 }
 
 
-.icon-google-plus-sign {
-  .ie7icon('&#xf0d4;');
-}
-
-
-.icon-google-plus {
-  .ie7icon('&#xf0d5;');
-}
-
-
 .icon-money {
   .ie7icon('&#xf0d6;');
 }

--- a/assets/less/bootstrap/font-awesome/icons.less
+++ b/assets/less/bootstrap/font-awesome/icons.less
@@ -195,8 +195,6 @@
 .icon-truck:before { content: @truck; }
 .icon-pinterest:before { content: @pinterest; }
 .icon-pinterest-sign:before { content: @pinterest-sign; }
-.icon-google-plus-sign:before { content: @google-plus-sign; }
-.icon-google-plus:before { content: @google-plus; }
 .icon-money:before { content: @money; }
 .icon-caret-down:before { content: @caret-down; }
 .icon-caret-up:before { content: @caret-up; }

--- a/assets/less/bootstrap/font-awesome/variables.less
+++ b/assets/less/bootstrap/font-awesome/variables.less
@@ -385,10 +385,6 @@
 
   @pinterest-sign: "\f0d3";
 
-  @google-plus-sign: "\f0d4";
-
-  @google-plus: "\f0d5";
-
   @money: "\f0d6";
 
   @caret-down: "\f0d7";


### PR DESCRIPTION
## Overview
In the Fauxton docs section, there's a reference to Google Plus:

![Bildschirmfoto vom 2022-02-14 10-59-25](https://user-images.githubusercontent.com/17586/153842205-31b8c1ce-9dbc-41c0-aa38-45c84cd1a1b6.png)

Since Google Plus was discontinued on April 2, 2019, we can remove this.

Thanks to @m90 for finding this!