### PR TITLE
[Bug fix] Set a default value for local database source/target for New Replications

### DIFF
--- a/app/addons/replication/reducers.js
+++ b/app/addons/replication/reducers.js
@@ -142,6 +142,20 @@ const updateFormField = (state, fieldName, value) => {
     }
   }
 
+  // Set default local source/target database to the first in the list (to match the default dropdown display)
+  if (fieldName === validFieldMap.replicationSource) {
+    const isLocalDB = updateState[validFieldMap.replicationSource] === Constants.REPLICATION_SOURCE.LOCAL;
+    if (isLocalDB && updateState.databases.length > 0) {
+      updateState[validFieldMap.localSource] = updateState.databases[0];
+    }
+  }
+  if (fieldName === validFieldMap.replicationTarget) {
+    const isLocalDB = updateState[validFieldMap.replicationTarget] === Constants.REPLICATION_TARGET.EXISTING_LOCAL_DATABASE;
+    if (isLocalDB && updateState.databases.length > 0) {
+      updateState[validFieldMap.localTarget] = updateState.databases[0];
+    }
+  }
+
   return updateState;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

When `Local database` is selected as the source/target for a new replication, set the internal value of `localSource/localTarget` to the first database by default. This reflects the behavior of the dropdown menu. 

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
Set the source/target type to `Local database` without changing the selection of the `Name` dropdown menu. The default value should be set to the first database and the `Start Replication `button should be enabled. 

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
