### PR TITLE
Remove dependency to 'couchapp'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5460,12 +5460,6 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
-    "coffee-script": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
-      "dev": true
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -5488,12 +5482,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -5569,18 +5557,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "connect": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
-      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "finalhandler": "1.1.2",
-        "parseurl": "~1.3.3",
-        "utils-merge": "1.0.1"
       }
     },
     "connect-history-api-fallback": {
@@ -5696,34 +5672,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "couchapp": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/couchapp/-/couchapp-0.11.0.tgz",
-      "integrity": "sha1-8J3DFdYQ9vbnn9DK9eXWJLDMeD4=",
-      "dev": true,
-      "requires": {
-        "coffee-script": "*",
-        "connect": "*",
-        "http-proxy": "0.8.7",
-        "nano": "*",
-        "request": "*",
-        "url": "*",
-        "watch": "~0.8.0"
-      },
-      "dependencies": {
-        "http-proxy": {
-          "version": "0.8.7",
-          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.7.tgz",
-          "integrity": "sha1-p7xThhgJLNJu0ZHkYlkzuu9t6A4=",
-          "dev": true,
-          "requires": {
-            "colors": "0.x.x",
-            "optimist": "0.3.x",
-            "pkginfo": "0.2.x"
-          }
-        }
-      }
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -12032,15 +11980,6 @@
         "is-wsl": "^1.1.0"
       }
     },
-    "optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-      "dev": true,
-      "requires": {
-        "wordwrap": "~0.0.2"
-      }
-    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -12567,12 +12506,6 @@
       "requires": {
         "find-up": "^3.0.0"
       }
-    },
-    "pkginfo": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
-      "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg=",
-      "dev": true
     },
     "pn": {
       "version": "1.1.0",
@@ -15392,12 +15325,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "watch": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-0.8.0.tgz",
-      "integrity": "sha1-G7DupT3v5uYh6cjGPANYAH7L28w=",
-      "dev": true
-    },
     "watchpack": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
@@ -16084,12 +16011,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "worker-farm": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "babel-loader": "^8.2.3",
     "babel-plugin-array-includes": "^2.0.3",
     "bootstrap": "^3.4.1",
-    "couchapp": "^0.11.0",
     "css-loader": "^3.6.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",

--- a/tasks/couchapp.js
+++ b/tasks/couchapp.js
@@ -11,11 +11,22 @@
 // the License.
 
 const path = require("path");
-const couchapp = require("couchapp");
 const { URL } = require("url");
+
+function loadCouchapp() {
+  try {
+    return require("couchapp");
+  } catch (ex) {
+    console.error("Missing dependency. Run 'npm install couchapp --no-save' and try again.");
+  }
+}
 
 module.exports = function (grunt) {
   grunt.registerMultiTask("couchapp", "Install Couchapp", function () {
+    // Loading 'couchapp' at runtime to avoid adding it to Fauxton's package.json
+    // because 'npm audit' is reporting vulnerabilities against it, and the package is
+    // no longer maintained.
+    const couchapp = loadCouchapp();
     const done = this.async();
     const appobj = require(path.join(process.cwd(), path.normalize(this.data.app)));
     return couchapp.createApp(appobj, this.data.db, function (app) {


### PR DESCRIPTION
## Overview

Removes 'couchapp' from package.json due to vulnerabilities reported against the package, which is no longer maintained.

Instead of removing the Grunt task that uses it altogether, it loads the package at runtime.
This way users can choose to install the dependency if they still require the ability to install Fauxton as a CouchApp.

## Testing recommendations

Run 'npm run couchapp', which requires a local CouchDB server.

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
