### PR TITLE
Fix errors running Nightwatch's execute()

### DIFF
--- a/app/addons/databases/tests/nightwatch/deletesDatabase.js
+++ b/app/addons/databases/tests/nightwatch/deletesDatabase.js
@@ -45,7 +45,7 @@ module.exports = {
       .assert.elementPresent('a[href="database/' + newDatabaseName + '/_all_docs"]')
 
       .waitForElementPresent('button[aria-label="Delete ' + newDatabaseName + '"]', waitTime, false)
-      .execute('button[aria-label="Delete ' + newDatabaseName + '"]").scrollIntoView();')
+      .execute(`document.querySelector("button[aria-label='Delete ${newDatabaseName}']").scrollIntoView();`)
       .clickWhenVisible('button[aria-label="Delete ' + newDatabaseName + '"]', waitTime, false)
 
       .waitForElementVisible('.delete-db-modal', waitTime, false)

--- a/app/addons/documents/tests/nightwatch/deletesDocuments.js
+++ b/app/addons/documents/tests/nightwatch/deletesDocuments.js
@@ -127,7 +127,7 @@ module.exports = {
       .clickWhenVisible('input[id="checkbox-_design/sidebar-update"][type="checkbox"]', waitTime, false)
 
       .waitForElementPresent('.bulk-action-component-selector-group button.toolbar-btn[icon="fonticon-trash"]', waitTime, false)
-      .execute('document.querySelector(".bulk-action-component-selector-group button.toolbar-btn[icon="fonticon-trash"]").scrollIntoView();')
+      .execute('document.querySelector(".bulk-action-component-selector-group button.toolbar-btn[icon=\'fonticon-trash\']").scrollIntoView();')
       .clickWhenVisible('.bulk-action-component-selector-group button.toolbar-btn[icon="fonticon-trash"]')
       .acceptAlert()
 

--- a/app/addons/replication/tests/nightwatch/replicationactivity.js
+++ b/app/addons/replication/tests/nightwatch/replicationactivity.js
@@ -19,8 +19,8 @@ module.exports = {
 
     const replicatorDoc = {
       _id: 'existing-doc-id-view-doc',
-      source: "http://source-db.com",
-      target: "http://target-db.com"
+      source: "https://source-db.com",
+      target: "https://target-db.com"
     };
     client
       .deleteDatabase('_replicator')
@@ -43,8 +43,8 @@ module.exports = {
 
     const replicatorDoc = {
       _id: 'existing-doc-id-edit-doc',
-      source: "http://source-db.com",
-      target: "http://target-db.com"
+      source: "https://source-db.com",
+      target: "https://target-db.com"
     };
     client
       .deleteDatabase('_replicator')
@@ -68,14 +68,14 @@ module.exports = {
 
     const replicatorDoc1 = {
       _id: 'existing-doc-id-filter1',
-      source: "http://source-db.com",
-      target: "http://target-db.com"
+      source: "https://source-db.com",
+      target: "https://target-db.com"
     };
 
     const replicatorDoc2 = {
       _id: 'existing-doc-filter2',
-      source: "http://source-db2.com",
-      target: "http://target-db.com"
+      source: "https://source-db2.com",
+      target: "https://target-db.com"
     };
     client
       .deleteDatabase('_replicator')
@@ -102,14 +102,14 @@ module.exports = {
 
     const replicatorDoc1 = {
       _id: 'existing-doc-id-filter1',
-      source: "http://source-db.com",
-      target: "http://target-db.com"
+      source: "https://source-db.com",
+      target: "https://target-db.com"
     };
 
     const replicatorDoc2 = {
       _id: 'existing-doc-filter2',
-      source: "http://source-db2.com",
-      target: "http://target-db.com"
+      source: "https://source-db2.com",
+      target: "https://target-db.com"
     };
     client
       .deleteDatabase('_replicator')
@@ -139,38 +139,38 @@ module.exports = {
 
     const replicatorDoc1 = {
       _id: 'existing-doc-id-display',
-      source: "http://source-db.com",
-      target: "http://target-db.com"
+      source: "https://source-db.com",
+      target: "https://target-db.com"
     };
 
     const replicatorDoc2 = {
       _id: 'existing-doc-id-display2',
-      source: "http://source-db2.com",
-      target: "http://target-db.com"
+      source: "https://source-db2.com",
+      target: "https://target-db.com"
     };
 
     const replicatorDoc3 = {
       _id: 'existing-doc-id-display3',
-      source: "http://source-db3.com",
-      target: "http://target-db.com"
+      source: "https://source-db3.com",
+      target: "https://target-db.com"
     };
 
     const replicatorDoc4 = {
       _id: 'existing-doc-id-display4',
-      source: "http://source-db4.com",
-      target: "http://target-db.com"
+      source: "https://source-db4.com",
+      target: "https://target-db.com"
     };
 
     const replicatorDoc5 = {
       _id: 'existing-doc-id-display5',
-      source: "http://source-db5.com",
-      target: "http://target-db.com"
+      source: "https://source-db5.com",
+      target: "https://target-db.com"
     };
 
     const replicatorDoc6 = {
       _id: 'existing-doc-id-display6',
-      source: "http://source-db6.com",
-      target: "http://target-db.com"
+      source: "https://source-db6.com",
+      target: "https://target-db.com"
     };
 
     client


### PR DESCRIPTION
## Overview

Fix syntax errors when calling Nightwatch `execute()` function.

## Testing recommendations

Verify that errors like the one below are no longer printed:

```
>> Error
>>      Response 500 POST /session/00adc39b522f52a7247d46533b2f9bc4/execute/sync (19ms)
   {
     value: {
       error: 'javascript error',
       message: 'javascript error: Invalid left-hand side in assignment\n' +
         '  (Session info: chrome=125.0.6422.141)',
       stacktrace: ''
     }
  }
```

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
