### PR TITLE
fix build status badge (readme)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-![Build Status](https://github.com/github/docs/actions/workflows/main.yml/badge.svg?branch=main)
+![Build Status](https://github.com/apache/couchdb-fauxton/actions/workflows/main.yml/badge.svg?branch=main)
 
 # Fauxton
 


### PR DESCRIPTION
Having moved from Travis to GitHub Actions, the [build status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) was updated. This PR fixes an earlier change.