### PR TITLE
The doc reset action should not reset the word wrap setting

### DIFF
--- a/app/addons/documents/doc-editor/reducers.js
+++ b/app/addons/documents/doc-editor/reducers.js
@@ -46,7 +46,8 @@ export default function docEditor (state = initialState, action) {
 
     case ActionTypes.RESET_DOC:
       return {
-        ...initialState
+        ...initialState,
+        docEditorPreferences: state.docEditorPreferences
       };
 
     case ActionTypes.DOC_LOADED:


### PR DESCRIPTION
## Overview

Fix: word wrap setting is not persisted after the doc reset action

## Testing recommendations

open doc, toggle the word wrap setting, close doc and open it again, then verify if the previous selection is kept

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
