### PR TITLE
Add nightwatch config for Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8921,9 +8921,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -25544,9 +25544,9 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true
     },
     "get-intrinsic": {

--- a/test/nightwatch_tests/helpers/helpers.js
+++ b/test/nightwatch_tests/helpers/helpers.js
@@ -87,13 +87,21 @@ module.exports = {
       if (res.errors > 0 || res.failed > 0) {
         promGetLog = new Promise((resolve, reject) => {
           try {
-            browser.getLog('browser', (logEntriesArray) => {
-              // !! IMPORTANT: Ends the session since the Nightwatch settings have "end_session_on_fail: false"
-              try {
-                browser.end();
-              } catch (e) {}
-              resolve(logEntriesArray);
+            browser.isLogAvailable('browser', function(isAvailable) {
+              if (isAvailable) {
+                browser.getLog('browser', (logEntriesArray) => {
+                  // !! IMPORTANT: Ends the session since the Nightwatch settings have "end_session_on_fail: false"
+                  try {
+                    browser.end();
+                  } catch (e) {}
+                  resolve(logEntriesArray);
+                });
+              } else {
+                console.warn('Browser logs are not available');
+                resolve([]);
+              }
             });
+            
           } catch (err) {
             reject(err);
           }

--- a/test/nightwatch_tests/nightwatch.json.underscore
+++ b/test/nightwatch_tests/nightwatch.json.underscore
@@ -30,12 +30,17 @@
       "screenshots" : {
         "enabled" : true,
         "path" : "./test/nightwatch_tests/reports"
+        <% 
+        // Add the line below to generate screenshots for any failures
+        // "on_failure" : true
+        %>
       },
       "desiredCapabilities" : {
         "browserName" : "chrome",
         "javascriptEnabled" : true,
         "acceptSslCerts" : true,
-        "chromeOptions": {}
+        "chromeOptions": {},
+        "moz:firefoxOptions": {}
       },
       "exclude": <%= exclude_tests %>,
       "skiptags": <%= skiptags %>


### PR DESCRIPTION
## Overview

Adds ability to run Nightwatch tests using Firefox.

- Added a check to see if the selected driver supports fetching browser logs, which the Geckodriver doesn't, so this prevents  an Exception which terminates Nightwatch when any of the test cases fail. 

## Testing recommendations

Run Nightwatch tests using Firefox, which can be done by setting `test_settings.default.desiredCapabilities.browserName: "firefox"` in `nightwatch.json.underscore`.

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
