### PR TITLE
Bug fix for replication page

### DIFF
--- a/app/addons/replication/components/activity.js
+++ b/app/addons/replication/components/activity.js
@@ -48,7 +48,7 @@ export default class Activity extends React.Component {
       docs = this.props.docs.filter(doc => doc.selected);
     }
 
-    this.props.deleteDocs(docs);
+    this.props.deleteDocs(docs, this.props.pageLimit);
     this.closeModal();
   }
 
@@ -112,5 +112,6 @@ Activity.propTypes = {
   onFilterChange: PropTypes.func.isRequired,
   deleteDocs: PropTypes.func.isRequired,
   activitySort: PropTypes.object.isRequired,
-  changeActivitySort: PropTypes.func.isRequired
+  changeActivitySort: PropTypes.func.isRequired,
+  pageLimit: PropTypes.number.isRequired,
 };

--- a/app/addons/replication/container.js
+++ b/app/addons/replication/container.js
@@ -109,7 +109,7 @@ const mapStateToProps = ({replication, databases}, ownProps) => {
   };
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = (dispatch) => {
   return {
     checkForNewApi: () => dispatch(checkForNewApi()),
     updateFormField: (fieldName) => (value) => {
@@ -127,7 +127,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     filterReplicate: (filter) => dispatch(filterReplicate(filter)),
     filterDocs: (filter) => dispatch(filterDocs(filter)),
     selectDoc: (doc) => dispatch(selectDoc(doc)),
-    deleteDocs: (docs) => dispatch(deleteDocs(docs, ownProps.pageLimit)),
+    deleteDocs: (docs, pageLimit) => dispatch(deleteDocs(docs, pageLimit)),
     selectAllDocs: () => dispatch(selectAllDocs()),
     changeActivitySort: (sort) => dispatch(changeActivitySort(sort)),
     selectAllReplicates: () => dispatch(selectAllReplicates()),

--- a/app/addons/replication/controller.js
+++ b/app/addons/replication/controller.js
@@ -146,6 +146,7 @@ export default class ReplicationController extends React.Component {
       deleteDocs={deleteDocs}
       activitySort={activitySort}
       changeActivitySort={changeActivitySort}
+      pageLimit={pageLimit}
     />;
   }
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Fix the use of `page limit` in deleteDocs() in the container for the replication page. It was receiving a NaN value, now it receives the proper page limit.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

The replication page should reload after a document is deleted with the number of reps dictated by the page limit set in the footer.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
