### PR TITLE
localhost color theme

### DIFF
--- a/app/core/__tests__/utils.test.js
+++ b/app/core/__tests__/utils.test.js
@@ -113,4 +113,41 @@ describe('Utils', () => {
       );
     });
   });
+
+  describe('isLocalDevelopment', () => {
+    it('returns true for localhost', () => {
+      expect(utils.isLocalDevelopment('localhost')).toBe(true);
+    });
+
+    it('returns true for 127.0.0.1', () => {
+      expect(utils.isLocalDevelopment('127.0.0.1')).toBe(true);
+    });
+
+    it('returns true for IPv6 localhost [::1]', () => {
+      expect(utils.isLocalDevelopment('[::1]')).toBe(true);
+    });
+
+    it('returns true for .local domains', () => {
+      expect(utils.isLocalDevelopment('myapp.local')).toBe(true);
+      expect(utils.isLocalDevelopment('test.local')).toBe(true);
+      expect(utils.isLocalDevelopment('dev.mycompany.local')).toBe(true);
+    });
+
+    it('returns false for production domains', () => {
+      expect(utils.isLocalDevelopment('example.com')).toBe(false);
+      expect(utils.isLocalDevelopment('app.example.com')).toBe(false);
+      expect(utils.isLocalDevelopment('couchdb.apache.org')).toBe(false);
+    });
+
+    it('returns false for IP addresses that are not localhost', () => {
+      expect(utils.isLocalDevelopment('203.0.113.1')).toBe(false);
+      expect(utils.isLocalDevelopment('192.168.1.1')).toBe(false);
+      expect(utils.isLocalDevelopment('10.0.0.1')).toBe(false);
+    });
+
+    it('returns false for domains ending with "local" but not .local TLD', () => {
+      expect(utils.isLocalDevelopment('mylocal.com')).toBe(false);
+      expect(utils.isLocalDevelopment('localhost.com')).toBe(false);
+    });
+  });
 });

--- a/app/core/utils.js
+++ b/app/core/utils.js
@@ -141,6 +141,15 @@ const utils = {
     const tmpElement = document.createElement('div');
     tmpElement.innerHTML = str;
     return tmpElement.textContent || tmpElement.innerText;
+  },
+
+  isLocalDevelopment: function (hostname = window.location.hostname) {
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '[::1]' || // IPv6 localhost
+      hostname.endsWith('.local')
+    );
   }
 };
 

--- a/app/main.js
+++ b/app/main.js
@@ -23,6 +23,22 @@ import { Provider } from 'react-redux';
 
 import LoadAddons from './load_addons';
 import '../assets/scss/fauxton.scss';
+// Detect local development environment and apply theme
+function isLocalDevelopment() {
+  const hostname = window.location.hostname;
+
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" || // IPv6 localhost
+    hostname.endsWith(".local")
+  );
+}
+
+// Set the environment indicator on the document root
+if (isLocalDevelopment()) {
+  document.documentElement.setAttribute("data-env", "development");
+}
 
 FauxtonAPI.addMiddleware(thunk);
 const store = createStore(

--- a/app/main.js
+++ b/app/main.js
@@ -23,21 +23,11 @@ import { Provider } from 'react-redux';
 
 import LoadAddons from './load_addons';
 import '../assets/scss/fauxton.scss';
-// Detect local development environment and apply theme
-function isLocalDevelopment() {
-  const hostname = window.location.hostname;
+import Utils from './core/utils';
 
-  return (
-    hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
-    hostname === "[::1]" || // IPv6 localhost
-    hostname.endsWith(".local")
-  );
-}
-
-// Set the environment indicator on the document root
-if (isLocalDevelopment()) {
-  document.documentElement.setAttribute("data-env", "development");
+// Apply color theme based on environment
+if (Utils.isLocalDevelopment()) {
+  document.documentElement.setAttribute('data-env', 'development');
 }
 
 FauxtonAPI.addMiddleware(thunk);

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -27,13 +27,27 @@
 // short.
 // =============================================================================================
 
+// Define theme colors as CSS custom properties for runtime switching between production and localhost
+:root {
+  --cf-brand-highlight: #af2d24;
+  --cf-brand-highlight-hover: #e73d34;
+  --input-focus-border-color: #e79289; // tint of red by 50%
+}
+
+// Localhost/development environment theme (purple)
+:root[data-env="development"] {
+  --cf-brand-highlight: #7b2cbf;
+  --cf-brand-highlight-hover: #9d4edd;
+  --input-focus-border-color: #bd96df; // tint of purple by 50%
+}
+
 // base
 $cf-background01: #f2f2f2 !default; // main page background color. former $background
 $cf-background02: #333333 !default; // background for overlay panels, trays
 $cf-background03: #564e4c !default; // background for items in dropdowns, main nav bar
 $cf-background-01-alt: #f7f7f7 !default; // sidebar subitems, stripped table
-$cf-brand-highlight: #af2d24 !default; // former $brandHighlight
-$cf-brand-hightlight-hover: #e73d34 !default; // former $hoverHighlight
+$cf-brand-highlight: var(--cf-brand-highlight) !default; // former $brandHighlight
+$cf-brand-hightlight-hover: var(--cf-brand-highlight-hover) !default; // former $hoverHighlight
 $cf-border-color01: #cccccc !default;
 $cf-border-color02: #999999 !default;
 $cf-primary: #208019 !default;
@@ -299,7 +313,7 @@ $dropdown-color: $cf-dropdown-color !default;
 
 // forms
 $input-btn-focus-color: rgba($cf-brand-highlight, 0.25) !default;
-$input-focus-border-color: tint-color($cf-brand-highlight, 50%) !default;
+$input-focus-border-color: var(--input-focus-border-color) !default;
 $input-bg: $cf-input-bg !default;
 $form-check-input-checked-bg-color: $cf-check-radio-bg !default;
 $form-check-input-checked-border-color: $cf-check-radio-bg !default;


### PR DESCRIPTION
## Overview

When the app is running in local, it uses a purple color theme.

## Testing recommendations

start the app locally and we should see:

<img width="399" height="368" alt="image" src="https://github.com/user-attachments/assets/d32fa795-47e1-4541-8769-43a775a58491" />

also added a test file for the env detection util function.

## GitHub issue number

Fixes #1466

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
