### PR TITLE
Update axios to 1.7.9 to address CVE-2024-57965

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@babel/preset-env": "^7.18.10",
         "@babel/preset-react": "^7.18.6",
         "@babel/register": "^7.18.9",
-        "axios": "^1.6.0",
+        "axios": "^1.7.9",
         "babel-jest": "^29.3.1",
         "babel-loader": "^8.2.5",
         "babel-plugin-array-includes": "^2.0.3",
@@ -103,7 +103,7 @@
         "webpack-dev-server": "^4.10.1"
       },
       "engines": {
-        "node": "^18"
+        "node": "^20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5120,9 +5120,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -23000,9 +23000,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/preset-env": "^7.18.10",
     "@babel/preset-react": "^7.18.6",
     "@babel/register": "^7.18.9",
-    "axios": "^1.6.0",
+    "axios": "^1.7.9",
     "babel-jest": "^29.3.1",
     "babel-loader": "^8.2.5",
     "babel-plugin-array-includes": "^2.0.3",


### PR DESCRIPTION
## Overview

Update axios to 1.7.9 to address CVE-2024-57965

## Testing recommendations

No application changes. It should be enough that CI checks pass.

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

- [ ] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
