### PR TITLE
fix: crypto.randomUUID() not available in insecure envs

### DIFF
--- a/app/core/__tests__/api.test.js
+++ b/app/core/__tests__/api.test.js
@@ -42,3 +42,13 @@ describe('URLs', () => {
   });
 
 });
+
+describe('generateUUID', () => {
+
+  it('returns a valid UUID', () => {
+    const uuid = FauxtonAPI.uuid();
+    expect(uuid).toHaveLength(36);
+    const uuid2 = FauxtonAPI.uuid();
+    expect(uuid).not.toBe(uuid2);
+  });
+});

--- a/app/core/api.js
+++ b/app/core/api.js
@@ -122,7 +122,21 @@ FauxtonAPI.getIndexTypePropNames = function () {
 
 // Generate a v4 UUID
 FauxtonAPI.uuid = function () {
-  return crypto.randomUUID();
+  if (crypto && crypto.randomUUID && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return generateUUID();
+
 };
+
+// Generates a random UUID with the same format as crypto.randomUUID().
+// Only meant as an alternative for environments where crypto.randomUUID() is not available.
+function generateUUID() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    const r = Math.random() * 16 | 0;
+    const v = c === 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}
 
 export default FauxtonAPI;


### PR DESCRIPTION
## Overview

Add an alternative implementation for when crypto.randomUUID() is not available in the environment. This can happen because crypto.randomUUID() is only available in the browser under a secure context (HTTPS or localhost), so if Fauxton is accessed via HTTP the function won't exist and cause the app to fail.

## Testing recommendations

No change in behavior - should be enough that CI passes.

## GitHub issue number

n/a

## Related Pull Requests

n/a

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes;
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made
