### PR TITLE
Allow adding extra content to the databases list footer

### DIFF
--- a/app/addons/databases/__tests__/components.test.js
+++ b/app/addons/databases/__tests__/components.test.js
@@ -118,6 +118,16 @@ describe('DatabasePagination', () => {
     expect(controller.find('.all-db-footer__total-db-count').text()).toBe('30');
   });
 
+  it('renders custom content when supplied', () => {
+    const withCustomFooter = (
+      <Views.DatabasePagination linkPath="_custom_path">
+        <span className="custom">custom content</span>
+      </Views.DatabasePagination>
+    );
+    const el = mount(withCustomFooter);
+    expect(el.find('span.custom').exists()).toBe(true);
+  });
+
 });
 
 describe('DatabaseTable', () => {

--- a/app/addons/databases/components.js
+++ b/app/addons/databases/components.js
@@ -531,6 +531,7 @@ class DatabasePagination extends React.Component {
     const { limit, page, totalAmountOfDatabases } = this.state;
     const start = 1 + (page - 1) * limit;
     const end = Math.min(totalAmountOfDatabases, page * limit);
+    const { children } = this.props;
 
     return (
       <footer className="all-db-footer pagination-footer">
@@ -547,6 +548,9 @@ class DatabasePagination extends React.Component {
           Showing <span className="all-db-footer__range">{start}&ndash;{end}</span>
           &nbsp;of&nbsp;<span className="all-db-footer__total-db-count">{totalAmountOfDatabases}</span>
           &nbsp;databases.
+        </div>
+        <div className="custom-db-footer-item">
+          {children}
         </div>
       </footer>
     );

--- a/assets/scss/_pagination.scss
+++ b/assets/scss/_pagination.scss
@@ -44,6 +44,10 @@ footer.pagination-footer {
     margin: 15px 20px 17px 20px;
   }
 
+  .custom-db-footer-item {
+    float: right;
+  }
+
   .documents-pagination {
     float: right;
   }


### PR DESCRIPTION
## Overview

Allow adding extra content to the databases list footer.

## Testing recommendations

Run the dev server and modify `app/addons/databases/layout.js` to add an element under `DatabasePagination`.
Example:

```
<DatabasePagination>
  <span>custom content</span>
</DatabasePagination>
```

then check that the content is displayed at the bottom of the databases list page.

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
