### PR TITLE
[Bug fix] Adjust nav bar icon badge placement

### DIFF
--- a/app/addons/fauxton/assets/scss/_navigation.scss
+++ b/app/addons/fauxton/assets/scss/_navigation.scss
@@ -45,10 +45,20 @@
 
 .faux-navbar--narrow {
   width: $cf-navbar-width-collapsed;
+
+  .faux-navbar__icon-badge:after {
+    bottom: 38px;
+    right: 10px;
+  }
 }
 
 .faux-navbar--wide {
   width: $cf-navbar-width;
+
+  .faux-navbar__icon-badge:after {
+    bottom: 11.5px;
+    right: 107px;
+  }
 }
 
 .faux-navbar__burger:hover .faux-navbar__burger__icon {
@@ -132,16 +142,6 @@
   text-align: center;
   font-size: 0.5rem;
   border-radius: 50%;
-}
-
-.faux-navbar--wide .faux-navbar__icon-badge:after {
-  bottom: 12px;
-  right: 107px;
-}
-
-.faux-navbar--narrow .faux-navbar__icon-badge:after {
-  bottom: 38px;
-  right: 10px;
 }
 
 .faux-navbar__link:hover .faux-navbar__icon-badge:after {

--- a/app/addons/fauxton/assets/scss/_navigation.scss
+++ b/app/addons/fauxton/assets/scss/_navigation.scss
@@ -125,8 +125,6 @@
   content: "";
   display: inline-block;
   position: relative;
-  top: -42px;
-  right: 8px;
   background: $cf-navbar-item-badge-bg;
   border: 1px solid $cf-navbar-item-badge-bg;
   height: 8px;
@@ -134,6 +132,16 @@
   text-align: center;
   font-size: 0.5rem;
   border-radius: 50%;
+}
+
+.faux-navbar--wide .faux-navbar__icon-badge:after {
+  bottom: 12px;
+  right: 107px;
+}
+
+.faux-navbar--narrow .faux-navbar__icon-badge:after {
+  bottom: 38px;
+  right: 10px;
 }
 
 .faux-navbar__link:hover .faux-navbar__icon-badge:after {


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

The icon badge indicating a new announcement is out of alignment with the nav bar when it is expanded. This change keeps it in the same place relative to the icon, regardless of the nav bar view.


## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Check that the badge stays in place.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
