### PR TITLE
Optimize getParams + Prettify utils

### DIFF
--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -17,131 +17,119 @@
 // want to change this later, but for now this should be thought of as a
 // "purely functional" helper system.
 
-
 import _ from 'lodash';
 import param from 'jquery-param-fn';
 
 const utils = {
+	getParams: function (queryString) {
+		const getUrlParams = (str) => {
+			const urlParams = {};
+			const search = /([^&=]+)=?([^&]*)/g;
+			str.replace(search, (match, key, value) => {
+				urlParams[decodeURIComponent(key)] = decodeURIComponent(value);
+			});
+			return urlParams;
+		};
 
-  // Thanks to: http://stackoverflow.com/a/2880929
-  getParams: function (queryString) {
-    if (queryString) {
-      // I think this could be combined into one if
-      if (queryString.substring(0, 1) === '?') {
-        queryString = queryString.substring(1);
-      } else if (queryString.indexOf('?') > -1) {
-        queryString = queryString.split('?')[1];
-      }
-    }
-    const hash = window.location.hash.split('?')[1];
-    queryString = queryString || hash || window.location.search.substring(1);
-    const urlParams = {},
-          pl = /\+/g,  // Regex for replacing addition symbol with a space
-          search = /([^&=]+)=?([^&]*)/g,
-          decode = function (s) { return decodeURIComponent(s.replace(pl, ' ')); },
-          query = queryString;
+		queryString = (
+			queryString ||
+			window.location.hash.split('?')[1] ||
+			window.location.search.substring(1)
+		).replace(/^\?/, '');
 
-    if (queryString) {
-      let match;
-      while ((match = search.exec(query))) {
-        urlParams[decode(match[1])] = decode(match[2]);
-      }
-    }
+		return getUrlParams(queryString);
+	},
 
-    return urlParams;
-  },
+	removeSpecialCharacters: function (name) {
+		return name.replace(/[^\w\s]/gi, '');
+	},
 
-  removeSpecialCharacters: function (name) {
-    return name.replace(/[^\w\s]/gi, '');
-  },
+	safeURLName: function (name = '') {
+		// These special caracters are allowed by couch: _, $, (, ), +, -, and /
+		// From them only $ + and / are to be escaped in a URI component.
+		// return (/[$+/]/g.test(name)) ? encodeURIComponent(name) : name;
+		return encodeURIComponent(name);
+	},
 
-  safeURLName: function (name = '') {
-    // These special caracters are allowed by couch: _, $, (, ), +, -, and /
-    // From them only $ + and / are to be escaped in a URI component.
-    // return (/[$+/]/g.test(name)) ? encodeURIComponent(name) : name;
-    return encodeURIComponent(name);
-  },
+	queryParams: function (obj) {
+		//Simulates jQuery.param()
+		return param(obj);
+	},
 
-  queryParams: function (obj) {
-    //Simulates jQuery.param()
-    return param(obj);
-  },
+	queryString: function (obj) {
+		//Similar to queryParams() but skips object properties
+		//that are undefined
+		Object.keys(obj).forEach((key) => {
+			if (obj[key] === undefined) {
+				delete obj[key];
+			}
+		});
+		return param(obj);
+	},
 
-  queryString: function (obj) {
-    //Similar to queryParams() but skips object properties
-    //that are undefined
-    Object.keys(obj).forEach((key) => {
-      if (obj[key] === undefined) {
-        delete obj[key];
-      }
-    });
-    return param(obj);
-  },
+	getDocTypeFromId: function (id) {
+		if (id && /^_design\//.test(id)) {
+			return 'design doc';
+		}
 
-  getDocTypeFromId: function (id) {
-    if (id && /^_design\//.test(id)) {
-      return 'design doc';
-    }
+		return 'doc';
+	},
 
-    return 'doc';
-  },
+	isSystemDatabase: function (id) {
+		return /^_/.test(id);
+	},
 
-  isSystemDatabase: function (id) {
-    return (/^_/).test(id);
-  },
+	// Need this to work around backbone router thinking _design/foo
+	// is a separate route. Alternatively, maybe these should be
+	// treated separately. For instance, we could default into the
+	// json editor for docs, or into a ddoc specific page.
+	getSafeIdForDoc: function (id) {
+		if (utils.getDocTypeFromId(id) === 'design doc') {
+			const ddoc = id.replace(/^_design\//, '');
+			return '_design/' + utils.safeURLName(ddoc);
+		}
 
-  // Need this to work around backbone router thinking _design/foo
-  // is a separate route. Alternatively, maybe these should be
-  // treated separately. For instance, we could default into the
-  // json editor for docs, or into a ddoc specific page.
-  getSafeIdForDoc: function (id) {
-    if (utils.getDocTypeFromId(id) === 'design doc') {
-      const ddoc = id.replace(/^_design\//, '');
-      return '_design/' + utils.safeURLName(ddoc);
-    }
+		return utils.safeURLName(id);
+	},
 
-    return utils.safeURLName(id);
-  },
+	// a pair of simple local storage wrapper functions. These ward against problems getting or
+	// setting (e.g. local storage full) and allow you to get/set complex data structures
+	localStorageSet: function (key, value) {
+		if (_.isObject(value) || _.isArray(value)) {
+			value = JSON.stringify(value);
+		}
+		let success = true;
+		try {
+			window.localStorage.setItem(key, value);
+		} catch (e) {
+			success = false;
+		}
+		return success;
+	},
 
-  // a pair of simple local storage wrapper functions. These ward against problems getting or
-  // setting (e.g. local storage full) and allow you to get/set complex data structures
-  localStorageSet: function (key, value) {
-    if (_.isObject(value) || _.isArray(value)) {
-      value = JSON.stringify(value);
-    }
-    let success = true;
-    try {
-      window.localStorage.setItem(key, value);
-    } catch (e) {
-      success = false;
-    }
-    return success;
-  },
+	localStorageGet: function (key) {
+		let data;
+		if (_.has(window.localStorage, key)) {
+			data = window.localStorage[key];
+			try {
+				return JSON.parse(data);
+			} catch (e) {
+				return data;
+			}
+		}
+		return data;
+	},
 
-  localStorageGet: function (key) {
-    let data;
-    if (_.has(window.localStorage, key)) {
-      data = window.localStorage[key];
-      try {
-        return JSON.parse(data);
-      } catch (e) {
-        return data;
-      }
-    }
-    return data;
-  },
+	stripHTML: function (str) {
+		if (!document) {
+			//not in browser, this should be ignored when testing in jest
+			return str;
+		}
 
-  stripHTML: function (str) {
-
-    if (!document) {
-      //not in browser, this should be ignored when testing in jest
-      return str;
-    }
-
-    const tmpElement = document.createElement('div');
-    tmpElement.innerHTML = str;
-    return tmpElement.textContent || tmpElement.innerText;
-  }
+		const tmpElement = document.createElement('div');
+		tmpElement.innerHTML = str;
+		return tmpElement.textContent || tmpElement.innerText;
+	},
 };
 
 export default utils;


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
This PR optimizes the `getParams` function to prevent the use of needless statements (such as while loops). With less statements, the function will block the event loop less, and run smoother.
> Note: The above is the primary reason for this PR. While I was implementing this, I also ran the code through the [prettier](https://tinyurl.com/5hbkwxaa) tool.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

This function should not require any changes to the original codebase, and will not provide any front-end change. To test these, try running it with varying formats of query parameters.

## GitHub issue number

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb-fauxton/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

This fixes no issues, but does end up resolving the comment `// I think this could be combined into one if`.

## Related Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->
N/A

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
> This shouldn't require any changes to existing tests, but I've left this unchecked until you have confirmed
- [ ] Documentation reflects the changes;
> This shouldn't require any changes to existing documentation, but I've left this unchecked until you have confirmed
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
