### PR TITLE
Add process status to tasks

### DIFF
--- a/app/addons/activetasks/components/tablebodycontents.js
+++ b/app/addons/activetasks/components/tablebodycontents.js
@@ -63,6 +63,10 @@ const activeTasksHelpers = {
       progressMessage.push(item.changes_done + ' Changes done.');
     }
 
+    if (_.has(item, 'process_status') && item.process_status != 'waiting') {
+      progressMessage.push('Process Status: ' + item.process_status);
+    }
+
     return progressMessage;
   },
 
@@ -86,6 +90,7 @@ export default class ActiveTaskTableBodyContents extends React.Component {
       node: item.node,
       pid: item.pid.replace(/[<>]/g, ''),
       progress: activeTasksHelpers.getProgressMessage(item),
+      process_status: item.process_status,
     };
   };
 


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

As a user, it would be convenient to see the process_status value for a compaction job. This is because smoosh may start a compaction job and have some progress before suspending it because it's outside the window for processing.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number

This is to address this issue: [https://github.com/apache/couchdb/issues/3816](https://github.com/apache/couchdb/issues/3816)

## Related Pull Requests

N/A

## Checklist

- [x] Code is written and works correctly;
- [ ] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
