### PR TITLE
Added new reducers to the list of MapReduce reducers in the pull-down list

### DIFF
--- a/app/addons/documents/index-editor/reducers.js
+++ b/app/addons/documents/index-editor/reducers.js
@@ -16,7 +16,7 @@ import Helpers from '../helpers';
 
 const defaultMap = 'function (doc) {\n  emit(doc._id, 1);\n}';
 const defaultReduce = 'function (keys, values, rereduce) {\n  if (rereduce) {\n    return sum(values);\n  } else {\n    return values.length;\n  }\n}';
-const builtInReducers = ['_sum', '_count', '_stats', '_approx_count_distinct'];
+const builtInReducers = ['_sum', '_count', '_stats', '_approx_count_distinct', '_top_1', '_top_10', '_top_100', '_bottom_1', '_bottom_10', '_bottom_100', '_first', '_last'];
 const allReducers = builtInReducers.concat(['CUSTOM', 'NONE']);
 
 const initialState = {


### PR DESCRIPTION
## Overview

The view editor has the following new items added:

```
'_top_1', '_top_10', '_top_100', '_bottom_1', '_bottom_10', '_bottom_100', '_first', '_last'
```

that is three example reducers for the _top_x & _bottom_x reducers, because they can take any number between 1 and 100, and that would be too many for this list. If users wanted to use _top_3, say, they would have to select the CUSTOM reducer and type _top_3 into the text field.

## Testing recommendations

Run Fauxton and create a new MapReduce view. The reducers pull-down list should look like:

![Screenshot 2025-04-08 at 16 36 45](https://github.com/user-attachments/assets/fc3e20c6-0520-4d6c-8d58-cfe72ed9c458)

## Checklist

- [X] Code is written and works correctly;
