### PR TITLE
[Bug fix] Changes feed duplicating results

### DIFF
--- a/app/addons/documents/changes/actions.js
+++ b/app/addons/documents/changes/actions.js
@@ -17,7 +17,6 @@ import { get } from '../../../core/ajax';
 import ActionTypes from './actiontypes';
 import Helpers from '../helpers';
 
-// const pollingTimeout = 60000;
 let currentDatabase, latestSeqNum;
 
 const addFilter = (filter) => (dispatch) => {
@@ -43,11 +42,12 @@ const getLatestChanges = (dispatch, databaseName) => {
     limit: 100
   };
 
-
+  // trigger a reset of the state if the current database is switched
   if (!currentDatabase || currentDatabase !== databaseName) {
     currentDatabase = databaseName;
     latestSeqNum = null;
   }
+  // otherwise only query for new changes since the most recent ones
   if (latestSeqNum) {
     params.since = latestSeqNum;
   }
@@ -70,6 +70,7 @@ const getLatestChanges = (dispatch, databaseName) => {
 };
 
 const updateChanges = (json, dispatch) => {
+  // if latestSeqNum is null, the state should be reset
   const resetChanges = !latestSeqNum;
   latestSeqNum = Helpers.getSeqNum(json.last_seq);
   dispatch({

--- a/app/addons/documents/changes/components/ChangesScreen.js
+++ b/app/addons/documents/changes/components/ChangesScreen.js
@@ -26,7 +26,7 @@ export default class ChangesScreen extends React.Component {
     let msg = '';
     if (isShowingSubset) {
       let numChanges = changes.length;
-      msg = <p className="changes-result-limit">Limiting results to latest <b>{numChanges}</b> changes.</p>;
+      msg = <p className="changes-result-limit">Limiting results to <b>{numChanges}</b> changes.</p>;
     }
     return msg;
   }

--- a/app/addons/documents/changes/reducers.js
+++ b/app/addons/documents/changes/reducers.js
@@ -24,13 +24,19 @@ const initialState = {
   lastSequenceNum: null
 };
 
-function updateChanges(state, seqNum, changes) {
-  const newState = {
-    ...state,
+function updateChanges(state, seqNum, changes, reset) {
+  // reset to the initial state when switching between databases so changes aren't carried over
+  const newState = (reset) ? {
+    ...initialState,
     // make a note of the most recent sequence number. This is used for a point of reference for polling for new changes
     lastSequenceNum: seqNum,
     isLoaded: true
-  };
+  } :
+    {
+      ...state,
+      lastSequenceNum: seqNum,
+      isLoaded: true
+    };
 
   // mark any additional changes that come after first page load as "new" so we can add a nice highlight effect
   // when the new row is rendered
@@ -108,11 +114,7 @@ export default function changes (state = initialState, action) {
   switch (action.type) {
 
     case ActionTypes.UPDATE_CHANGES:
-      // only bother updating the list of changes if the seq num has changed
-      if (state.lastSequenceNum !== action.seqNum) {
-        return updateChanges(state, action.seqNum, action.changes);
-      }
-      return state;
+      return updateChanges(state, action.seqNum, action.changes, action.resetChanges);
 
     case ActionTypes.ADD_CHANGES_FILTER_ITEM:
       return addFilter(state, action.filter);


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

- Update the logic used for populating the changes feed. The query now uses the `since` parameter when loading new changes for the current database. This stops previously loaded changes from being passed as new ones and being duplicated. 
- The internal state will reset when switched to a new database, so changes aren't carried over. A hard reset was only happening with a manual reload, so changes for multiple databases were appearing in one feed. 
- Change the message on the changes feed to `Limiting results to 100 changes` instead of `Limiting results to latest 100 changes` since the order cannot be guaranteed.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

Click on changes for any database. Click away within the document side panel (e.g. permissions) then switch back to changes. The feed should stay consistent and no longer be inundated with duplicated changes. Make a new document and switch back to changes, this should be the only change reflected in the feed. Then create a new database with no documents. That changes feed should be empty.
This is new behavior that fixes a bug in the changes feed.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
