### PR TITLE
Remove GH action trigger on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [ push, pull_request ]
+on: [ push ]
 jobs:
   run-unit-tests:
     name: Run unit tests


### PR DESCRIPTION
Currently, creating a pr will trigger to run the gh action twice. Remove trigger `pull_request` to run only once.
