### PR TITLE
Preserve integers larger than MAX_SAFE_INTEGER in the doc editor

### DIFF
--- a/app/addons/documents/__tests__/shared-resources.test.js
+++ b/app/addons/documents/__tests__/shared-resources.test.js
@@ -1,0 +1,61 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import Backbone from 'backbone';
+import sinon from 'sinon';
+import Documents from '../shared-resources';
+
+describe('Documents.Doc large integer round-trip', () => {
+  const BIG_INT = '9223372036854775807';
+  const ROUNDED = '9223372036854776000';
+  let ajaxStub;
+
+  afterEach(() => {
+    if (ajaxStub) {
+      ajaxStub.restore();
+    }
+  });
+
+  const makeDoc = () => {
+    const doc = new Documents.Doc(
+      { _id: 'large-int-test' },
+      { database: { id: 'db', safeID: () => 'db' } }
+    );
+    doc.url = () => '/db/large-int-test';
+    return doc;
+  };
+
+  it('reads and writes an integer beyond MAX_SAFE_INTEGER without rounding it', () => {
+    const responseBody = `{"_id":"large-int-test","_rev":"1-abc","hugeNumber":${BIG_INT}}`;
+    let sentBody;
+
+    ajaxStub = sinon.stub(Backbone, 'ajax').callsFake((params) => {
+      if (params.type === 'GET') {
+        params.success(responseBody);
+      } else {
+        sentBody = params.data;
+        params.success({ ok: true, id: 'large-int-test', rev: '2-def' });
+      }
+      return { done() {}, fail() {} };
+    });
+
+    const doc = makeDoc();
+
+    doc.fetch();
+    expect(doc.get('hugeNumber').toString()).toEqual(BIG_INT);
+    expect(doc.prettyJSON()).toContain(BIG_INT);
+
+    doc.save();
+    expect(sentBody).toContain(BIG_INT);
+    expect(sentBody).not.toContain(ROUNDED);
+  });
+});

--- a/app/addons/documents/doc-editor/components/DocEditorScreen.js
+++ b/app/addons/documents/doc-editor/components/DocEditorScreen.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Button } from 'react-bootstrap';
 import FauxtonAPI from '../../../../core/api';
+import * as losslessJSON from '../../../../core/lossless-json';
 import FauxtonComponents from '../../../fauxton/components';
 import GeneralComponents from '../../../components/react-components';
 import AttachmentsPanelButton from './AttachmentsPanelButton';
@@ -76,7 +77,7 @@ export default class DocEditorScreen extends React.Component {
         docContent._id = ':' + docContent._id;
       }
     }
-    const code = JSON.stringify(docContent, null, '  ');
+    const code = losslessJSON.stringify(docContent, null, '  ');
     const editorCommands = [{
       name: 'save',
       bindKey: { win: 'Ctrl-S', mac: 'Ctrl-S' },
@@ -105,7 +106,7 @@ export default class DocEditorScreen extends React.Component {
         (this.props.doc && nextProps.doc && this.props.doc.id !== nextProps.doc.id)) {
       const editor = this.getEditor();
       if (editor && nextProps.doc) {
-        this.getEditor().setValue(JSON.stringify(nextProps.doc.attributes, null, '  '));
+        this.getEditor().setValue(losslessJSON.stringify(nextProps.doc.attributes, null, '  '));
       }
       this.onSaveComplete();
     }
@@ -138,7 +139,7 @@ export default class DocEditorScreen extends React.Component {
     if (this.getEditor().hasErrors()) {
       return false;
     }
-    const json = JSON.parse(this.getEditor().getValue());
+    const json = losslessJSON.parse(this.getEditor().getValue());
     this.props.doc.clear().set(json, { validate: true });
 
     return !this.props.doc.validationError;

--- a/app/addons/documents/shared-resources.js
+++ b/app/addons/documents/shared-resources.js
@@ -13,6 +13,7 @@
 import app from "../../app";
 import FauxtonAPI from "../../core/api";
 import { deleteRequest } from "../../core/ajax";
+import * as losslessJSON from "../../core/lossless-json";
 import PagingCollection from "../../../assets/js/plugins/cloudant.pagingcollection";
 
 // defined here because this is contains the base resources used throughout the addon and outside,
@@ -174,7 +175,23 @@ Documents.Doc = FauxtonAPI.Model.extend({
     });
   },
 
+  // Read requests are fetched as raw text (see sync) so that integers larger
+  // than Number.MAX_SAFE_INTEGER survive parsing instead of being rounded.
+  sync: function (method, model, options = {}) {
+    if (method === 'read') {
+      options.dataType = 'text';
+    } else {
+      options.contentType = 'application/json';
+      options.data = losslessJSON.stringify(options.attrs || model.toJSON(options));
+    }
+    return FauxtonAPI.Model.prototype.sync.call(this, method, model, options);
+  },
+
   parse: function (resp) {
+    if (typeof resp === 'string') {
+      resp = losslessJSON.parse(resp);
+    }
+
     if (resp.rev) {
       resp._rev = resp.rev;
       delete resp.rev;
@@ -196,7 +213,7 @@ Documents.Doc = FauxtonAPI.Model.extend({
   prettyJSON: function () {
     var data = this.get("doc") ? this.get("doc") : this.attributes;
 
-    return JSON.stringify(data, null, "  ");
+    return losslessJSON.stringify(data, null, "  ");
   },
 
   copy: function (copyId) {

--- a/app/core/__tests__/lossless-json.test.js
+++ b/app/core/__tests__/lossless-json.test.js
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import * as losslessJSON from '../lossless-json';
+
+describe('lossless-json', () => {
+  it('keeps integers larger than MAX_SAFE_INTEGER intact through a round-trip', () => {
+    const text = '{"hugeNumber":9223372036854775807}';
+    expect(losslessJSON.stringify(losslessJSON.parse(text))).toEqual(text);
+  });
+
+  it('does not round a large integer the way JSON.parse does', () => {
+    const parsed = losslessJSON.parse('{"hugeNumber":9223372036854775807}');
+    expect(parsed.hugeNumber.toString()).toEqual('9223372036854775807');
+    expect(JSON.parse('{"hugeNumber":9223372036854775807}').hugeNumber)
+      .toEqual(9223372036854776000);
+  });
+
+  it('leaves numbers within the safe range as plain numbers', () => {
+    const parsed = losslessJSON.parse('{"count":42,"ratio":3.14}');
+    expect(parsed.count).toEqual(42);
+    expect(parsed.ratio).toEqual(3.14);
+  });
+});

--- a/app/core/lossless-json.js
+++ b/app/core/lossless-json.js
@@ -1,0 +1,24 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+import { parse as llParse, stringify as llStringify, isSafeNumber, LosslessNumber } from 'lossless-json';
+
+// CouchDB keeps integers at full precision, but the browser's native JSON.parse
+// rounds anything larger than Number.MAX_SAFE_INTEGER. Wrap those values in a
+// LosslessNumber so they can be read, displayed and written back untouched.
+// Numbers that fit in a JS number are returned as plain numbers, so the rest of
+// the app keeps working with regular values.
+const keepBigInts = (value) => (isSafeNumber(value) ? parseFloat(value) : new LosslessNumber(value));
+
+export const parse = (text) => llParse(text, null, keepBigInts);
+
+export const stringify = (value, replacer, space) => llStringify(value, replacer, space);

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "jquery-param-fn": "^1.0.0",
         "jsondiffpatch": "^0.7.2",
         "lodash": "^4.17.20",
+        "lossless-json": "^4.3.0",
         "mkdirp": "^1.0.4",
         "moment": "^2.29.4",
         "nano": "^10.0.0",
@@ -15195,6 +15196,12 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/lossless-json": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.3.0.tgz",
+      "integrity": "sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==",
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -31683,6 +31690,11 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lossless-json": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.3.0.tgz",
+      "integrity": "sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g=="
     },
     "loupe": {
       "version": "2.3.7",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "jquery-param-fn": "^1.0.0",
     "jsondiffpatch": "^0.7.2",
     "lodash": "^4.17.20",
+    "lossless-json": "^4.3.0",
     "mkdirp": "^1.0.4",
     "moment": "^2.29.4",
     "nano": "^10.0.0",


### PR DESCRIPTION
## Overview

Save a document with an integer bigger than `Number.MAX_SAFE_INTEGER` and it comes back rounded: `9223372036854775807` turns into `9223372036854776000`. CouchDB keeps the number fine, but the editor runs the doc through native `JSON.parse`/`JSON.stringify`, which can't hold ints that big. It rounds on load, on display, on re-parse, and on save.

I added a small helper (`app/core/lossless-json.js`) around [lossless-json](https://github.com/josdejong/lossless-json) (MIT) that keeps oversized ints as `LosslessNumber` and leaves normal numbers alone, then used it at those spots in the Doc model and the editor.

I kept it scoped to the doc editor. The same rounding can happen anywhere the app parses JSON, so the wider option is to do this in the core ajax layer instead. Bigger blast radius, so I left it out for now. Happy to go that way if you'd rather. (M-Tesla sketched basically this approach on the issue but hadn't opened a PR.)

## Testing recommendations

Add a doc like `{"_id": "big", "hugeNumber": 9223372036854775807}`, open it in Fauxton, save, fetch again. Should be unchanged. `npm run jest` and `npm run stylecheck` are green (744 tests); there's a round-trip test that checks the save body keeps the full number, and it fails without the fix.

## GitHub issue number

Fixes apache/couchdb#6008

## Checklist

- [x] Code is written and works correctly;
- [x] Changes are covered by tests;
- [ ] Documentation reflects the changes (no docs affected);
- [ ] Update [rebar.config.script](https://github.com/apache/couchdb/blob/main/rebar.config.script) with the correct tag once a new Fauxton release is made (release step).
