### PR TITLE
Fix empty _rev parameter from dropdown select list

### DIFF
--- a/app/addons/documents/rev-browser/components/revisionbrowsercontrols.js
+++ b/app/addons/documents/rev-browser/components/revisionbrowsercontrols.js
@@ -41,7 +41,7 @@ export default class RevisionBrowserControls extends React.Component {
   }
 
   onRevisionClick(revTheirs) {
-    this.props.chooseLeaves(this.props.ours, revTheirs.value);
+    this.props.chooseLeaves(this.props.ours, revTheirs.target.value);
   }
 
   onForwardClick() {


### PR DESCRIPTION
If there are multiple conflict versions in the dropdown field, the http get request was called with an empty rev parameter and failed. Use the right child object to get the value.

Example:

Before:
GET /b/1?rev= HTTP/1.1

After:
GET /b/1?rev=1-03a8cbc32975d2f58295a1ea2617d965 HTTP/1.1
