### PR TITLE
Fix: space indent in Mango Query editor doesn't match the indent guides

### DIFF
--- a/app/addons/documents/mango/mango.helper.js
+++ b/app/addons/documents/mango/mango.helper.js
@@ -39,7 +39,7 @@ const getIndexName = ({def, type}) => {
 };
 
 const formatCode = (code) => {
-  return JSON.stringify(code, null, 3);
+  return JSON.stringify(code, null, 2);
 };
 
 const getIndexContent = (doc) => {


### PR DESCRIPTION
## Overview

The Mango query editor was using a 3-space indent, which doesn't match the indent guides drawn in the editor (2 spaces).
This PR updates the formatter so both use 2-space ident. 

Before
<img width="426" alt="2nd_level {" src="https://user-images.githubusercontent.com/30349380/217908555-507e6076-565d-4cd9-acec-6144e3184a71.png">

After
<img width="421" alt="Mango Query ®" src="https://user-images.githubusercontent.com/30349380/217908604-af504f09-ff6f-4498-b5f8-21cbf6541b72.png">


## Testing recommendations

Run Fauxton and verify the indent guide line up with the formatted text.

## GitHub issue number

https://github.com/apache/couchdb-fauxton/issues/1313

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
