### PR TITLE
Add node to Active Tasks

### DIFF
--- a/app/addons/activetasks/assets/scss/activetasks.scss
+++ b/app/addons/activetasks/assets/scss/activetasks.scss
@@ -31,15 +31,19 @@
       }
 
       &.header-database {
-        width: 30%;
+        width: 25%;
       }
 
       &.header-tarted-on {
-        width: 13%;
+        width: 10%;
       }
 
       &.header-updated-on {
-        width: 13%;
+        width: 10%;
+      }
+
+      &.header-node {
+        width: 15%;
       }
 
       &.header-pid {
@@ -47,7 +51,7 @@
       }
 
       &.header-progress {
-        width: 23%;
+        width: 20%;
       }
 
       .fonticon-up-dir,

--- a/app/addons/activetasks/components/tablebodycontents.js
+++ b/app/addons/activetasks/components/tablebodycontents.js
@@ -79,6 +79,7 @@ export default class ActiveTaskTableBodyContents extends React.Component {
       objectField: activeTasksHelpers.getDatabaseFieldMessage(item),
       started_on: activeTasksHelpers.getTimeInfo(item.started_on),
       updated_on: activeTasksHelpers.getTimeInfo(item.updated_on),
+      node: item.node,
       pid: item.pid.replace(/[<>]/g, ''),
       progress: activeTasksHelpers.getProgressMessage(item),
     };
@@ -109,6 +110,7 @@ export default class ActiveTaskTableBodyContents extends React.Component {
         <td>{objectFieldMsg}</td>
         <td>{startedOnMsg}</td>
         <td>{updatedOnMsg}</td>
+        <td>{rowData.node}</td>
         <td>{rowData.pid}</td>
         <td>{progressMsg}</td>
       </tr>

--- a/app/addons/activetasks/components/tableheader.js
+++ b/app/addons/activetasks/components/tableheader.js
@@ -51,6 +51,7 @@ export default class ActiveTasksTableHeader extends React.Component {
       ['database', 'Database'],
       ['started-on', 'Started on'],
       ['updated-on', 'Updated on'],
+      ['node', 'Node'],
       ['pid', 'PID'],
       ['progress', 'Status']
     ]


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Include Node in Active Tasks Component as it was already in the api response.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
When running fauxton navigate to Active Tasks and you will notice the addition of the Node column on all tabs.  Which indicates the cluster node that task is executing on currently.

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
