### PR TITLE
change create db interface to radio buttons

### DIFF
--- a/app/addons/databases/__tests__/components.test.js
+++ b/app/addons/databases/__tests__/components.test.js
@@ -1,3 +1,4 @@
+
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy of
 // the License at
@@ -35,6 +36,13 @@ describe('AddDatabaseWidget', () => {
     el.setState({databaseName: 'my-db'});
     el.instance().onAddDatabase();
     sinon.assert.calledWith(Actions.createNewDatabase, 'my-db');
+  });
+
+  it('creates a non-partitioned database', () => {
+    const el = mount(<Views.AddDatabaseWidget showPartitionedOption={true}/>);
+    el.setState({databaseName: 'my-db', partitionedSelected: false});
+    el.instance().onAddDatabase();
+    sinon.assert.calledWith(Actions.createNewDatabase, 'my-db', false);
   });
 
   it('creates a partitioned database', () => {

--- a/app/addons/databases/components.js
+++ b/app/addons/databases/components.js
@@ -312,7 +312,7 @@ class AddDatabaseWidget extends React.Component {
     this.state = {
       isPromptVisible: false,
       databaseName: '',
-      partitionedSelected: undefined
+      partitionedSelected: false
     };
 
     this.onTrayToggle = this.onTrayToggle.bind(this);
@@ -374,7 +374,7 @@ class AddDatabaseWidget extends React.Component {
     }
     const partitionedDbHelp = this.props.partitionedDbHelpText ? (
       <Accordion className='partitioned-db-help'>
-        <AccordionItem title='What is a Partitioned Database?'>
+        <AccordionItem title='Which should I chose?'>
           <p dangerouslySetInnerHTML={{__html: this.props.partitionedDbHelpText}} />
         </AccordionItem>
       </Accordion>
@@ -385,13 +385,26 @@ class AddDatabaseWidget extends React.Component {
           Partitioning
         </label>
         <div className='partitioned-db-options'>
-          <input
-            id="partitioned-db"
-            type="checkbox"
-            checked={this.state.partitionedSelected === true}
-            onChange={this.onTogglePartitioned}
-          />
-          <label htmlFor="partitioned-db">Partitioned</label>
+          <form>
+            <label htmlFor="non-partitioned-option">
+              <input
+                id="non-partitioned-option"
+                type="radio"
+                checked={this.state.partitionedSelected === false}
+                onChange={this.onTogglePartitioned}
+              />
+              Non-partitioned - recommended for most workloads
+            </label>
+            <label htmlFor="partitioned-option">
+              <input
+                id="partitioned-option"
+                type="radio"
+                checked={this.state.partitionedSelected === true}
+                onChange={this.onTogglePartitioned}
+              />
+              Partitioned
+            </label>
+          </form>
         </div>
         {partitionedDbHelp}
       </div>
@@ -561,3 +574,4 @@ export default {
   JumpToDatabaseWidget: JumpToDatabaseWidget,
   DatabasePagination: DatabasePagination
 };
+

--- a/app/addons/databases/tests/nightwatch/createsDatabasePartitioned.js
+++ b/app/addons/databases/tests/nightwatch/createsDatabasePartitioned.js
@@ -1,3 +1,4 @@
+
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy of
 // the License at
@@ -51,10 +52,11 @@ module.exports = {
       .clickWhenVisible('.add-new-database-btn')
       .waitForElementVisible('#js-new-database-name', waitTime, false)
       .setValue('#js-new-database-name', [newDatabaseName])
+      .clickWhenVisible('#partitioned-option', waitTime, false)
       .clickWhenVisible('#js-create-database', waitTime, false)
       .waitForElementNotPresent('.new-database-tray', waitTime, false)
       .checkForDatabaseCreated(newDatabaseName, waitTime)
-      .url(baseUrl + '/#/_all_dbs')
+      .url(baseUrl + '/_all_dbs')
       .waitForElementVisible('html', waitTime, false)
       .getText('html', function (result) {
         var data = result.value,
@@ -80,6 +82,7 @@ module.exports = {
       .clickWhenVisible('.add-new-database-btn')
       .waitForElementVisible('#js-new-database-name', waitTime, false)
       .setValue('#js-new-database-name', [invalidDatabaseName])
+      .clickWhenVisible('#partitioned-option', waitTime, false)
       .clickWhenVisible('#js-create-database', waitTime, false)
       .waitForElementVisible('.Toastify__toast-container .Toastify__toast--error', waitTime, false)
       .url(baseUrl + '/_all_dbs')
@@ -94,3 +97,4 @@ module.exports = {
       .end();
   }
 };
+


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Change the Create Database panel to use radio buttons when partitioning is available. Give more detailed guidance about picking the partitioned option as outlined [here](https://github.ibm.com/cloudant/onecloud/issues/900)

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Can test all of the changes by opening the Create Database panel and creating new partitioned/non-partitioned databases
## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
